### PR TITLE
fix go vet complaint related to oci migration tool

### DIFF
--- a/tools/oci-tool/actions.go
+++ b/tools/oci-tool/actions.go
@@ -27,7 +27,7 @@ func ProcessDirectory(targetDir string, backupDir string, fileActionFn FileActio
 	files, err := ioutil.ReadDir(targetDir)
 
 	if err != nil {
-		fmt.Errorf("Error reading directory contents \n %s", err)
+		return fmt.Errorf("Error reading directory contents \n %s", err)
 	}
 
 	for _, res := range files {


### PR DESCRIPTION
* this code is not part of the oci provider but added here for convenience
* formatted error message was not being returned to calling context