### PR TITLE
Fix for oci-tool matching

### DIFF
--- a/data_source_obmcs_identity_policies_test.go
+++ b/data_source_obmcs_identity_policies_test.go
@@ -53,8 +53,8 @@ func (s *DatasourceIdentityPolicyTestSuite) TestAccDatasourceIdentityPolicies_ba
 			{
 				ImportState:       true,
 				ImportStateVerify: true,
-				Config: s.Config,
-			},{
+				Config:            s.Config,
+			}, {
 				Config: s.Config + `
 				data "oci_identity_policies" "p" {
 					compartment_id = "${oci_identity_compartment.t.id}"

--- a/resource_obmcs_identity_compartment_test.go
+++ b/resource_obmcs_identity_compartment_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/oracle/bmcs-go-sdk"
 
-	"github.com/stretchr/testify/suite"
 	"fmt"
+	"github.com/stretchr/testify/suite"
 )
 
 type ResourceIdentityCompartmentTestSuite struct {

--- a/tools/oci-tool/transforms.go
+++ b/tools/oci-tool/transforms.go
@@ -15,11 +15,11 @@ var matchBlockHeader = regexp.MustCompile(`(provider|resource|data)(\s+")(bareme
 
 // matches resource interpolation strings, ex:
 //   load_balancer_id = "${baremetal_load_balancer.lb1.id}"
-var matchResourceInterpolation = regexp.MustCompile(`(.*)(\${\s*)(baremetal)(_.*)`)
+var matchResourceInterpolation = regexp.MustCompile(`(.*?)(\${\s*)(baremetal)(_.*?)`)
 
 // matches datasource interpolation strings, ex:
 //   image = "${lookup(data.baremetal_core_images.image-list.images[0], "id")}"
-var matchDatasourceInterpolation = regexp.MustCompile(`(.*data)(\.)(baremetal)(_.*)`)
+var matchDatasourceInterpolation = regexp.MustCompile(`(.*?data)(\.)(baremetal)(_.*?)`)
 
 // replace specific string patterns in template files
 func replaceTemplateTokens(str string) string {


### PR DESCRIPTION
Allows data source and resource matching when multiple matches are on
a single line.