### PR TITLE
fixing the policy format changes issue

### DIFF
--- a/resource_obmcs_identity_policy.go
+++ b/resource_obmcs_identity_policy.go
@@ -6,6 +6,10 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/oracle/bmcs-go-sdk"
 
+	"crypto/md5"
+	"encoding/hex"
+	"strings"
+
 	"github.com/oracle/terraform-provider-oci/crud"
 )
 
@@ -42,9 +46,22 @@ func PolicyResource() *schema.Resource {
 			Computed: true,
 		},
 		"statements": {
-			Type:     schema.TypeList,
-			Required: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
+			Type:             schema.TypeList,
+			Required:         true,
+			DiffSuppressFunc: ignorePolicyFormatDiff,
+			Elem:             &schema.Schema{Type: schema.TypeString},
+		},
+		"ETag": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"policyHash": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"lastUpdateETag": {
+			Type:     schema.TypeString,
+			Computed: true,
 		},
 		"inactive_state": {
 			Type:     schema.TypeInt,
@@ -67,6 +84,25 @@ func PolicyResource() *schema.Resource {
 		Delete:   deletePolicy,
 		Schema:   policySchema,
 	}
+}
+
+func ignorePolicyFormatDiff(k string, old string, new string, d *schema.ResourceData) bool {
+	oldHash := getOrDefault(d, "policyHash", "")
+	newHash := getMD5Hash(toStringArray(d.Get("statements")))
+	oldETag := getOrDefault(d, "lastUpdateETag", "")
+	currentETag := getOrDefault(d, "ETag", "")
+	suppressDiff := strings.EqualFold(oldHash, newHash) && strings.EqualFold(oldETag, currentETag)
+
+	return suppressDiff
+}
+
+func getOrDefault(d *schema.ResourceData, key string, defaultValue string) string {
+	valueString := defaultValue
+	if value, ok := d.GetOk(key); ok {
+		valueString = value.(string)
+	}
+
+	return valueString
 }
 
 func createPolicy(d *schema.ResourceData, m interface{}) (e error) {
@@ -131,7 +167,7 @@ func (s *PolicyResourceCrud) DeletedTarget() []string {
 	return []string{baremetal.ResourceDeleted}
 }
 
-func (s *PolicyResourceCrud) toStringArray(vals interface{}) []string {
+func toStringArray(vals interface{}) []string {
 	arr := vals.([]interface{})
 	result := []string{}
 	for _, val := range arr {
@@ -144,9 +180,15 @@ func (s *PolicyResourceCrud) Create() (e error) {
 	name := s.D.Get("name").(string)
 	description := s.D.Get("description").(string)
 	compartmentID := s.D.Get("compartment_id").(string)
-	statements := s.toStringArray(s.D.Get("statements"))
+	statements := toStringArray(s.D.Get("statements"))
 
 	s.Res, e = s.Client.CreatePolicy(name, description, compartmentID, statements, nil)
+
+	if e == nil {
+		s.D.Set("policyHash", getMD5Hash(statements))
+		s.D.Set("lastUpdateETag", s.Res.ETag)
+	}
+
 	return
 }
 
@@ -164,22 +206,34 @@ func (s *PolicyResourceCrud) Update() (e error) {
 		opts.Description = description.(string)
 	}
 
+	policyHash := ""
 	if rawStatements, ok := s.D.GetOk("statements"); ok {
-		statements := s.toStringArray(rawStatements)
+		statements := toStringArray(rawStatements)
 		opts.Statements = statements
+		policyHash = getMD5Hash(statements)
 	}
 
 	s.Res, e = s.Client.UpdatePolicy(s.D.Id(), opts)
+	if e == nil {
+		s.D.Set("policyHash", policyHash)
+		s.D.Set("lastUpdateETag", s.Res.ETag)
+	}
 	return
 }
 
 func (s *PolicyResourceCrud) SetData() {
 	s.D.Set("statements", s.Res.Statements)
+	s.D.Set("ETag", s.Res.ETag)
 	s.D.Set("name", s.Res.Name)
 	s.D.Set("description", s.Res.Description)
 	s.D.Set("compartment_id", s.Res.CompartmentID)
 	s.D.Set("state", s.Res.State)
 	s.D.Set("time_created", s.Res.TimeCreated.String())
+}
+
+func getMD5Hash(values []string) string {
+	hash := md5.Sum([]byte(strings.Join(values, "#")))
+	return hex.EncodeToString(hash[:])
 }
 
 func (s *PolicyResourceCrud) Delete() (e error) {


### PR DESCRIPTION

Testing Done:
manually created the policy resource and validated 
1. Apply does not update the policy even though format difference
2. server side policy update gets overwritten  on apply
[update.txt](https://github.com/oracle/terraform-provider-oci/files/1342432/update.txt)
[create.txt](https://github.com/oracle/terraform-provider-oci/files/1342433/create.txt)
[terraform.tfstate.backup.txt](https://github.com/oracle/terraform-provider-oci/files/1342442/terraform.tfstate.backup.txt)
[terraform.tfstate.txt](https://github.com/oracle/terraform-provider-oci/files/1342443/terraform.tfstate.txt)
[policy.tf.txt](https://github.com/oracle/terraform-provider-oci/files/1342444/policy.tf.txt)


