### PR TITLE
address possible race condition in policy test

### DIFF
--- a/data_source_obmcs_identity_policies_test.go
+++ b/data_source_obmcs_identity_policies_test.go
@@ -53,7 +53,9 @@ func (s *DatasourceIdentityPolicyTestSuite) TestAccDatasourceIdentityPolicies_ba
 			{
 				ImportState:       true,
 				ImportStateVerify: true,
-				Config: s.Config + `	
+				Config: s.Config,
+			},{
+				Config: s.Config + `
 				data "oci_identity_policies" "p" {
 					compartment_id = "${oci_identity_compartment.t.id}"
 				}`,


### PR DESCRIPTION
Separate out the Config "setup" steps from the verification to address a possible race condition that may be the cause of failures.