### PR TITLE
Fix boolean parsing in create_vnic_details

### DIFF
--- a/resource_obmcs_core_instance.go
+++ b/resource_obmcs_core_instance.go
@@ -260,16 +260,19 @@ func (s *InstanceResourceCrud) Create() (e error) {
 	}
 
 	if rawVnic, ok := s.D.GetOk("create_vnic_details"); ok {
-		opts.CreateVnicOptions = SetCreateVnicOptions(rawVnic)
+		opts.CreateVnicOptions, e = SetCreateVnicOptions(rawVnic)
 	}
 
-	s.Resource, e = s.Client.LaunchInstance(
-		availabilityDomain,
-		compartmentID,
-		image,
-		shape,
-		subnet,
-		opts)
+	if e == nil {
+		s.Resource, e = s.Client.LaunchInstance(
+			availabilityDomain,
+			compartmentID,
+			image,
+			shape,
+			subnet,
+			opts)
+	}
+
 	return
 }
 

--- a/resource_obmcs_core_vnic_attachment.go
+++ b/resource_obmcs_core_vnic_attachment.go
@@ -159,9 +159,10 @@ func (s *VnicAttachmentResourceCrud) Create() (e error) {
 		vaOpts.DisplayName = displayName.(string)
 	}
 
-	vnicOpts := SetCreateVnicOptions(s.D.Get("create_vnic_details"))
-
-	s.Resource, e = s.Client.AttachVnic(instanceID, vnicOpts, vaOpts)
+	vnicOpts, e := SetCreateVnicOptions(s.D.Get("create_vnic_details"))
+	if e == nil {
+		s.Resource, e = s.Client.AttachVnic(instanceID, vnicOpts, vaOpts)
+	}
 
 	return
 }


### PR DESCRIPTION
For most bool values in Terraform, you can use true and "true" interchangeably.
The bool values nested in create_vnic_details are treated differently, apprently
due to https://github.com/hashicorp/terraform/issues/13512: true appears as "1",
while "true" appears as "true". ParseBool handles both.

Verified that the changes to ResourceCoreVnicAttachmentTestSuite fail before applying the other changes and succeed after. 