### PR TITLE
Refactor object store tests

### DIFF
--- a/data_source_obmcs_objectstorage_bucketsummary_test.go
+++ b/data_source_obmcs_objectstorage_bucketsummary_test.go
@@ -4,52 +4,41 @@ package main
 
 import (
 	"testing"
-	"time"
 
-	baremetal "github.com/MustWin/baremetal-sdk-go"
+	"github.com/MustWin/baremetal-sdk-go"
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 
 	"github.com/stretchr/testify/suite"
 )
 
-type ObjectstorageBucketSummaryTestSuite struct {
+type DatasourceObjectstorageBucketSummaryTestSuite struct {
 	suite.Suite
 	Client       *baremetal.Client
 	Config       string
 	Provider     terraform.ResourceProvider
 	Providers    map[string]terraform.ResourceProvider
 	ResourceName string
-	TimeCreated  time.Time
 }
 
-func (s *ObjectstorageBucketSummaryTestSuite) SetupTest() {
-	s.Client = GetTestProvider()
-	s.Provider = Provider(func(d *schema.ResourceData) (interface{}, error) {
-		return s.Client, nil
-	})
-
-	s.Providers = map[string]terraform.ResourceProvider{
-		"oci": s.Provider,
+func (s *DatasourceObjectstorageBucketSummaryTestSuite) SetupTest() {
+	s.Client = testAccClient
+	s.Provider = testAccProvider
+	s.Providers = testAccProviders
+	s.Config = testProviderConfig() + `
+	data "oci_objectstorage_namespace" "t" {
 	}
-	s.Config = `
+	
 	resource "oci_objectstorage_bucket" "t" {
 		compartment_id = "${var.compartment_id}"
-		name = "bucketID"
-		namespace = "${var.namespace}"
-		metadata = {
-			"foo" = "bar"
-		}
-	}
-  `
-	s.Config += testProviderConfig()
+		namespace = "${data.oci_objectstorage_namespace.t.namespace}"
+		name = "-tf-bucket"
+	}`
 	s.ResourceName = "data.oci_objectstorage_bucket_summaries.t"
-	s.TimeCreated = time.Now()
 }
 
-func (s *ObjectstorageBucketSummaryTestSuite) TestReadBucketSummaries() {
-	resource.UnitTest(s.T(), resource.TestCase{
+func (s *DatasourceObjectstorageBucketSummaryTestSuite) TestAccDatasourceObjectstorageBucketSummaries_basic() {
+	resource.Test(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 s.Providers,
 		Steps: []resource.TestStep{
@@ -60,14 +49,16 @@ func (s *ObjectstorageBucketSummaryTestSuite) TestReadBucketSummaries() {
 			},
 			{
 				Config: s.Config + `
-					data "oci_objectstorage_bucket_summaries" "t" {
-						compartment_id = "${var.compartment_id}"
-						namespace = "${var.namespace}"
-					}
-				`,
+				data "oci_objectstorage_bucket_summaries" "t" {
+					compartment_id = "${var.compartment_id}"
+					namespace = "${data.oci_objectstorage_namespace.t.namespace}"
+				}`,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(s.ResourceName, "bucket_summaries.0.name"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "compartment_id"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "namespace"),
 					resource.TestCheckResourceAttrSet(s.ResourceName, "bucket_summaries.#"),
+					resource.TestCheckResourceAttr(s.ResourceName, "bucket_summaries.#", "1"),
+					resource.TestCheckResourceAttr(s.ResourceName, "bucket_summaries.0.name", "-tf-bucket"),
 				),
 			},
 		},
@@ -75,6 +66,6 @@ func (s *ObjectstorageBucketSummaryTestSuite) TestReadBucketSummaries() {
 	)
 }
 
-func TestObjectstorageBucketSummaryTestSuite(t *testing.T) {
-	suite.Run(t, new(ObjectstorageBucketSummaryTestSuite))
+func TestDatasourceObjectstorageBucketSummaryTestSuite(t *testing.T) {
+	suite.Run(t, new(DatasourceObjectstorageBucketSummaryTestSuite))
 }

--- a/data_source_obmcs_objectstorage_namespace_test.go
+++ b/data_source_obmcs_objectstorage_namespace_test.go
@@ -4,11 +4,9 @@ package main
 
 import (
 	"testing"
-	"time"
 
 	"github.com/MustWin/baremetal-sdk-go"
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 
 	"github.com/stretchr/testify/suite"
@@ -19,41 +17,23 @@ type DatasourceObjectstorageNamespaceTestSuite struct {
 	Client       *baremetal.Client
 	Provider     terraform.ResourceProvider
 	Providers    map[string]terraform.ResourceProvider
-	TimeCreated  baremetal.Time
 	Config       string
 	ResourceName string
-	Res          *baremetal.Namespace
 }
 
 func (s *DatasourceObjectstorageNamespaceTestSuite) SetupTest() {
-	s.Client = GetTestProvider()
-
-	s.Provider = Provider(
-		func(d *schema.ResourceData) (interface{}, error) {
-			return s.Client, nil
-		},
-	)
-
-	s.Providers = map[string]terraform.ResourceProvider{
-		"oci": s.Provider,
-	}
-
-	s.TimeCreated = baremetal.Time{Time: time.Now()}
-
-	s.Config = `
-		data "oci_objectstorage_namespace" "t" {}
-	`
-
-	s.Config += testProviderConfig()
-
-	s.ResourceName = "oci_objectstorage_namespace.t"
-	namespace := baremetal.Namespace("namespaceID")
-	s.Res = &namespace
+	s.Client = testAccClient
+	s.Provider = testAccProvider
+	s.Providers = testAccProviders
+	s.Config = testProviderConfig() + `
+	data "oci_objectstorage_namespace" "t" {
+	}`
+	s.ResourceName = "data.oci_objectstorage_namespace.t"
 }
 
-func (s *DatasourceObjectstorageNamespaceTestSuite) TestObjectstorageNamespace() {
+func (s *DatasourceObjectstorageNamespaceTestSuite) TestAccDatasourceObjectstorageNamespace_basic() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
@@ -61,14 +41,13 @@ func (s *DatasourceObjectstorageNamespaceTestSuite) TestObjectstorageNamespace()
 				ImportStateVerify: true,
 				Config:            s.Config,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(s.ResourceName, "namespace", "namespaceID"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "namespace"),
 				),
 			},
 		},
 	})
-
 }
 
-func TestDatasourceobjectstorageNamespaceTestSuite(t *testing.T) {
-	suite.Run(t, new(ResourceObjectstorageObjectTestSuite))
+func TestDatasourceObjectstorageNamespaceTestSuite(t *testing.T) {
+	suite.Run(t, new(DatasourceObjectstorageNamespaceTestSuite))
 }

--- a/data_source_obmcs_objectstorage_object.go
+++ b/data_source_obmcs_objectstorage_object.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 
 	"github.com/oracle/terraform-provider-oci/crud"
+	"strconv"
 )
 
 func ObjectDatasource() *schema.Resource {
@@ -127,6 +128,7 @@ func (s *ObjectDatasourceCrud) Get() (e error) {
 }
 
 func (s *ObjectDatasourceCrud) SetData() {
+	
 	if s.Res != nil {
 		// Important, if you don't have an ID, make one up for your datasource
 		// or things will end in tears
@@ -135,9 +137,9 @@ func (s *ObjectDatasourceCrud) SetData() {
 		for _, v := range s.Res.Objects {
 			res := map[string]interface{}{
 				"name":         v.Name,
-				"size":         v.Size,
+				"size":         strconv.FormatUint(v.Size, 10),
 				"md5":          v.MD5,
-				"time_created": v.TimeCreated,
+				"time_created": v.TimeCreated.String(),
 			}
 			resources = append(resources, res)
 		}

--- a/data_source_obmcs_objectstorage_object_head_test.go
+++ b/data_source_obmcs_objectstorage_object_head_test.go
@@ -4,11 +4,9 @@ package main
 
 import (
 	"testing"
-	"time"
 
 	"github.com/MustWin/baremetal-sdk-go"
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 
 	"github.com/stretchr/testify/suite"
@@ -19,77 +17,61 @@ type DatasourceObjectstorageObjectHeadTestSuite struct {
 	Client       *baremetal.Client
 	Provider     terraform.ResourceProvider
 	Providers    map[string]terraform.ResourceProvider
-	TimeCreated  baremetal.Time
 	Config       string
 	ResourceName string
-	Res          *baremetal.HeadObject
 }
 
 func (s *DatasourceObjectstorageObjectHeadTestSuite) SetupTest() {
-	s.Client = GetTestProvider()
-
-	s.Provider = Provider(
-		func(d *schema.ResourceData) (interface{}, error) {
-			return s.Client, nil
-		},
-	)
-
-	s.Providers = map[string]terraform.ResourceProvider{
-		"oci": s.Provider,
+	s.Client = testAccClient
+	s.Provider = testAccProvider
+	s.Providers = testAccProviders
+	s.Config = testProviderConfig() + `
+	data "oci_objectstorage_namespace" "t" {
 	}
-
-	s.TimeCreated = baremetal.Time{Time: time.Now()}
-
-	s.Config = `
-		resource "oci_objectstorage_bucket" "t" {
-			compartment_id = "${var.compartment_id}"
-			name = "bucketID"
-			namespace = "${var.namespace}"
-			metadata = {
-				"foo" = "bar"
-			}
+	
+	resource "oci_objectstorage_bucket" "t" {
+		compartment_id = "${var.compartment_id}"
+		namespace = "${data.oci_objectstorage_namespace.t.namespace}"
+		name = "-tf-bucket"
+		access_type="ObjectRead"
+	}
+	
+	resource "oci_objectstorage_object" "t" {
+		namespace = "${data.oci_objectstorage_namespace.t.namespace}"
+		bucket = "${oci_objectstorage_bucket.t.name}"
+		object = "-tf-object"
+		content = "test content"
+		metadata = {
+			"content-type" = "text/plain"
 		}
-
-		resource "oci_objectstorage_object" "t" {
-			namespace = "${var.namespace}"
-			bucket = "${oci_objectstorage_bucket.t.name}"
-			object = "objectID"
-			content = "bodyContent"
-			metadata = {
-				"foo" = "bar"
-			}
-		}
-		data "oci_objectstorage_object_head" "t" {
-			namespace = "${var.namespace}"
-			bucket = "${oci_objectstorage_bucket.t.name}"
-			object = "${oci_objectstorage_object.t.object}"
-		}
-	`
-
-	s.Config += testProviderConfig()
-
+	}`
 	s.ResourceName = "data.oci_objectstorage_object_head.t"
 }
 
-func (s *DatasourceObjectstorageObjectHeadTestSuite) TestObjectstorageHeadObject() {
-	resource.UnitTest(s.T(), resource.TestCase{
+func (s *DatasourceObjectstorageObjectHeadTestSuite) TestObjectstorageObjectHead_basic() {
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
 				ImportState:       true,
 				ImportStateVerify: true,
-				Config:            s.Config,
+				Config: s.Config + `
+				data "oci_objectstorage_object_head" "t" {
+					namespace = "${data.oci_objectstorage_namespace.t.namespace}"
+					bucket = "${oci_objectstorage_bucket.t.name}"
+					object = "${oci_objectstorage_object.t.object}"
+				}`,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(s.ResourceName, "bucket", "bucketID"),
 					resource.TestCheckResourceAttrSet(s.ResourceName, "namespace"),
-					resource.TestCheckResourceAttr(s.ResourceName, "metadata.foo", "bar"),
+					resource.TestCheckResourceAttr(s.ResourceName, "bucket", "-tf-bucket"),
+					resource.TestCheckResourceAttr(s.ResourceName, "object", "-tf-object"),
+					resource.TestCheckResourceAttr(s.ResourceName, "metadata.content-type", "text/plain"),
 				),
 			},
 		},
 	})
-
 }
 
-func TestDatasourceobjectstorageObjectHeadTestSuite(t *testing.T) {
+func TestDatasourceObjectstorageObjectHeadTestSuite(t *testing.T) {
 	suite.Run(t, new(DatasourceObjectstorageObjectHeadTestSuite))
 }

--- a/resource_obmcs_objectstorage_bucket.go
+++ b/resource_obmcs_objectstorage_bucket.go
@@ -62,6 +62,7 @@ func (s *BucketResourceCrud) ID() string {
 	return string(s.Res.Namespace) + "/" + s.Res.Name
 }
 
+// todo: this delay doesnt seem necessary but should be well tested in real world scenarios before removal
 func (s *BucketResourceCrud) ExtraWaitPostCreateDelete() time.Duration {
 	return time.Duration(10 * time.Second)
 }

--- a/resource_obmcs_objectstorage_preauthenticatedrequest_test.go
+++ b/resource_obmcs_objectstorage_preauthenticatedrequest_test.go
@@ -4,95 +4,68 @@ package main
 
 import (
 	"testing"
-	"time"
 
 	"github.com/MustWin/baremetal-sdk-go"
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 
 	"github.com/stretchr/testify/suite"
 )
 
-type ResourcePARTestSuite struct {
+type ResourceObjectstoragePARTestSuite struct {
 	suite.Suite
 	Client       *baremetal.Client
 	Provider     terraform.ResourceProvider
 	Providers    map[string]terraform.ResourceProvider
-	TimeCreated  baremetal.Time
-	TimeExpired  baremetal.Time
 	Config       string
 	ResourceName string
-	Res          *PreauthenticatedRequestResourceCrud
 }
 
-func (s *ResourcePARTestSuite) SetupTest() {
-	s.Client = GetTestProvider()
-
-	s.Provider = Provider(
-		func(d *schema.ResourceData) (interface{}, error) {
-			return s.Client, nil
-		},
-	)
-
-	s.Providers = map[string]terraform.ResourceProvider{
-		"oci": s.Provider,
+func (s *ResourceObjectstoragePARTestSuite) SetupTest() {
+	s.Client = testAccClient
+	s.Provider = testAccProvider
+	s.Providers = testAccProviders
+	s.Config = testProviderConfig() + `
+	data "oci_objectstorage_namespace" "t" {
 	}
-
-	s.TimeCreated = baremetal.Time{Time: time.Now()}
-	t, _ := time.Parse(time.RFC3339, "2019-11-10T23:00:00Z")
-	s.TimeExpired = baremetal.Time{Time: t}
-
-	s.Config = `
-		resource "oci_objectstorage_preauthrequest" "t" {
-			namespace ="internalbriangustafson"
-			bucket = "testOne"
-			name = "parOne"
-			access_type = "AnyObjectWrite"
-			time_expires = "2019-11-10T23:00:00Z"
-		}`
-
-	s.Config += testProviderConfig()
+	
+	resource "oci_objectstorage_bucket" "t" {
+		compartment_id = "${var.compartment_id}"
+		namespace = "${data.oci_objectstorage_namespace.t.namespace}"
+		name = "-tf-bucket"
+		access_type="ObjectRead"
+	}`
 
 	s.ResourceName = "oci_objectstorage_preauthrequest.t"
-
 }
 
-func (s *ResourcePARTestSuite) TestCreatePAR() {
-
-	resource.UnitTest(s.T(), resource.TestCase{
+func (s *ResourceObjectstoragePARTestSuite) TestAccResourceObjectstoragePAR_basic() {
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
 				ImportState:       true,
 				ImportStateVerify: true,
-				Config:            s.Config,
+				Config: s.Config + `
+				resource "oci_objectstorage_preauthrequest" "t" {
+					namespace = "${data.oci_objectstorage_namespace.t.namespace}"
+					bucket = "${oci_objectstorage_bucket.t.name}"
+					name = "-tf-par"
+					access_type = "AnyObjectWrite"
+					time_expires = "2019-11-10T23:00:00Z"
+				}`,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(s.ResourceName, "name", "parOne"),
+					resource.TestCheckResourceAttr(s.ResourceName, "name", "-tf-par"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "namespace"),
+					resource.TestCheckResourceAttr(s.ResourceName, "bucket", "-tf-bucket"),
+					resource.TestCheckResourceAttr(s.ResourceName, "access_type", "AnyObjectWrite"),
+					resource.TestCheckResourceAttr(s.ResourceName, "time_expires", "2019-11-10T23:00:00Z"),
 				),
 			},
 		},
 	})
 }
 
-func (s *ResourcePARTestSuite) TestDeletePAR() {
-
-	resource.UnitTest(s.T(), resource.TestCase{
-		Providers: s.Providers,
-		Steps: []resource.TestStep{
-			{
-				ImportState:       true,
-				ImportStateVerify: true,
-				Config:            s.Config,
-			},
-			{
-				Config:  s.Config,
-				Destroy: true,
-			},
-		},
-	})
-}
-
-func TestResourcePARTestSuite(t *testing.T) {
-	suite.Run(t, new(ResourcePARTestSuite))
+func TestResourceObjectstoragePARTestSuite(t *testing.T) {
+	suite.Run(t, new(ResourceObjectstoragePARTestSuite))
 }


### PR DESCRIPTION
* fix silent failure in data_source_obmcs_objectstorage_object.go
* use namespace datasource in lieu of namespace env var

### Test output
ccushing-mac:terraform-provider-oci ccushing$ make test run=make test run=Test.*Objectstorage
TF_ACC=1 TF_ORACLE_ENV=test go test -v -timeout 120m -run Test.*Objectstorage
2017/09/19 11:02:00 User Agent: Oracle-GoSDK/20160918 (go/go1.8; darwin/amd64; terraform/0.9.4-dev) Oracle-TerraformProvider/0.0.0
=== RUN   TestDatasourceObjectstorageBucketSummaryTestSuite
=== RUN   TestAccDatasourceObjectstorageBucketSummaries_basic
--- PASS: TestAccDatasourceObjectstorageBucketSummaries_basic (22.70s)
--- PASS: TestDatasourceObjectstorageBucketSummaryTestSuite (22.70s)
=== RUN   TestDatasourceObjectstorageNamespaceTestSuite
=== RUN   TestAccDatasourceObjectstorageNamespace_basic
--- PASS: TestAccDatasourceObjectstorageNamespace_basic (0.45s)
--- PASS: TestDatasourceObjectstorageNamespaceTestSuite (0.45s)
=== RUN   TestDatasourceObjectstorageObjectHeadTestSuite
=== RUN   TestObjectstorageObjectHead_basic
--- PASS: TestObjectstorageObjectHead_basic (22.08s)
--- PASS: TestDatasourceObjectstorageObjectHeadTestSuite (22.09s)
=== RUN   TestDatasourceObjectstorageObjectTestSuite
=== RUN   TestAccDatasourceObjectstorageObjects_basic
--- PASS: TestAccDatasourceObjectstorageObjects_basic (22.50s)
--- PASS: TestDatasourceObjectstorageObjectTestSuite (22.50s)
=== RUN   TestResourceObjectstorageBucketTestSuite
=== RUN   TestAccResourceObjectstorageBucket_basic
--- PASS: TestAccResourceObjectstorageBucket_basic (21.02s)
--- PASS: TestResourceObjectstorageBucketTestSuite (21.02s)
=== RUN   TestResourceObjectstorageObjectTestSuite
=== RUN   TestAccResourceObjectstorageObject_basic
--- PASS: TestAccResourceObjectstorageObject_basic (22.81s)
--- PASS: TestResourceObjectstorageObjectTestSuite (22.82s)
=== RUN   TestResourceObjectstoragePARTestSuite
=== RUN   TestAccResourceObjectstoragePAR_basic
--- PASS: TestAccResourceObjectstoragePAR_basic (21.82s)
--- PASS: TestResourceObjectstoragePARTestSuite (21.82s)
PASS
ok  	github.com/oracle/terraform-provider-oci	133.408s