### PR TITLE
Add object store fixes and file upload example

### DIFF
--- a/docs/examples/object_storage/file_upload/data.txt
+++ b/docs/examples/object_storage/file_upload/data.txt
@@ -1,0 +1,1 @@
+This file was uploaded via terraform

--- a/docs/examples/object_storage/file_upload/file_upload.tf
+++ b/docs/examples/object_storage/file_upload/file_upload.tf
@@ -1,0 +1,44 @@
+/* This example demonstrates limited support for object store file upload using terraforms `file` 
+ * helper method.
+ * 
+ * WARNING: This is not an appropriate solution for large files, this should only be used with small files.
+ * The file helper does stringification so large files may cause terraform to slow, become unresponsive or 
+ * exceed allowed memory usage.
+ */
+
+variable "tenancy_ocid" {}
+variable "user_ocid" {}
+variable "fingerprint" {}
+variable "private_key_path" {}
+variable "compartment_ocid" {}
+variable "region" { default = "us-phoenix-1" }
+
+
+provider "oci" {
+  tenancy_ocid = "${var.tenancy_ocid}"
+  user_ocid = "${var.user_ocid}"
+  fingerprint = "${var.fingerprint}"
+  private_key_path = "${var.private_key_path}"
+  region = "${var.region}"
+}
+
+data "oci_objectstorage_namespace" "t" {
+}
+
+resource "oci_objectstorage_bucket" "t" {
+  compartment_id = "${var.compartment_ocid}"
+  namespace = "${data.oci_objectstorage_namespace.t.namespace}"
+  name = "-tf-bucket"
+  access_type="ObjectRead"
+}
+
+resource "oci_objectstorage_object" "t" {
+  namespace = "${data.oci_objectstorage_namespace.t.namespace}"
+  bucket = "${oci_objectstorage_bucket.t.name}"
+  object = "-tf-object"
+  content = "${file("data.txt")}"
+  content_type = "text/plain"
+  metadata = {
+    "version" = "1"
+  }
+}

--- a/docs/resources/objectstorage/object.md
+++ b/docs/resources/objectstorage/object.md
@@ -4,16 +4,19 @@ Provides an Objectstorage resource for CRUD operations on objects.
 
 ## Example Usage
 
-### Object w/ Metadata
+### Object
 
 ```
 resource "oci_objectstorage_object" "t" {
     namespace = "namespaceID"
     bucket = "bucketID"
     object = "objectID"
-    content = "bodyContent"
+    content = "the content"
+    content_type = "text/plain"
+    content_language = "en-US"
+    content_encoding = "identity"
     metadata = {
-        "foo" = "bar"
+        "version" = "1"
     }
 }
 ```
@@ -26,3 +29,11 @@ The following arguments are supported:
 * `bucket` - (Required) The name of the bucket.
 * `object` - (Required) The name of the object.
 * `content` - (Optional) A string that will form the body of the object.
+* `metadata` - (Optional) User-defined metadata key value pairs.
+* `content_type` - (Optional) The content type of the object. Defaults to 'application/octet-stream' if not overridden during the PutObject call.
+* `content_language` - (Optional) The content language of the object.
+* `content_encoding` - (Optional) The content encoding of the object.
+
+## Additional Attributes
+* `content_length` - The content length of the body.
+* `content_MD5` - The base-64 encoded MD5 hash of the body.

--- a/docs/resources/objectstorage/object.md
+++ b/docs/resources/objectstorage/object.md
@@ -36,4 +36,4 @@ The following arguments are supported:
 
 ## Additional Attributes
 * `content_length` - The content length of the body.
-* `content_MD5` - The base-64 encoded MD5 hash of the body.
+* `content_md5` - The base-64 encoded MD5 hash of the body.

--- a/helpers_objectstorage.go
+++ b/helpers_objectstorage.go
@@ -47,32 +47,6 @@ var bucketSchema = map[string]*schema.Schema{
 	},
 }
 
-var objectSchema = map[string]*schema.Schema{
-	"namespace": {
-		Type:     schema.TypeString,
-		Required: true,
-		Computed: false,
-	},
-	"bucket": {
-		Type:     schema.TypeString,
-		Required: true,
-		Computed: false,
-	},
-	"object": {
-		Type:     schema.TypeString,
-		Required: true,
-		Computed: false,
-	},
-	"content": {
-		Type:     schema.TypeString,
-		Optional: true,
-	},
-	"metadata": {
-		Type:     schema.TypeMap,
-		Optional: true,
-	},
-}
-
 var preauthenticatedRequestSchema = map[string]*schema.Schema{
 	"id": {
 		Type:     schema.TypeString,

--- a/resource_obmcs_objectstorage_object.go
+++ b/resource_obmcs_objectstorage_object.go
@@ -10,7 +10,6 @@ import (
 
 	"crypto/md5"
 	"encoding/hex"
-	"strings"
 
 	"github.com/oracle/terraform-provider-oci/crud"
 )
@@ -40,7 +39,7 @@ func ObjectResource() *schema.Resource {
 				if v == "" {
 					return ""
 				}
-				h := md5.Sum([]byte(strings.TrimSpace(v)))
+				h := md5.Sum([]byte(v))
 				return hex.EncodeToString(h[:])
 			},
 		},
@@ -56,7 +55,7 @@ func ObjectResource() *schema.Resource {
 			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		"content_MD5": {
+		"content_md5": {
 			Type:     schema.TypeString,
 			Computed: true,
 		},
@@ -131,7 +130,7 @@ func (s *ObjectResourceCrud) SetData() {
 	s.D.Set("content_encoding", s.Res.ContentEncoding)
 	s.D.Set("content_language", s.Res.ContentLanguage)
 	s.D.Set("content_length", s.Res.ContentLength)
-	s.D.Set("content_MD5", s.Res.ContentMD5)
+	s.D.Set("content_md5", s.Res.ContentMD5)
 	s.D.Set("content_type", s.Res.ContentType)
 }
 

--- a/resource_obmcs_objectstorage_object_test.go
+++ b/resource_obmcs_objectstorage_object_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/oracle/bmcs-go-sdk"
 
+	"fmt"
+
 	"github.com/stretchr/testify/suite"
 )
 
@@ -41,10 +43,11 @@ func (s *ResourceObjectstorageObjectTestSuite) SetupTest() {
 }
 
 func (s *ResourceObjectstorageObjectTestSuite) TestAccResourceObjectstorageObject_basic() {
+	var resId, resId2 string
 	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
-			// verify create
+			// verify create with expected defaults
 			{
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -53,17 +56,26 @@ func (s *ResourceObjectstorageObjectTestSuite) TestAccResourceObjectstorageObjec
 					namespace = "${data.oci_objectstorage_namespace.t.namespace}"
 					bucket = "${oci_objectstorage_bucket.t.name}"
 					object = "-tf-object"
-					content = "test content"
+					content = "123"
 					metadata = {
-						"content-type" = "text/plain"
+						"version" = "1"
 					}
 				}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(s.ResourceName, "namespace"),
 					resource.TestCheckResourceAttr(s.ResourceName, "bucket", "-tf-bucket"),
 					resource.TestCheckResourceAttr(s.ResourceName, "object", "-tf-object"),
-					resource.TestCheckResourceAttr(s.ResourceName, "content", "test content"),
-					resource.TestCheckResourceAttr(s.ResourceName, "metadata.content-type", "text/plain"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "content"),
+					resource.TestCheckResourceAttr(s.ResourceName, "content_type", "application/octet-stream"),
+					resource.TestCheckResourceAttr(s.ResourceName, "content_language", ""),
+					resource.TestCheckResourceAttr(s.ResourceName, "content_encoding", ""),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "content_length"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "content_MD5"),
+					resource.TestCheckResourceAttr(s.ResourceName, "metadata.version", "1"),
+					func(s *terraform.State) (err error) {
+						resId, err = fromInstanceState(s, "oci_objectstorage_object.t", "content")
+						return err
+					},
 				),
 			},
 			// verify update
@@ -74,13 +86,29 @@ func (s *ResourceObjectstorageObjectTestSuite) TestAccResourceObjectstorageObjec
 					bucket = "${oci_objectstorage_bucket.t.name}"
 					object = "-tf-object"
 					content = "{}"
+					content_type = "text/json"
+					content_language = "*"
+					content_encoding = "identity"
 					metadata = {
-						"content-type" = "text/json"
+						"version" = "2"
+						"modified" = "10-18-2017"
 					}
 				}`,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(s.ResourceName, "content", "{}"),
-					resource.TestCheckResourceAttr(s.ResourceName, "metadata.content-type", "text/json"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "content"),
+					resource.TestCheckResourceAttr(s.ResourceName, "content_type", "text/json"),
+					resource.TestCheckResourceAttr(s.ResourceName, "content_language", "*"),
+					resource.TestCheckResourceAttr(s.ResourceName, "content_encoding", "identity"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "content_length"),
+					resource.TestCheckResourceAttr(s.ResourceName, "metadata.version", "2"),
+					resource.TestCheckResourceAttr(s.ResourceName, "metadata.modified", "10-18-2017"),
+					func(s *terraform.State) (err error) {
+						resId2, err = fromInstanceState(s, "oci_objectstorage_object.t", "content")
+						if resId == resId2 {
+							return fmt.Errorf("Expected different content hash, got same.")
+						}
+						return err
+					},
 				),
 			},
 		},

--- a/resource_obmcs_objectstorage_object_test.go
+++ b/resource_obmcs_objectstorage_object_test.go
@@ -70,7 +70,7 @@ func (s *ResourceObjectstorageObjectTestSuite) TestAccResourceObjectstorageObjec
 					resource.TestCheckResourceAttr(s.ResourceName, "content_language", ""),
 					resource.TestCheckResourceAttr(s.ResourceName, "content_encoding", ""),
 					resource.TestCheckResourceAttrSet(s.ResourceName, "content_length"),
-					resource.TestCheckResourceAttrSet(s.ResourceName, "content_MD5"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "content_md5"),
 					resource.TestCheckResourceAttr(s.ResourceName, "metadata.version", "1"),
 					func(s *terraform.State) (err error) {
 						resId, err = fromInstanceState(s, "oci_objectstorage_object.t", "content")

--- a/vendor/github.com/oracle/bmcs-go-sdk/object_storage_objects.go
+++ b/vendor/github.com/oracle/bmcs-go-sdk/object_storage_objects.go
@@ -204,6 +204,15 @@ func (c *Client) PutObject(
 	}
 	required.Body = content
 
+	// application/json gets added by default if content-type is not specified. This is not desirable
+	// for object storage, so override empty content-type with the object storage default
+	if opts == nil {
+		opts = &PutObjectOptions{}
+	}
+	if opts.ContentType == "" {
+		opts.ContentType = "application/octet-stream"
+	}
+
 	details := &requestDetails{
 		ids: urlParts{
 			namespace,

--- a/vendor/github.com/oracle/bmcs-go-sdk/response.go
+++ b/vendor/github.com/oracle/bmcs-go-sdk/response.go
@@ -61,14 +61,18 @@ func (r *response) unmarshal(resource interface{}) (e error) {
 	if cr, ok := resource.(ContentUnmarshallable); ok {
 		cr.SetContentEncoding(r.header.Get(headerContentEncoding))
 		cr.SetContentLanguage(r.header.Get(headerContentLanguage))
-		if length, err := strconv.Atoi(r.header.Get(headerContentLength)); err != nil {
-			e = err
-			return
-		} else {
-			cr.SetContentLength(uint64(length))
-		}
 		cr.SetContentMD5(r.header.Get(headerContentMD5))
 		cr.SetContentType(r.header.Get(headerContentType))
+
+		lengthStr := r.header.Get(headerContentLength)
+		if lengthStr != "" {
+			if length, err := strconv.Atoi(lengthStr); err != nil {
+				e = err
+				return
+			} else {
+				cr.SetContentLength(uint64(length))
+			}
+		}
 	}
 
 	if md, ok := resource.(MetadataUnmarshallable); ok {

--- a/vendor/github.com/oracle/bmcs-go-sdk/response_unmarshallers.go
+++ b/vendor/github.com/oracle/bmcs-go-sdk/response_unmarshallers.go
@@ -110,7 +110,7 @@ type ContentUnmarshallable interface {
 type ContentUnmarshaller struct {
 	ContentLength   uint64
 	ContentRange    string
-	MD5             string
+	ContentMD5      string
 	ContentType     string
 	ContentLanguage string
 	ContentEncoding string
@@ -124,8 +124,8 @@ func (ref *ContentUnmarshaller) SetContentRange(r string) {
 	ref.ContentRange = r
 }
 
-func (ref *ContentUnmarshaller) SetMD5(md5 string) {
-	ref.MD5 = md5
+func (ref *ContentUnmarshaller) SetContentMD5(md5 string) {
+	ref.ContentMD5 = md5
 }
 
 func (ref *ContentUnmarshaller) SetContentType(t string) {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2972,10 +2972,10 @@
 			"revisionTime": "2017-01-25T16:36:56Z"
 		},
 		{
-			"checksumSHA1": "nJDtb0MGvWZ+X7Dr5YJL9OGmxnQ=",
+			"checksumSHA1": "gqijMtR7yMtoJBTQtbLubunv5DI=",
 			"path": "github.com/oracle/bmcs-go-sdk",
-			"revision": "66e8b1975ce5451e364e4e9707065b21491c1d09",
-			"revisionTime": "2017-09-27T23:26:00Z"
+			"revision": "9b861514578760cf496b598ce298b37240998328",
+			"revisionTime": "2017-09-28T23:17:12Z"
 		},
 		{
 			"checksumSHA1": "ImgLNIpeXsGjZGXw4rd+rwzQxpo=",


### PR DESCRIPTION
### Tests
ccushing-mac:terraform-provider-oci ccushing$ make test run=Test.*Objectstorage.*TestSuite
=== RUN   TestDatasourceObjectstorageBucketSummaryTestSuite
=== RUN   TestAccDatasourceObjectstorageBucketSummaries_basic
--- PASS: TestAccDatasourceObjectstorageBucketSummaries_basic (23.43s)
--- PASS: TestDatasourceObjectstorageBucketSummaryTestSuite (23.43s)
=== RUN   TestDatasourceObjectstorageNamespaceTestSuite
=== RUN   TestAccDatasourceObjectstorageNamespace_basic
--- PASS: TestAccDatasourceObjectstorageNamespace_basic (1.41s)
--- PASS: TestDatasourceObjectstorageNamespaceTestSuite (1.42s)
=== RUN   TestDatasourceObjectstorageObjectHeadTestSuite
=== RUN   TestObjectstorageObjectHead_basic
--- PASS: TestObjectstorageObjectHead_basic (23.75s)
--- PASS: TestDatasourceObjectstorageObjectHeadTestSuite (23.75s)
=== RUN   TestDatasourceObjectstorageObjectTestSuite
=== RUN   TestAccDatasourceObjectstorageObjects_basic
--- PASS: TestAccDatasourceObjectstorageObjects_basic (24.85s)
--- PASS: TestDatasourceObjectstorageObjectTestSuite (24.85s)
=== RUN   TestResourceObjectstorageBucketTestSuite
=== RUN   TestAccResourceObjectstorageBucket_basic
--- PASS: TestAccResourceObjectstorageBucket_basic (22.31s)
--- PASS: TestResourceObjectstorageBucketTestSuite (22.32s)
=== RUN   TestResourceObjectstorageObjectTestSuite
=== RUN   TestAccResourceObjectstorageObject_basic
--- PASS: TestAccResourceObjectstorageObject_basic (25.23s)
--- PASS: TestResourceObjectstorageObjectTestSuite (25.23s)
=== RUN   TestResourceObjectstoragePARTestSuite
=== RUN   TestAccResourceObjectstoragePAR_basic
--- PASS: TestAccResourceObjectstoragePAR_basic (23.39s)
--- PASS: TestResourceObjectstoragePARTestSuite (23.40s)
PASS
ok      github.com/oracle/terraform-provider-oci        144.405s
