### PR TITLE
Fixing the example as dhcp options id is required field for subnet 

### DIFF
--- a/docs/examples/clusters/Mongodb/network.tf
+++ b/docs/examples/clusters/Mongodb/network.tf
@@ -106,6 +106,7 @@ resource "oci_core_subnet" "PublicSubnetAD1" {
   vcn_id = "${oci_core_virtual_network.MongoDB.id}"
   route_table_id = "${oci_core_route_table.MongoDB.id}"
   security_list_ids = ["${oci_core_security_list.PublicSubnet.id}"]
+  dhcp_options_id = "${oci_core_virtual_network.MongoDB.default_dhcp_options_id}"
 }
 
 resource "oci_core_subnet" "PrivSubnetAD1" {
@@ -116,6 +117,7 @@ resource "oci_core_subnet" "PrivSubnetAD1" {
   vcn_id = "${oci_core_virtual_network.MongoDB.id}"
   route_table_id = "${oci_core_route_table.MongoDB.id}"
   security_list_ids = ["${oci_core_security_list.PrivateSubnets.id}"]
+  dhcp_options_id = "${oci_core_virtual_network.MongoDB.default_dhcp_options_id}"
 }
 
 resource "oci_core_subnet" "PrivSubnetAD2" {
@@ -126,6 +128,7 @@ resource "oci_core_subnet" "PrivSubnetAD2" {
   vcn_id = "${oci_core_virtual_network.MongoDB.id}"
   route_table_id = "${oci_core_route_table.MongoDB.id}"
   security_list_ids = ["${oci_core_security_list.PrivateSubnets.id}"]
+  dhcp_options_id = "${oci_core_virtual_network.MongoDB.default_dhcp_options_id}"
 }
 
 resource "oci_core_subnet" "BastionSubnetAD1" {
@@ -136,5 +139,6 @@ resource "oci_core_subnet" "BastionSubnetAD1" {
   vcn_id = "${oci_core_virtual_network.MongoDB.id}"
   route_table_id = "${oci_core_route_table.MongoDB.id}"
   security_list_ids = ["${oci_core_security_list.BastionSubnet.id}"]
+  dhcp_options_id = "${oci_core_virtual_network.MongoDB.default_dhcp_options_id}"
 }
 


### PR DESCRIPTION
Manually tested by running the example
[terraform_tfstate.txt](https://github.com/oracle/terraform-provider-oci/files/1322298/terraform_tfstate.txt)


