### PR TITLE
Support compartment renaming

### DIFF
--- a/docs/datasources/identity/compartment.md
+++ b/docs/datasources/identity/compartment.md
@@ -19,10 +19,10 @@ The following arguments are supported:
 ## Attribute Reference
 * `compartments` - A list of compartments
 
-## Group Reference
+## Compartment Reference
 * `id` - The OCID of the compartment.
 * `compartment_id` - The OCID of the tenancy containing the compartment.
-* `name` - The name you assign to the compartment during creation. The name must be unique across all compartments in the tenancy and cannot be changed.
+* `name` - The name you assign to the compartment during creation. The name must be unique across all compartments in the tenancy, and it's changeable.
 * `description` - The description you assign to the compartment. Does not have to be unique, and it's changeable.
 * `time_created` - Date and time the compartment was created.
 * `state` - The compartment's current state. [CREATING, ACTIVE, INACTIVE, DELETING, DELETED]

--- a/docs/datasources/identity/policy.md
+++ b/docs/datasources/identity/policy.md
@@ -19,7 +19,7 @@ The following arguments are supported:
 ## Attribute Reference
 * `policies` - A list of policies
 
-## Group Reference
+## Policy Reference
 * `id` - The OCID of the policy.
 * `compartment_id` - The OCID of the compartment containing the policy (either the tenancy or another compartment).
 * `name` - The name you assign to the policy during creation. The name must be unique across all policies in the tenancy and cannot be changed.

--- a/docs/datasources/identity/user.md
+++ b/docs/datasources/identity/user.md
@@ -19,7 +19,7 @@ The following arguments are supported:
 ## Attribute Reference
 * `users` - A list of users
 
-## Group Reference
+## User Reference
 * `id` - The OCID of the user.
 * `compartment_id` - The OCID of the tenancy containing the user.
 * `name` - The name you assign to the user during creation. This is the user's login for the Console. The name must be unique across all users in the tenancy and cannot be changed.

--- a/docs/resources/identity/compartment.md
+++ b/docs/resources/identity/compartment.md
@@ -15,13 +15,13 @@ resource "oci_identity_compartment" "t" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name you assign to the compartment during creation. The name must be unique across all compartments in the tenancy and cannot be changed.
+* `name` - (Required) The name you assign to the compartment during creation. The name must be unique across all compartments in the tenancy, and it's changeable.
 * `description` - (Required) The description you assign to the compartment during creation. Does not have to be unique, and it's changeable.
 
 ## Attributes Reference
 * `id` - The OCID of the compartment.
 * `compartment_id` - The OCID of the tenancy containing the compartment.
-* `name` - The name you assign to the compartment during creation. The name must be unique across all compartments in the tenancy and cannot be changed.
+* `name` - The name you assign to the compartment during creation. The name must be unique across all compartments in the tenancy, and it's changeable.
 * `descriptions` - The description you assign to the compartment. Does not have to be unique, and it's changeable.
 * `time_created` - Date and time the compartment was created.
 * `state` - The compartment's current state. [CREATING, ACTIVE, INACTIVE, DELETING, DELETED]

--- a/helpers_identity.go
+++ b/helpers_identity.go
@@ -4,7 +4,8 @@ package main
 
 import "github.com/hashicorp/terraform/helper/schema"
 
-var baseIdentitySchemaWithID = map[string]*schema.Schema{
+// User and group happen to have the same schema and share this
+var baseIdentitySchema = map[string]*schema.Schema{
 	"id": {
 		Type:     schema.TypeString,
 		Computed: true,
@@ -29,96 +30,6 @@ var baseIdentitySchemaWithID = map[string]*schema.Schema{
 	},
 	"inactive_state": {
 		Type:     schema.TypeInt,
-		Computed: true,
-	},
-	"time_created": {
-		Type:     schema.TypeString,
-		Computed: true,
-	},
-	"time_modified": {
-		Type:     schema.TypeString,
-		Computed: true,
-	},
-}
-
-// Just has a computed compartment_id
-var baseIdentitySchema = map[string]*schema.Schema{
-	"name": {
-		Type:     schema.TypeString,
-		Required: true,
-		ForceNew: true,
-	},
-	"description": {
-		Type:     schema.TypeString,
-		Required: true,
-	},
-	"compartment_id": {
-		Type:     schema.TypeString,
-		Computed: true,
-	},
-	"state": {
-		Type:     schema.TypeString,
-		Computed: true,
-	},
-	"time_created": {
-		Type:     schema.TypeString,
-		Computed: true,
-	},
-	"time_modified": {
-		Type:     schema.TypeString,
-		Computed: true,
-	},
-}
-
-var identitySchema = map[string]*schema.Schema{
-	"name": {
-		Type:     schema.TypeString,
-		Required: true,
-		ForceNew: true,
-	},
-	"description": {
-		Type:     schema.TypeString,
-		Required: true,
-	},
-	"compartment_id": {
-		Type:     schema.TypeString,
-		Required: true,
-	},
-	"state": {
-		Type:     schema.TypeString,
-		Computed: true,
-	},
-	"time_created": {
-		Type:     schema.TypeString,
-		Computed: true,
-	},
-	"time_modified": {
-		Type:     schema.TypeString,
-		Computed: true,
-	},
-}
-
-var identitySchemaWithID = map[string]*schema.Schema{
-	"id": {
-		Type:     schema.TypeString,
-		Computed: true,
-		ForceNew: true,
-	},
-	"name": {
-		Type:     schema.TypeString,
-		Required: true,
-		ForceNew: true,
-	},
-	"description": {
-		Type:     schema.TypeString,
-		Required: true,
-	},
-	"compartment_id": {
-		Type:     schema.TypeString,
-		Required: true,
-	},
-	"state": {
-		Type:     schema.TypeString,
 		Computed: true,
 	},
 	"time_created": {

--- a/resource_obmcs_identity_compartment.go
+++ b/resource_obmcs_identity_compartment.go
@@ -15,6 +15,42 @@ import (
 
 // ResourceIdentityCompartment exposes an IdentityCompartment Resource
 func CompartmentResource() *schema.Resource {
+	compartmentSchema := map[string]*schema.Schema{
+		"id": {
+			Type:     schema.TypeString,
+			Computed: true,
+			ForceNew: true,
+		},
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"description": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"compartment_id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"state": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"inactive_state": {
+			Type:     schema.TypeInt,
+			Computed: true,
+		},
+		"time_created": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"time_modified": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+	}
+
 	return &schema.Resource{
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -24,7 +60,7 @@ func CompartmentResource() *schema.Resource {
 		Read:     readCompartment,
 		Update:   updateCompartment,
 		Delete:   deleteCompartment,
-		Schema:   baseIdentitySchemaWithID,
+		Schema:   compartmentSchema,
 	}
 }
 
@@ -132,7 +168,10 @@ func (s *CompartmentResourceCrud) Get() (e error) {
 }
 
 func (s *CompartmentResourceCrud) Update() (e error) {
-	opts := &baremetal.UpdateIdentityOptions{}
+	opts := &baremetal.UpdateCompartmentOptions{}
+	if name, ok := s.D.GetOk("name"); ok {
+		opts.Name = name.(string)
+	}
 	if description, ok := s.D.GetOk("description"); ok {
 		opts.Description = description.(string)
 	}

--- a/resource_obmcs_identity_compartment.go
+++ b/resource_obmcs_identity_compartment.go
@@ -19,7 +19,6 @@ func CompartmentResource() *schema.Resource {
 		"id": {
 			Type:     schema.TypeString,
 			Computed: true,
-			ForceNew: true,
 		},
 		"name": {
 			Type:     schema.TypeString,

--- a/resource_obmcs_identity_compartment_test.go
+++ b/resource_obmcs_identity_compartment_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/oracle/bmcs-go-sdk"
 
 	"github.com/stretchr/testify/suite"
+	"fmt"
 )
 
 type ResourceIdentityCompartmentTestSuite struct {
@@ -31,6 +32,7 @@ func (s *ResourceIdentityCompartmentTestSuite) SetupTest() {
 }
 
 func (s *ResourceIdentityCompartmentTestSuite) TestAccResourceIdentityCompartment_basic() {
+	var resId, resId2 string
 	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
@@ -47,6 +49,10 @@ func (s *ResourceIdentityCompartmentTestSuite) TestAccResourceIdentityCompartmen
 					resource.TestCheckResourceAttr(s.ResourceName, "name", "-tf-compartment"),
 					resource.TestCheckResourceAttr(s.ResourceName, "description", "tf test compartment"),
 					resource.TestCheckResourceAttr(s.ResourceName, "state", baremetal.ResourceActive),
+					func(s *terraform.State) (err error) {
+						resId, err = fromInstanceState(s, "oci_identity_compartment.t", "id")
+						return err
+					},
 				),
 			},
 			// verify update
@@ -59,6 +65,13 @@ func (s *ResourceIdentityCompartmentTestSuite) TestAccResourceIdentityCompartmen
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(s.ResourceName, "name", "-tf-compartment2"),
 					resource.TestCheckResourceAttr(s.ResourceName, "description", "tf test compartment2"),
+					func(s *terraform.State) (err error) {
+						resId2, err = fromInstanceState(s, "oci_identity_compartment.t", "id")
+						if resId != resId2 {
+							return fmt.Errorf("Expected same ocid, got the different.")
+						}
+						return err
+					},
 				),
 			},
 			// restore compartment to original state (for future tests)

--- a/resource_obmcs_identity_compartment_test.go
+++ b/resource_obmcs_identity_compartment_test.go
@@ -53,11 +53,11 @@ func (s *ResourceIdentityCompartmentTestSuite) TestAccResourceIdentityCompartmen
 			{
 				Config: s.Config + `
 				resource "oci_identity_compartment" "t" {
-					name = "-tf-compartment"
+					name = "-tf-compartment2"
 					description = "tf test compartment2"
 				}`,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(s.ResourceName, "name", "-tf-compartment"),
+					resource.TestCheckResourceAttr(s.ResourceName, "name", "-tf-compartment2"),
 					resource.TestCheckResourceAttr(s.ResourceName, "description", "tf test compartment2"),
 				),
 			},

--- a/resource_obmcs_identity_group.go
+++ b/resource_obmcs_identity_group.go
@@ -22,7 +22,7 @@ func GroupResource() *schema.Resource {
 		Read:     readGroup,
 		Update:   updateGroup,
 		Delete:   deleteGroup,
-		Schema:   baseIdentitySchemaWithID,
+		Schema:   baseIdentitySchema,
 	}
 }
 

--- a/resource_obmcs_identity_policy.go
+++ b/resource_obmcs_identity_policy.go
@@ -10,24 +10,50 @@ import (
 )
 
 func PolicyResource() *schema.Resource {
-	policySchema := make(map[string]*schema.Schema)
-
-	for key, value := range identitySchemaWithID {
-		policySchema[key] = value
-	}
-
-	policySchema["statements"] = &schema.Schema{
-		Type:     schema.TypeList,
-		Required: true,
-		Elem:     &schema.Schema{Type: schema.TypeString},
-	}
-	policySchema["inactive_state"] = &schema.Schema{
-		Type:     schema.TypeInt,
-		Computed: true,
-	}
-	policySchema["version_date"] = &schema.Schema{
-		Type:     schema.TypeString,
-		Computed: true,
+	policySchema := map[string]*schema.Schema{
+		"id": {
+			Type:     schema.TypeString,
+			Computed: true,
+			ForceNew: true,
+		},
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+		"description": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"compartment_id": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"state": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"time_created": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"time_modified": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"statements": {
+			Type:     schema.TypeList,
+			Required: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
+		"inactive_state": {
+			Type:     schema.TypeInt,
+			Computed: true,
+		},
+		"version_date": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 	}
 
 	return &schema.Resource{

--- a/resource_obmcs_identity_user.go
+++ b/resource_obmcs_identity_user.go
@@ -20,7 +20,7 @@ func UserResource() *schema.Resource {
 		Read:     readUser,
 		Update:   updateUser,
 		Delete:   deleteUser,
-		Schema:   baseIdentitySchemaWithID,
+		Schema:   baseIdentitySchema,
 	}
 }
 

--- a/vendor/github.com/oracle/bmcs-go-sdk/identity_compartment.go
+++ b/vendor/github.com/oracle/bmcs-go-sdk/identity_compartment.go
@@ -77,7 +77,7 @@ func (c *Client) GetCompartment(id string) (res *Compartment, e error) {
 // UpdateCompartment updates the description of a compartment.
 //
 // See https://docs.us-phoenix-1.oraclecloud.com/api/#/en/identity/20160918/Compartment/UpdateCompartment
-func (c *Client) UpdateCompartment(id string, opts *UpdateIdentityOptions) (res *Compartment, e error) {
+func (c *Client) UpdateCompartment(id string, opts *UpdateCompartmentOptions) (res *Compartment, e error) {
 	details := &requestDetails{
 		ids:      urlParts{id},
 		name:     resourceCompartments,

--- a/vendor/github.com/oracle/bmcs-go-sdk/request_options.go
+++ b/vendor/github.com/oracle/bmcs-go-sdk/request_options.go
@@ -155,8 +155,8 @@ type UpdatePrivateIPOptions struct {
 
 type UpdateVnicOptions struct {
 	UpdateOptions
-	HostnameLabel 		string `header:"-" json:"hostnameLabel,omitempty" url:"-"`
-	SkipSourceDestCheck	*bool  `header:"-" json:"skipSourceDestCheck,omitempty" url:"-"`
+	HostnameLabel       string `header:"-" json:"hostnameLabel,omitempty" url:"-"`
+	SkipSourceDestCheck *bool  `header:"-" json:"skipSourceDestCheck,omitempty" url:"-"`
 }
 
 type CreateVolumeOptions struct {
@@ -171,12 +171,12 @@ type CreatePolicyOptions struct {
 }
 
 type CreateVnicOptions struct {
-	AssignPublicIp 		*bool  `header:"-" json:"assignPublicIp,omitempty" url:"-"`
-	DisplayName    		string `header:"-" json:"displayName,omitempty" url:"-"`
-	HostnameLabel  		string `header:"-" json:"hostnameLabel,omitempty" url:"-"`
-	PrivateIp      		string `header:"-" json:"privateIp,omitempty" url:"-"`
-	SkipSourceDestCheck	*bool  `header:"-" json:"skipSourceDestCheck,omitempty" url:"-"`
-	SubnetID      		string `header:"-" json:"subnetId,omitempty" url:"-"`
+	AssignPublicIp      *bool  `header:"-" json:"assignPublicIp,omitempty" url:"-"`
+	DisplayName         string `header:"-" json:"displayName,omitempty" url:"-"`
+	HostnameLabel       string `header:"-" json:"hostnameLabel,omitempty" url:"-"`
+	PrivateIp           string `header:"-" json:"privateIp,omitempty" url:"-"`
+	SkipSourceDestCheck *bool  `header:"-" json:"skipSourceDestCheck,omitempty" url:"-"`
+	SubnetID            string `header:"-" json:"subnetId,omitempty" url:"-"`
 }
 
 type LaunchInstanceOptions struct {
@@ -240,6 +240,11 @@ type UpdateBucketOptions struct {
 type UpdateIdentityOptions struct {
 	IfMatchOptions
 	Description string `header:"-" json:"description,omitempty" url:"-"`
+}
+
+type UpdateCompartmentOptions struct {
+	UpdateIdentityOptions
+	Name string `header:"-" json:"name,omitempty" url:"-"`
 }
 
 type UpdateUserStateOptions struct {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2972,10 +2972,10 @@
 			"revisionTime": "2017-01-25T16:36:56Z"
 		},
 		{
-			"checksumSHA1": "52cecCncaYeBtPjEq5GXLnbUVAA=",
+			"checksumSHA1": "i5+LuvTFk7sBs5CUWo9+cjE1YcA=",
 			"path": "github.com/oracle/bmcs-go-sdk",
-			"revision": "c12b16924d0c0613c8651bda0c0156ce527ed2bd",
-			"revisionTime": "2017-09-25T22:50:26Z"
+			"revision": "c58f2bfda490d2e87610265d056aea0716d94c87",
+			"revisionTime": "2017-09-27T00:20:41Z"
 		},
 		{
 			"checksumSHA1": "ImgLNIpeXsGjZGXw4rd+rwzQxpo=",


### PR DESCRIPTION
* Denormalize not really normal shared schemas in helpers_identity + policy + compartments
  * remove dead code/schema defs in helpers_identity
* fix some copy/paste errors in related docs/datasources

### Tests
ccushing-mac:terraform-provider-oci ccushing$ make test run=Test.*Identity.*TestSuite
=== RUN   TestDatasourceIdentityAPIKeysTestSuite
=== RUN   TestAccDatasourceIdentityAPIKeys_basic
--- PASS: TestAccDatasourceIdentityAPIKeys_basic (3.45s)
--- PASS: TestDatasourceIdentityAPIKeysTestSuite (3.45s)
=== RUN   TestDatasourceIdentityAvailabilityDomainsTestSuite
=== RUN   TestAccIdentityAvailabilityDomains_basic
--- PASS: TestAccIdentityAvailabilityDomains_basic (0.30s)
--- PASS: TestDatasourceIdentityAvailabilityDomainsTestSuite (0.30s)
=== RUN   TestDatasourceIdentityCompartmentsTestSuite
=== RUN   TestAccIdentityCompartments_basic
--- PASS: TestAccIdentityCompartments_basic (2.46s)
--- PASS: TestDatasourceIdentityCompartmentsTestSuite (2.46s)
=== RUN   TestDatasourceIdentityGroupsTestSuite
=== RUN   TestAccDatasourceIdentityGroups_basic
--- PASS: TestAccDatasourceIdentityGroups_basic (4.49s)
--- PASS: TestDatasourceIdentityGroupsTestSuite (4.49s)
=== RUN   TestDatasourceIdentityPoliciesTestSuite
=== RUN   TestAccDatasourceIdentityPolicies_basic
--- PASS: TestAccDatasourceIdentityPolicies_basic (6.05s)
--- PASS: TestDatasourceIdentityPoliciesTestSuite (6.05s)
=== RUN   TestDatasourceIdentitySwiftPasswordsTestSuite
=== RUN   TestAccDatasourceIdentitySwiftPasswords_basic
--- PASS: TestAccDatasourceIdentitySwiftPasswords_basic (2.27s)
--- PASS: TestDatasourceIdentitySwiftPasswordsTestSuite (2.27s)
=== RUN   TestDatasourceIdentityUserGroupMembershipsTestSuite
=== RUN   TestAccIdentityUserGroupMemberships_basic
--- PASS: TestAccIdentityUserGroupMemberships_basic (7.98s)
--- PASS: TestDatasourceIdentityUserGroupMembershipsTestSuite (7.98s)
=== RUN   TestDatasourceIdentityUsersTestSuite
=== RUN   TestAccIdentityUsers_basic
--- PASS: TestAccIdentityUsers_basic (3.70s)
--- PASS: TestDatasourceIdentityUsersTestSuite (3.70s)
=== RUN   TestResourceIdentityAPIKeyTestSuite
=== RUN   TestAccResourceIdentityAPIKey_basic
--- PASS: TestAccResourceIdentityAPIKey_basic (1.71s)
--- PASS: TestResourceIdentityAPIKeyTestSuite (1.71s)
=== RUN   TestResourceIdentityCompartmentTestSuite
=== RUN   TestAccResourceIdentityCompartment_basic
--- PASS: TestAccResourceIdentityCompartment_basic (1.65s)
--- PASS: TestResourceIdentityCompartmentTestSuite (1.65s)
=== RUN   TestResourceIdentityGroupTestSuite
=== RUN   TestAccResourceIdentityGroup_basic
--- PASS: TestAccResourceIdentityGroup_basic (3.87s)
--- PASS: TestResourceIdentityGroupTestSuite (3.87s)
=== RUN   TestResourceIdentityPolicyTestSuite
=== RUN   TestAccResourceIdentityPolicy_basic
--- PASS: TestAccResourceIdentityPolicy_basic (8.18s)
--- PASS: TestResourceIdentityPolicyTestSuite (8.18s)
=== RUN   TestResourceIdentitySwiftPasswordTestSuite
=== RUN   TestAccResourceIdentitySwiftPassword_basic
--- PASS: TestAccResourceIdentitySwiftPassword_basic (2.11s)
--- PASS: TestResourceIdentitySwiftPasswordTestSuite (2.11s)
=== RUN   TestResourceIdentityUIPasswordTestSuite
=== RUN   TestAccIdentityUIPassword_basic
--- PASS: TestAccIdentityUIPassword_basic (1.25s)
--- PASS: TestResourceIdentityUIPasswordTestSuite (1.25s)
=== RUN   TestResourceIdentityUserGroupMembershipTestSuite
=== RUN   TestAccResourceUserGroupMemberships_basic
--- PASS: TestAccResourceUserGroupMemberships_basic (4.64s)
--- PASS: TestResourceIdentityUserGroupMembershipTestSuite (4.64s)
=== RUN   TestResourceIdentityUserTestSuite
=== RUN   TestAccResourceIdentityUser_basic
--- PASS: TestAccResourceIdentityUser_basic (1.24s)
--- PASS: TestResourceIdentityUserTestSuite (1.24s)
PASS
ok      github.com/oracle/terraform-provider-oci        55.373s
