### PR TITLE
test: replace resource.UnitTest with resource.Test

### DIFF
--- a/data_source_obmcs_core_console_history_data_test.go
+++ b/data_source_obmcs_core_console_history_data_test.go
@@ -49,7 +49,7 @@ func (s *CoreConsoleHistoryDataDatasourceTestSuite) TestResourceShowConsoleHisto
 	data := make([]byte, 100)
 	rand.Read(data)
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 s.Providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_core_cpe_test.go
+++ b/data_source_obmcs_core_cpe_test.go
@@ -50,7 +50,7 @@ data "baremetal_core_cpes" "s" {
 
 func (s *DatasourceCoreCpeTestSuite) TestCpeList() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 s.Providers,
 		Steps: []resource.TestStep{
@@ -93,7 +93,7 @@ func (s *DatasourceCoreCpeTestSuite) TestCpePagedList() {
 		},
 	}
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 s.Providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_core_dhcp_options_test.go
+++ b/data_source_obmcs_core_dhcp_options_test.go
@@ -59,7 +59,7 @@ func (s *ResourceCoreDHCPOptionsDatasourceTestSuite) SetupTest() {
 }
 
 func (s *ResourceCoreDHCPOptionsDatasourceTestSuite) TestReadDHCPOptions() {
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 s.Providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_core_drg_attachment_test.go
+++ b/data_source_obmcs_core_drg_attachment_test.go
@@ -58,7 +58,7 @@ func (s *CoreDrgAttachmentDatasourceTestSuite) SetupTest() {
 
 func (s *CoreDrgAttachmentDatasourceTestSuite) TestReadDrgAttachments() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 s.Providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_core_drg_test.go
+++ b/data_source_obmcs_core_drg_test.go
@@ -42,7 +42,7 @@ func (s *ResourceCoreDrgsTestSuite) SetupTest() {
 
 func (s *ResourceCoreDrgsTestSuite) TestReadDrgs() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 s.Providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_core_image_test.go
+++ b/data_source_obmcs_core_image_test.go
@@ -63,7 +63,7 @@ func (s *ResourceCoreImagesTestSuite) SetupTest() {
 }
 
 func (s *ResourceCoreImagesTestSuite) TestReadImages() {
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 s.Providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_core_instance_credential_test.go
+++ b/data_source_obmcs_core_instance_credential_test.go
@@ -42,7 +42,7 @@ func (s *ResourceCoreInstanceCredentialTestSuite) SetupTest() {
 
 func (s *ResourceCoreInstanceCredentialTestSuite) TestResourceReadCoreInstanceCredential() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 s.Providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_core_internet_gateway_test.go
+++ b/data_source_obmcs_core_internet_gateway_test.go
@@ -50,7 +50,7 @@ resource "baremetal_core_internet_gateway" "t" {
 }
 
 func (s *CoreInternetGatewayDatasourceTestSuite) TestResourceListInternetGateways() {
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 s.Providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_core_ipsec_config_test.go
+++ b/data_source_obmcs_core_ipsec_config_test.go
@@ -60,7 +60,7 @@ func (s *DatasourceCoreIPSecConfigTestSuite) SetupTest() {
 }
 
 func (s *DatasourceCoreIPSecConfigTestSuite) TestIPSecConfig() {
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 s.Providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_core_ipsec_status_test.go
+++ b/data_source_obmcs_core_ipsec_status_test.go
@@ -57,7 +57,7 @@ func (s *DatasourceCoreIPSecStatusTestSuite) SetupTest() {
 }
 
 func (s *DatasourceCoreIPSecStatusTestSuite) TestIPSecStatus() {
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 s.Providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_core_ipsec_test.go
+++ b/data_source_obmcs_core_ipsec_test.go
@@ -58,7 +58,7 @@ func (s *DatasourceCoreIPSecTestSuite) SetupTest() {
 }
 
 func (s *DatasourceCoreIPSecTestSuite) TestResourceListIPConnections() {
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 s.Providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_core_route_table_test.go
+++ b/data_source_obmcs_core_route_table_test.go
@@ -60,7 +60,7 @@ resource "baremetal_core_route_table" "t" {
 }
 
 func (s *ResourceCoreRouteTablesTestSuite) TestResourceListRouteTables() {
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 s.Providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_core_security_list_test.go
+++ b/data_source_obmcs_core_security_list_test.go
@@ -65,7 +65,7 @@ resource "baremetal_core_security_list" "WebSubnet" {
 }
 
 func (s *CoreSecurityListDatasourceTestSuite) TestReadSecurityLists() {
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 s.Providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_core_shape_test.go
+++ b/data_source_obmcs_core_shape_test.go
@@ -46,7 +46,7 @@ func (s *ResourceCoreShapeTestSuite) SetupTest() {
 
 func (s *ResourceCoreShapeTestSuite) TestResourceReadCoreShape() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 s.Providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_core_subnet_test.go
+++ b/data_source_obmcs_core_subnet_test.go
@@ -97,7 +97,7 @@ resource "baremetal_core_subnet" "WebSubnetAD1" {
 
 func (s *ResourceCoreSubnetsTestSuite) TestResourceListSubnets() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 s.Providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_core_virtual_network_test.go
+++ b/data_source_obmcs_core_virtual_network_test.go
@@ -46,7 +46,7 @@ data "baremetal_core_virtual_networks" "t" {
 
 func (s *ResourceCoreVirtualNetworksTestSuite) TestReadVirtualNetworks() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 s.Providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_core_vnic_attachment_test.go
+++ b/data_source_obmcs_core_vnic_attachment_test.go
@@ -44,7 +44,7 @@ func (s *ResourceCoreVnicAttachmentsTestSuite) SetupTest() {
 }
 
 func (s *ResourceCoreVnicAttachmentsTestSuite) TestResourceReadCoreVnicAttachments() {
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 s.Providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_core_volume_attachment_test.go
+++ b/data_source_obmcs_core_volume_attachment_test.go
@@ -49,7 +49,7 @@ func (s *ResourceCoreVolumeAttachmentsTestSuite) SetupTest() {
 }
 
 func (s *ResourceCoreVolumeAttachmentsTestSuite) TestReadVolumeAttachments() {
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 s.Providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_core_volume_backup_test.go
+++ b/data_source_obmcs_core_volume_backup_test.go
@@ -72,7 +72,7 @@ resource "baremetal_core_volume_backup" "t" {
 }
 
 func (s *ResourceCoreVolumeBackupsTestSuite) TestReadVolumeBackups() {
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 s.Providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_core_volume_test.go
+++ b/data_source_obmcs_core_volume_test.go
@@ -52,7 +52,7 @@ func (s *ResourceCoreVolumesTestSuite) SetupTest() {
 
 func (s *ResourceCoreVolumesTestSuite) TestReadVolumes() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 s.Providers,
 		Steps: []resource.TestStep{
@@ -75,7 +75,7 @@ func (s *ResourceCoreVolumesTestSuite) TestReadVolumes() {
 
 func (s *ResourceCoreVolumesTestSuite) TestReadVolumesWithPagination() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 s.Providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_database_databases_test.go
+++ b/data_source_obmcs_database_databases_test.go
@@ -34,7 +34,7 @@ func (s *DatabaseDatabasesTestSuite) SetupTest() {
 }
 
 func (s *DatabaseDatabasesTestSuite) TestReadDatabases() {
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 s.Providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_database_db_system_shape_test.go
+++ b/data_source_obmcs_database_db_system_shape_test.go
@@ -43,7 +43,7 @@ data "baremetal_identity_availability_domains" "ADs" {
 }
 
 func (s *DatabaseDBSystemShapeTestSuite) TestReadDBSystemShapes() {
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 s.Providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_database_db_version_test.go
+++ b/data_source_obmcs_database_db_version_test.go
@@ -41,7 +41,7 @@ func (s *DatabaseDBVersionTestSuite) SetupTest() {
 
 func (s *DatabaseDBVersionTestSuite) TestReadDBVersions() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 s.Providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_identity_api_key_test.go
+++ b/data_source_obmcs_identity_api_key_test.go
@@ -76,7 +76,7 @@ EOF
 
 func (s *ResourceIdentityAPIKeysTestSuite) TestReadAPIKeys() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 s.Providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_identity_availability_domain_test.go
+++ b/data_source_obmcs_identity_availability_domain_test.go
@@ -54,7 +54,7 @@ func (s *ResourceIdentityAvailabilityDomainsTestSuite) SetupTest() {
 
 func (s *ResourceIdentityAvailabilityDomainsTestSuite) TestReadAvailabilityDomains() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 s.Providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_identity_compartment_test.go
+++ b/data_source_obmcs_identity_compartment_test.go
@@ -60,7 +60,7 @@ func (s *ResourceIdentityCompartmentsTestSuite) SetupTest() {
 
 func (s *ResourceIdentityCompartmentsTestSuite) TestReadCompartments() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 s.Providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_identity_group_test.go
+++ b/data_source_obmcs_identity_group_test.go
@@ -61,7 +61,7 @@ func (s *ResourceIdentityGroupsTestSuite) SetupTest() {
 
 func (s *ResourceIdentityGroupsTestSuite) TestReadGroups() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 s.Providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_identity_policy_test.go
+++ b/data_source_obmcs_identity_policy_test.go
@@ -66,7 +66,7 @@ func (s *ResourceIdentityPoliciesTestSuite) SetupTest() {
 }
 
 func (s *ResourceIdentityPoliciesTestSuite) TestListResourceIdentityPolicies() {
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{

--- a/data_source_obmcs_identity_swift_password_test.go
+++ b/data_source_obmcs_identity_swift_password_test.go
@@ -51,7 +51,7 @@ func (s *ResourceIdentitySwiftPasswordsTestSuite) SetupTest() {
 }
 
 func (s *ResourceIdentitySwiftPasswordsTestSuite) TestListResourceIdentitySwiftPasswords() {
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{

--- a/data_source_obmcs_identity_user_group_membership_test.go
+++ b/data_source_obmcs_identity_user_group_membership_test.go
@@ -68,7 +68,7 @@ func (s *ResourceIdentityUserGroupMembershipsTestSuite) TestGetUserGroupMembersh
 	    group_id = "${baremetal_identity_group.g.id}"
         }
 	`
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 s.Providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_identity_user_test.go
+++ b/data_source_obmcs_identity_user_test.go
@@ -44,7 +44,7 @@ func (s *ResourceIdentityUsersTestSuite) SetupTest() {
 
 func (s *ResourceIdentityUsersTestSuite) TestReadUsers() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 s.Providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_load_balancer_backends_test.go
+++ b/data_source_obmcs_load_balancer_backends_test.go
@@ -41,7 +41,7 @@ data "baremetal_load_balancer_backends" "t" {
 		backendsetName,
 	).Return(list, nil)
 
-	resource.UnitTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_load_balancer_backendsets_test.go
+++ b/data_source_obmcs_load_balancer_backendsets_test.go
@@ -39,7 +39,7 @@ data "baremetal_load_balancer_backendsets" "t" {
 		(*baremetal.ClientRequestOptions)(nil),
 	).Return(list, nil)
 
-	resource.UnitTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_load_balancer_certificates_test.go
+++ b/data_source_obmcs_load_balancer_certificates_test.go
@@ -39,7 +39,7 @@ data "baremetal_load_balancer_certificates" "t" {
 		(*baremetal.ClientRequestOptions)(nil),
 	).Return(list, nil)
 
-	resource.UnitTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_load_balancer_policies_test.go
+++ b/data_source_obmcs_load_balancer_policies_test.go
@@ -25,7 +25,7 @@ data "baremetal_load_balancer_policies" "t" {
 `
 	config += testProviderConfig()
 
-	resource.UnitTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_load_balancer_protocols_test.go
+++ b/data_source_obmcs_load_balancer_protocols_test.go
@@ -25,7 +25,7 @@ data "baremetal_load_balancer_protocols" "t" {
 `
 	config += testProviderConfig()
 
-	resource.UnitTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_load_balancer_shapes_test.go
+++ b/data_source_obmcs_load_balancer_shapes_test.go
@@ -25,7 +25,7 @@ data "baremetal_load_balancer_shapes" "t" {
 `
 	config += testProviderConfig()
 
-	resource.UnitTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_load_balancers_test.go
+++ b/data_source_obmcs_load_balancers_test.go
@@ -50,7 +50,7 @@ data "baremetal_load_balancers" "t" {
 		(*baremetal.ListOptions)(nil),
 	).Return(list, nil)
 
-	resource.UnitTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_objectstorage_bucketsummary_test.go
+++ b/data_source_obmcs_objectstorage_bucketsummary_test.go
@@ -48,7 +48,7 @@ func (s *ObjectstorageBucketSummaryTestSuite) SetupTest() {
 }
 
 func (s *ObjectstorageBucketSummaryTestSuite) TestReadBucketSummaries() {
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 s.Providers,
 		Steps: []resource.TestStep{

--- a/data_source_obmcs_objectstorage_namespace_test.go
+++ b/data_source_obmcs_objectstorage_namespace_test.go
@@ -53,7 +53,7 @@ func (s *DatasourceObjectstorageNamespaceTestSuite) SetupTest() {
 
 func (s *DatasourceObjectstorageNamespaceTestSuite) TestObjectstorageNamespace() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{

--- a/data_source_obmcs_objectstorage_object_head_test.go
+++ b/data_source_obmcs_objectstorage_object_head_test.go
@@ -72,7 +72,7 @@ func (s *DatasourceObjectstorageObjectHeadTestSuite) SetupTest() {
 }
 
 func (s *DatasourceObjectstorageObjectHeadTestSuite) TestObjectstorageHeadObject() {
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{

--- a/data_source_obmcs_objectstorage_object_test.go
+++ b/data_source_obmcs_objectstorage_object_test.go
@@ -77,7 +77,7 @@ func (s *DatasourceObjectstorageObjectTestSuite) SetupTest() {
 }
 
 func (s *DatasourceObjectstorageObjectTestSuite) TestObjectstorageListObjects() {
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{

--- a/resource_obmcs_core_console_history_test.go
+++ b/resource_obmcs_core_console_history_test.go
@@ -60,7 +60,7 @@ func (s *ResourceCoreConsoleHistoryTestSuite) SetupTest() {
 
 func (s *ResourceCoreConsoleHistoryTestSuite) TestCreateResourceCoreInstanceConsoleHistory() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{

--- a/resource_obmcs_core_cpe_test.go
+++ b/resource_obmcs_core_cpe_test.go
@@ -55,7 +55,7 @@ func (s *ResourceCoreCpeTestSuite) SetupTest() {
 
 func (s *ResourceCoreCpeTestSuite) TestCreateResourceCoreCpe() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -86,7 +86,7 @@ func (s ResourceCoreCpeTestSuite) TestUpdateForcesNewCoreCpe() {
   `
 	updateForcingChangeConfig += testProviderConfig()
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -107,7 +107,7 @@ func (s ResourceCoreCpeTestSuite) TestUpdateForcesNewCoreCpe() {
 
 func (s *ResourceCoreCpeTestSuite) TestDeleteResourceCoreCpe() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{

--- a/resource_obmcs_core_dhcp_options_test.go
+++ b/resource_obmcs_core_dhcp_options_test.go
@@ -103,7 +103,7 @@ func (s *ResourceCoreDHCPOptionsTestSuite) SetupTest() {
 
 func (s *ResourceCoreDHCPOptionsTestSuite) TestCreateResourceCoreDHCPOptions() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -135,7 +135,7 @@ func (s *ResourceCoreDHCPOptionsTestSuite) TestCreateResourceCoreDHCPOptions() {
 
 func (s *ResourceCoreDHCPOptionsTestSuite) TestDeleteDHCPOptions() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{

--- a/resource_obmcs_core_drg_attachment_test.go
+++ b/resource_obmcs_core_drg_attachment_test.go
@@ -66,7 +66,7 @@ func (s *ResourceCoreDrgAttachmentTestSuite) SetupTest() {
 
 func (s *ResourceCoreDrgAttachmentTestSuite) TestCreateResourceCoreDrgAttachment() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -89,7 +89,7 @@ func (s *ResourceCoreDrgAttachmentTestSuite) TestCreateResourceCoreDrgAttachment
 
 func (s *ResourceCoreDrgAttachmentTestSuite) TestDetachVolume() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{

--- a/resource_obmcs_core_drg_test.go
+++ b/resource_obmcs_core_drg_test.go
@@ -55,7 +55,7 @@ func (s *ResourceCoreDrgTestSuite) SetupTest() {
 
 func (s *ResourceCoreDrgTestSuite) TestCreateResourceCoreDrg() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -86,7 +86,7 @@ func (s *ResourceCoreDrgTestSuite) TestCreateResourceCoreDrgWithoutDisplayName()
 	`
 	s.Config += testProviderConfig()
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -103,7 +103,7 @@ func (s *ResourceCoreDrgTestSuite) TestCreateResourceCoreDrgWithoutDisplayName()
 
 func (s *ResourceCoreDrgTestSuite) TestDeleteDrg() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{

--- a/resource_obmcs_core_image_test.go
+++ b/resource_obmcs_core_image_test.go
@@ -49,7 +49,7 @@ func (s *ResourceCoreImageTestSuite) SetupTest() {
 
 func (s *ResourceCoreImageTestSuite) TestCreateImage() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -80,7 +80,7 @@ func (s ResourceCoreImageTestSuite) TestUpdateImageDisplayName() {
 	`
 	config += testProviderConfig()
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -100,7 +100,7 @@ func (s ResourceCoreImageTestSuite) TestUpdateImageDisplayName() {
 
 func (s *ResourceCoreImageTestSuite) TestDeleteImage() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{

--- a/resource_obmcs_core_instance_test.go
+++ b/resource_obmcs_core_instance_test.go
@@ -56,7 +56,7 @@ func (s *ResourceCoreInstanceTestSuite) SetupTest() {
 
 func (s *ResourceCoreInstanceTestSuite) TestCreateResourceCoreInstance() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{

--- a/resource_obmcs_core_internet_gateway_test.go
+++ b/resource_obmcs_core_internet_gateway_test.go
@@ -61,7 +61,7 @@ resource "baremetal_core_internet_gateway" "t" {
 
 func (s *ResourceCoreInternetGatewayTestSuite) TestCreateResourceCoreInternetGateway() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -98,7 +98,7 @@ resource "baremetal_core_internet_gateway" "t" {
 
 	config += testProviderConfig()
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -120,7 +120,7 @@ resource "baremetal_core_internet_gateway" "t" {
 
 func (s *ResourceCoreInternetGatewayTestSuite) TestDeleteInternetGateway() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{

--- a/resource_obmcs_core_ipsec_test.go
+++ b/resource_obmcs_core_ipsec_test.go
@@ -69,7 +69,7 @@ func (s *ResourceCoreIPSecTestSuite) SetupTest() {
 
 func (s *ResourceCoreIPSecTestSuite) TestCreateResourceCoreIpsec() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -91,7 +91,7 @@ func (s *ResourceCoreIPSecTestSuite) TestCreateResourceCoreIpsec() {
 
 func (s *ResourceCoreIPSecTestSuite) TestTerminateIPSec() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{

--- a/resource_obmcs_core_route_table_test.go
+++ b/resource_obmcs_core_route_table_test.go
@@ -70,7 +70,7 @@ resource "baremetal_core_route_table" "t" {
 
 func (s *ResourceCoreRouteTableTestSuite) TestCreateResourceCoreRouteTable() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -106,7 +106,7 @@ func (s ResourceCoreRouteTableTestSuite) TestUpdateRouteTable() {
 	`
 	config += testProviderConfig()
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -124,7 +124,7 @@ func (s ResourceCoreRouteTableTestSuite) TestUpdateRouteTable() {
 
 func (s *ResourceCoreRouteTableTestSuite) TestDeleteRouteTable() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{

--- a/resource_obmcs_core_security_list_test.go
+++ b/resource_obmcs_core_security_list_test.go
@@ -93,7 +93,7 @@ resource "baremetal_core_security_list" "t" {
 
 func (s *ResourceCoreSecurityListTestSuite) TestCreateResourceCoreSecurityList() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -116,7 +116,7 @@ func (s *ResourceCoreSecurityListTestSuite) TestCreateResourceCoreSecurityList()
 
 func (s *ResourceCoreSecurityListTestSuite) TestCreateResourceCoreSecurityListUpdateRules() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -200,7 +200,7 @@ func (s *ResourceCoreSecurityListTestSuite) TestCreateResourceCoreSecurityListUp
 
 func (s *ResourceCoreSecurityListTestSuite) TestDeleteSecurityList() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{

--- a/resource_obmcs_core_subnet_test.go
+++ b/resource_obmcs_core_subnet_test.go
@@ -45,7 +45,7 @@ resource "baremetal_core_subnet" "s" {
 
 	resourceName := "baremetal_core_subnet.s"
 
-	resource.UnitTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		Providers: map[string]terraform.ResourceProvider{
 			"baremetal": provider,
 		},
@@ -105,7 +105,7 @@ resource "baremetal_core_subnet" "s" {
 }
 	`
 	config += testProviderConfig()
-	resource.UnitTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		Providers: map[string]terraform.ResourceProvider{
 			"baremetal": provider,
 		},

--- a/resource_obmcs_core_virtual_network_test.go
+++ b/resource_obmcs_core_virtual_network_test.go
@@ -57,7 +57,7 @@ func (s *ResourceCoreVirtualNetworkTestSuite) SetupTest() {
 
 func (s *ResourceCoreVirtualNetworkTestSuite) TestCreateResourceCoreVirtualNetwork() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -79,7 +79,7 @@ func (s *ResourceCoreVirtualNetworkTestSuite) TestCreateResourceCoreVirtualNetwo
 
 func (s *ResourceCoreVirtualNetworkTestSuite) TestDeleteResourceCoreVirtualNetwork() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -112,7 +112,7 @@ func (s ResourceCoreVirtualNetworkTestSuite) TestUpdateCidrBlockForcesNewVirtual
   `
 	config += testProviderConfig()
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -132,7 +132,7 @@ func (s ResourceCoreVirtualNetworkTestSuite) TestUpdateCidrBlockForcesNewVirtual
 
 func (s *ResourceCoreVirtualNetworkTestSuite) TestDeleteVirtualNetwork() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{

--- a/resource_obmcs_core_volume_attachment_test.go
+++ b/resource_obmcs_core_volume_attachment_test.go
@@ -62,7 +62,7 @@ func (s *ResourceCoreVolumeAttachmentTestSuite) SetupTest() {
 
 func (s *ResourceCoreVolumeAttachmentTestSuite) TestCreateResourceCoreVolumeAttachment() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -89,7 +89,7 @@ func (s *ResourceCoreVolumeAttachmentTestSuite) TestCreateResourceCoreVolumeAtta
 
 func (s *ResourceCoreVolumeAttachmentTestSuite) TestDetachVolume() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{

--- a/resource_obmcs_core_volume_backup_test.go
+++ b/resource_obmcs_core_volume_backup_test.go
@@ -57,7 +57,7 @@ func (s *ResourceCoreVolumeBackupTestSuite) SetupTest() {
 
 func (s *ResourceCoreVolumeBackupTestSuite) TestCreateVolumeBackup() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -89,7 +89,7 @@ func (s *ResourceCoreVolumeBackupTestSuite) TestCreateVolumeBackupWithoutDisplay
 	`
 	s.Config += testProviderConfig()
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -117,7 +117,7 @@ func (s ResourceCoreVolumeBackupTestSuite) TestUpdateVolumeBackupDisplayName() {
 	`
 	config += testProviderConfig()
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -137,7 +137,7 @@ func (s ResourceCoreVolumeBackupTestSuite) TestUpdateVolumeBackupDisplayName() {
 
 func (s *ResourceCoreVolumeBackupTestSuite) TestDeleteVolumeBackup() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{

--- a/resource_obmcs_core_volume_test.go
+++ b/resource_obmcs_core_volume_test.go
@@ -62,7 +62,7 @@ func (s *ResourceCoreVolumeTestSuite) SetupTest() {
 
 func (s *ResourceCoreVolumeTestSuite) TestCreateResourceCoreVolume() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -97,7 +97,7 @@ func (s ResourceCoreVolumeTestSuite) TestUpdateVolumeDisplayName() {
 	`
 	config += testProviderConfig()
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -129,7 +129,7 @@ func (s ResourceCoreVolumeTestSuite) TestUpdateAvailabilityDomainForcesNewVolume
   `
 	config += testProviderConfig()
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -149,7 +149,7 @@ func (s ResourceCoreVolumeTestSuite) TestUpdateAvailabilityDomainForcesNewVolume
 
 func (s *ResourceCoreVolumeTestSuite) TestDeleteVolume() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{

--- a/resource_obmcs_database_db_system_test.go
+++ b/resource_obmcs_database_db_system_test.go
@@ -45,7 +45,7 @@ func (s *ResourceDatabaseDBSystemTestSuite) SetupTest() {
 }
 
 func (s *ResourceDatabaseDBSystemTestSuite) TestCreateResourceDatabaseDBSystem() {
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{

--- a/resource_obmcs_identity_api_key_test.go
+++ b/resource_obmcs_identity_api_key_test.go
@@ -60,7 +60,7 @@ EOF
 }
 
 func (s *ResourceIdentityAPIKeyTestSuite) TestCreateAPIKey() {
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -78,7 +78,7 @@ func (s *ResourceIdentityAPIKeyTestSuite) TestCreateAPIKey() {
 
 func (s *ResourceIdentityAPIKeyTestSuite) TestDeleteAPIKey() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{

--- a/resource_obmcs_identity_compartment_test.go
+++ b/resource_obmcs_identity_compartment_test.go
@@ -63,7 +63,7 @@ func (s *ResourceIdentityCompartmentTestSuite) SetupTest() {
 
 func (s *ResourceIdentityCompartmentTestSuite) TestCreateResourceIdentityCompartment() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{

--- a/resource_obmcs_identity_group_test.go
+++ b/resource_obmcs_identity_group_test.go
@@ -61,7 +61,7 @@ func (s *ResourceIdentityGroupTestSuite) SetupTest() {
 
 func (s *ResourceIdentityGroupTestSuite) TestCreateResourceIdentityGroup() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -86,7 +86,7 @@ func (s *ResourceIdentityGroupTestSuite) TestCreateResourceIdentityGroupPolling(
 	u := *s.Res
 	u.State = baremetal.ResourceActive
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -110,7 +110,7 @@ func (s *ResourceIdentityGroupTestSuite) TestUpdateResourceIdentityGroupDescript
 
 	c += testProviderConfig()
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -138,7 +138,7 @@ func (s *ResourceIdentityGroupTestSuite) TestFailedUpdateResourceIdentityGroupDe
 	`
 	c += testProviderConfig()
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -170,7 +170,7 @@ func (s *ResourceIdentityGroupTestSuite) TestUpdateResourceIdentityGroupNameShou
 
 	c += testProviderConfig()
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -188,7 +188,7 @@ func (s *ResourceIdentityGroupTestSuite) TestUpdateResourceIdentityGroupNameShou
 
 func (s *ResourceIdentityGroupTestSuite) TestDeleteResourceIdentityGroup() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{

--- a/resource_obmcs_identity_policy_test.go
+++ b/resource_obmcs_identity_policy_test.go
@@ -59,7 +59,7 @@ func (s *ResourceIdentityPolicyTestSuite) SetupTest() {
 
 func (s *ResourceIdentityPolicyTestSuite) TestCreateResourceIdentityPolicy() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{

--- a/resource_obmcs_identity_swift_password_test.go
+++ b/resource_obmcs_identity_swift_password_test.go
@@ -57,7 +57,7 @@ func (s *ResourceIdentitySwiftPasswordTestSuite) SetupTest() {
 }
 
 func (s *ResourceIdentitySwiftPasswordTestSuite) TestCreateSwiftPassword() {
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -86,7 +86,7 @@ func (s ResourceIdentitySwiftPasswordTestSuite) TestUpdateDescriptionUpdatesSwif
   `
 	config += testProviderConfig()
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{

--- a/resource_obmcs_identity_ui_password_test.go
+++ b/resource_obmcs_identity_ui_password_test.go
@@ -55,7 +55,7 @@ func (s *ResourceIdentityUIPasswordTestSuite) SetupTest() {
 }
 
 func (s *ResourceIdentityUIPasswordTestSuite) TestCreateUIPassword() {
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -84,7 +84,7 @@ func (s ResourceIdentityUIPasswordTestSuite) TestUpdateVersionForcesNewUIPasswor
   `
 	config += testProviderConfig()
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{

--- a/resource_obmcs_identity_user_group_membership_test.go
+++ b/resource_obmcs_identity_user_group_membership_test.go
@@ -50,7 +50,7 @@ func (s *ResourceIdentityUserGroupMembershipTestSuite) SetupTest() {
 }
 
 func (s *ResourceIdentityUserGroupMembershipTestSuite) TestGetUserGroupMembershipsByGroup() {
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 s.Providers,
 		Steps: []resource.TestStep{

--- a/resource_obmcs_identity_user_test.go
+++ b/resource_obmcs_identity_user_test.go
@@ -60,7 +60,7 @@ func (s *ResourceIdentityUserTestSuite) SetupTest() {
 
 func (s *ResourceIdentityUserTestSuite) TestCreateResourceIdentityUser() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -88,7 +88,7 @@ func (s *ResourceIdentityUserTestSuite) TestCreateResourceIdentityUserPolling() 
 	u := *s.Res
 	u.State = baremetal.ResourceActive
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -114,7 +114,7 @@ func (s *ResourceIdentityUserTestSuite) TestUpdateResourceIdentityUserDescriptio
 	`
 	c += testProviderConfig()
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -143,7 +143,7 @@ func (s *ResourceIdentityUserTestSuite) TestUpdateResourceIdentityUserNameShould
 
 	c += testProviderConfig()
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -163,7 +163,7 @@ func (s *ResourceIdentityUserTestSuite) TestUpdateResourceIdentityUserNameShould
 
 func (s *ResourceIdentityUserTestSuite) TestDeleteResourceIdentityUser() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{

--- a/resource_obmcs_loadbalancer_test.go
+++ b/resource_obmcs_loadbalancer_test.go
@@ -159,7 +159,7 @@ resource "baremetal_load_balancer_backend" "minimal" {
 
 func (s *ResourceLoadBalancerTestSuite) TestCreateResourceLoadBalancerMaximal() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{

--- a/resource_obmcs_objectstorage_bucket_test.go
+++ b/resource_obmcs_objectstorage_bucket_test.go
@@ -75,7 +75,7 @@ func (s *ResourceObjectstorageBucketTestSuite) SetupTest() {
 
 func (s *ResourceObjectstorageBucketTestSuite) TestCreateResourceObjectstorageBucket() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -94,7 +94,7 @@ func (s *ResourceObjectstorageBucketTestSuite) TestCreateResourceObjectstorageBu
 
 func (s *ResourceObjectstorageBucketTestSuite) TestDeleteResourceObjectstorageBucket() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{

--- a/resource_obmcs_objectstorage_object_test.go
+++ b/resource_obmcs_objectstorage_object_test.go
@@ -70,7 +70,7 @@ func (s *ResourceObjectstorageObjectTestSuite) SetupTest() {
 
 func (s *ResourceObjectstorageObjectTestSuite) TestCreateResourceObjectstorageObject() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -109,7 +109,7 @@ func (s *ResourceObjectstorageObjectTestSuite) TestUpdateResourceObjectstorageOb
 	`
 	config += testProviderConfig()
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -129,7 +129,7 @@ func (s *ResourceObjectstorageObjectTestSuite) TestUpdateResourceObjectstorageOb
 
 func (s *ResourceObjectstorageObjectTestSuite) TestDeleteResourceObjectstorageObject() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{

--- a/resource_obmcs_objectstorage_preauthenticatedrequest_test.go
+++ b/resource_obmcs_objectstorage_preauthenticatedrequest_test.go
@@ -60,7 +60,7 @@ func (s *ResourcePARTestSuite) SetupTest() {
 
 func (s *ResourcePARTestSuite) TestCreatePAR() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -77,7 +77,7 @@ func (s *ResourcePARTestSuite) TestCreatePAR() {
 
 func (s *ResourcePARTestSuite) TestDeletePAR() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{


### PR DESCRIPTION
test: replace resource.UnitTest with resource.Test

resource.UnitTest doc specifies:
>  This should only be used for resource that don't have any external dependencies.

See: https://godoc.org/github.com/hashicorp/terraform/helper/resource#UnitTest

Similarly, resource.TestCase doc specifies:
>  IsUnitTest allows a test to run regardless of the TF_ACC
> environment variable. This should be used with care - only for
>  fast tests on local resources (e.g. remote state with a local
> backend) but can be used to increase confidence in correct
>  operation of Terraform without waiting for a full acctest run.

See: https://godoc.org/github.com/hashicorp/terraform/helper/resource#TestCase
