### PR TITLE
POC test simplification

### DIFF
--- a/provider_test.go
+++ b/provider_test.go
@@ -19,6 +19,24 @@ import (
 	"github.com/oracle/terraform-provider-baremetal/client/mocks"
 )
 
+var testAccClient mockableClient
+var testAccProviders map[string]terraform.ResourceProvider
+var testAccProvider *schema.Provider
+
+func init() {
+	testAccClient = GetTestProvider()
+	testAccProvider = testProvider().(*schema.Provider)
+	testAccProviders = map[string]terraform.ResourceProvider{
+		"baremetal": testAccProvider,
+	}
+}
+
+func testProvider() terraform.ResourceProvider {
+	return Provider(func(d *schema.ResourceData) (interface{}, error) {
+		return testAccClient, nil
+	})
+}
+
 func testProviderConfig() string {
 	return `
 	provider "baremetal" {

--- a/resource_obmcs_core_instance.go
+++ b/resource_obmcs_core_instance.go
@@ -174,6 +174,9 @@ type InstanceResourceCrud struct {
 	private_ip string
 }
 
+// Ensure InstanceResourceCrud implements crud.StatefulResource
+var _ crud.StatefulResource = (*InstanceResourceCrud)(nil)
+
 func (s *InstanceResourceCrud) ID() string {
 	return s.Resource.ID
 }

--- a/resource_obmcs_core_instance_test.go
+++ b/resource_obmcs_core_instance_test.go
@@ -4,88 +4,37 @@ package main
 
 import (
 	"testing"
-	"time"
 
 	"github.com/MustWin/baremetal-sdk-go"
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/hashicorp/terraform/terraform"
-
-	"github.com/stretchr/testify/suite"
-
-	"github.com/oracle/terraform-provider-baremetal/crud"
 )
 
-type ResourceCoreInstanceTestSuite struct {
-	suite.Suite
-	Client       mockableClient
-	Provider     terraform.ResourceProvider
-	Providers    map[string]terraform.ResourceProvider
-	TimeCreated  baremetal.Time
-	Config       string
-	ResourceName string
-	Res          *baremetal.Instance
-	DeletedRes   *baremetal.Instance
-}
-
-func (s *ResourceCoreInstanceTestSuite) SetupTest() {
-	s.Client = GetTestProvider()
-
-	s.Provider = Provider(
-		func(d *schema.ResourceData) (interface{}, error) {
-			return s.Client, nil
-		},
-	)
-
-	s.Providers = map[string]terraform.ResourceProvider{
-		"baremetal": s.Provider,
-	}
-
-	s.TimeCreated = baremetal.Time{Time: time.Now()}
-
-	s.Config = instanceConfig + `
+func TestAccResourceCoreInstance(t *testing.T) {
+	config := instanceConfig + `
 	data "baremetal_core_instances" "s" {
       		compartment_id = "${var.compartment_id}"
       		availability_domain = "${data.baremetal_identity_availability_domains.ADs.availability_domains.0.name}"
     	}`
 
-	s.Config += testProviderConfig()
-
-	s.ResourceName = "baremetal_core_instance.t"
-}
-
-func (s *ResourceCoreInstanceTestSuite) TestCreateResourceCoreInstance() {
-
-	resource.UnitTest(s.T(), resource.TestCase{
-		Providers: s.Providers,
+	config += testProviderConfig()
+	resource.UnitTest(t, resource.TestCase{
+		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				ImportState:       true,
 				ImportStateVerify: true,
-				Config:            s.Config,
+				Config:            config,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(s.ResourceName, "availability_domain"),
-					resource.TestCheckResourceAttr(s.ResourceName, "display_name", "instance_name"),
-					resource.TestCheckResourceAttrSet(s.ResourceName, "id"),
-					resource.TestCheckResourceAttr(s.ResourceName, "state", baremetal.ResourceRunning),
-					resource.TestCheckResourceAttrSet(s.ResourceName, "time_created"),
-					resource.TestCheckResourceAttrSet(s.ResourceName, "public_ip"),
-					resource.TestCheckResourceAttrSet(s.ResourceName, "private_ip"),
+					resource.TestCheckResourceAttrSet("baremetal_core_instance.t", "availability_domain"),
+					resource.TestCheckResourceAttr("baremetal_core_instance.t", "display_name", "instance_name"),
+					resource.TestCheckResourceAttrSet("baremetal_core_instance.t", "id"),
+					resource.TestCheckResourceAttr("baremetal_core_instance.t", "state", baremetal.ResourceRunning),
+					resource.TestCheckResourceAttrSet("baremetal_core_instance.t", "time_created"),
+					resource.TestCheckResourceAttrSet("baremetal_core_instance.t", "public_ip"),
+					resource.TestCheckResourceAttrSet("baremetal_core_instance.t", "private_ip"),
 					resource.TestCheckResourceAttrSet("data.baremetal_core_instances.s", "instances.#"),
 				),
 			},
 		},
 	})
-}
-
-func TestIsStatefulResource(t *testing.T) {
-	var sr crud.StatefulResource
-	sr = &InstanceResourceCrud{}
-	if sr == nil {
-		t.Fail()
-	}
-}
-
-func TestResourceCoreInstanceTestSuite(t *testing.T) {
-	suite.Run(t, new(ResourceCoreInstanceTestSuite))
 }


### PR DESCRIPTION
Going through the tests, there seems like a lot of unnecessary work happening. This is the beginning of cleaning them up. I'd very much appreciate :eyes: from @codycushing & @rcohenma to make sure these changes are clear.

Some places for improvement:
- remove `testify/suite` when it's not saving any code
- remove explicit destroy tests, that behaviour is already handled by terraform's helpers
- remove interface verification tests, it can be done a single line right next to the relevant code
- merge create & update tests into a multi-step test when possible

These are changes that leverage go and terraform's test helpers more fully, make the test more idiomatic (so hashicorp is more able to assist in future), and improve speed.