### PR TITLE
Add instance datasource test

### DIFF
--- a/data_source_obmcs_core_instance.go
+++ b/data_source_obmcs_core_instance.go
@@ -25,6 +25,10 @@ func InstanceDatasource() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"display_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"page": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -118,8 +122,11 @@ func (s *InstanceDatasourceCrud) Get() (e error) {
 
 	opts := &baremetal.ListInstancesOptions{}
 	options.SetListOptions(s.D, &opts.ListOptions)
-	if val, ok := s.D.GetOk("availability_domain"); ok {
-		opts.AvailabilityDomain = val.(string)
+	if ad, ok := s.D.GetOk("availability_domain"); ok {
+		opts.AvailabilityDomain = ad.(string)
+	}
+	if dispName, ok := s.D.GetOk("display_name"); ok {
+		opts.DisplayName = dispName.(string)
 	}
 
 	s.Res = &baremetal.ListInstances{Instances: []baremetal.Instance{}}

--- a/data_source_obmcs_core_instance_test.go
+++ b/data_source_obmcs_core_instance_test.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	baremetal "github.com/oracle/bmcs-go-sdk"
+
+	"github.com/stretchr/testify/suite"
+	"fmt"
+	"time"
+)
+
+type DatasourceCoreInstanceTestSuite struct {
+	suite.Suite
+	Client 			*baremetal.Client
+	Config			string
+	Provider		terraform.ResourceProvider
+	Providers 		map[string]terraform.ResourceProvider
+	ResourceName	string
+}
+
+
+var instance_display_name string
+var metadata_ssh_key_entry = "ssh_authorized_keys"
+
+func timestampNameSuffix() string {
+	var t = time.Now()
+	return fmt.Sprintf("%d%02d%02d%02d%02d%02d", t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second())
+}
+
+func (s *DatasourceCoreInstanceTestSuite) SetupTest() {
+	instance_display_name = "instance" + timestampNameSuffix()
+
+	s.Client = testAccClient
+	s.Provider = testAccProvider
+	s.Providers = testAccProviders
+	s.Config = testProviderConfig() + `
+		data "oci_identity_availability_domains" "ADs" {
+		compartment_id = "${var.compartment_id}"
+	}
+
+	resource "oci_core_virtual_network" "vn" {
+		compartment_id = "${var.compartment_id}"
+		cidr_block = "10.0.0.0/16"
+		display_name = "-tf-vcn"
+	}
+
+	resource "oci_core_subnet" "sb" {
+		compartment_id      = "${var.compartment_id}"
+		vcn_id              = "${oci_core_virtual_network.vn.id}"
+		availability_domain = "${lookup(data.oci_identity_availability_domains.ADs.availability_domains[0],"name")}"
+		route_table_id      = "${oci_core_virtual_network.vn.default_route_table_id}"
+		security_list_ids = ["${oci_core_virtual_network.vn.default_security_list_id}"]
+		dhcp_options_id     = "${oci_core_virtual_network.vn.default_dhcp_options_id}"
+		cidr_block          = "10.0.1.0/24"
+		display_name        = "-tf-subnet"
+	}
+
+	data "oci_core_images" "img" {
+		compartment_id = "${var.compartment_id}"
+		operating_system = "Oracle Linux"
+		operating_system_version = "7.3"
+		limit = 1
+	}
+
+	resource "oci_core_instance" "inst" {
+		availability_domain = "${data.oci_identity_availability_domains.ADs.availability_domains.0.name}"
+		compartment_id = "${var.compartment_id}"
+		display_name = "` + instance_display_name + `"
+		subnet_id = "${oci_core_subnet.sb.id}"
+		image = "${data.oci_core_images.img.images.0.id}"
+		shape = "VM.Standard1.1"
+		metadata {` +
+			metadata_ssh_key_entry + `= "${var.ssh_public_key}"
+		}
+		timeouts {
+			create = "15m"
+		}
+	}`
+
+	s.ResourceName = "data.oci_core_instances.inst"
+}
+
+func (s *DatasourceCoreInstanceTestSuite) TestAccDatasourceCoreInstance_basic() {
+
+	resource.Test(s.T(), resource.TestCase {
+		PreventPostDestroyRefresh: 	true,
+		Providers:					s.Providers,
+		Steps:	[]resource.TestStep{
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				Config:            s.Config,
+			},
+			{
+				Config: s.Config + `
+				data "oci_core_instances" "inst" {
+					compartment_id = "${var.compartment_id}"
+					availability_domain = "${data.oci_identity_availability_domains.ADs.availability_domains.0.name}"
+					display_name = "` + instance_display_name + `"
+					limit = 1
+				}`,
+				Check: resource.ComposeTestCheckFunc(
+					// check to make sure that the display_name matches what we set it to first.
+					// Otherwise, the rest of the check could produce a false positive
+					resource.TestCheckResourceAttrSet(s.ResourceName, "instances.0.display_name"),
+					resource.TestCheckResourceAttr(s.ResourceName, "instances.#", "1"),
+					resource.TestCheckResourceAttrSet(s.ResourceName,"instances.0.availability_domain"),
+					resource.TestCheckResourceAttrSet(s.ResourceName,"instances.0.id"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "instances.0.region"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "instances.0.state"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "instances.0.shape"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "instances.0.image"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "instances.0.metadata.%"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "instances.0.metadata." + metadata_ssh_key_entry),
+				),
+			},
+		},
+	},
+	)
+}
+
+func TestDatasourceCoreInstanceTestSuite(t *testing.T) {
+	suite.Run(t, new(DatasourceCoreInstanceTestSuite))
+}

--- a/data_source_obmcs_core_instance_test.go
+++ b/data_source_obmcs_core_instance_test.go
@@ -10,113 +10,100 @@ import (
 	baremetal "github.com/oracle/bmcs-go-sdk"
 
 	"github.com/stretchr/testify/suite"
-	"fmt"
-	"time"
 )
 
 type DatasourceCoreInstanceTestSuite struct {
 	suite.Suite
-	Client 			*baremetal.Client
-	Config			string
-	Provider		terraform.ResourceProvider
-	Providers 		map[string]terraform.ResourceProvider
-	ResourceName	string
-}
-
-
-var instance_display_name string
-var metadata_ssh_key_entry = "ssh_authorized_keys"
-
-func timestampNameSuffix() string {
-	var t = time.Now()
-	return fmt.Sprintf("%d%02d%02d%02d%02d%02d", t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second())
+	Client       *baremetal.Client
+	Config       string
+	Provider     terraform.ResourceProvider
+	Providers    map[string]terraform.ResourceProvider
+	ResourceName string
+	Token        string
+	TokenFn      func(string, map[string]string) string
 }
 
 func (s *DatasourceCoreInstanceTestSuite) SetupTest() {
-	instance_display_name = "instance" + timestampNameSuffix()
-
+	s.Token, s.TokenFn = tokenize()
 	s.Client = testAccClient
 	s.Provider = testAccProvider
 	s.Providers = testAccProviders
-	s.Config = testProviderConfig() + `
-		data "oci_identity_availability_domains" "ADs" {
+	s.Config = testProviderConfig() + s.TokenFn(`
+	data "oci_identity_availability_domains" "ADs" {
 		compartment_id = "${var.compartment_id}"
 	}
 
-	resource "oci_core_virtual_network" "vn" {
+	resource "oci_core_virtual_network" "t" {
 		compartment_id = "${var.compartment_id}"
-		cidr_block = "10.0.0.0/16"
 		display_name = "-tf-vcn"
+		cidr_block = "10.0.0.0/16"
 	}
 
-	resource "oci_core_subnet" "sb" {
-		compartment_id      = "${var.compartment_id}"
-		vcn_id              = "${oci_core_virtual_network.vn.id}"
+	resource "oci_core_subnet" "t" {
 		availability_domain = "${lookup(data.oci_identity_availability_domains.ADs.availability_domains[0],"name")}"
-		route_table_id      = "${oci_core_virtual_network.vn.default_route_table_id}"
-		security_list_ids = ["${oci_core_virtual_network.vn.default_security_list_id}"]
-		dhcp_options_id     = "${oci_core_virtual_network.vn.default_dhcp_options_id}"
-		cidr_block          = "10.0.1.0/24"
+		compartment_id      = "${var.compartment_id}"
+		vcn_id              = "${oci_core_virtual_network.t.id}"
 		display_name        = "-tf-subnet"
+		cidr_block          = "10.0.1.0/24"
+		dhcp_options_id     = "${oci_core_virtual_network.t.default_dhcp_options_id}"
+		route_table_id      = "${oci_core_virtual_network.t.default_route_table_id}"
+		security_list_ids = ["${oci_core_virtual_network.t.default_security_list_id}"]
 	}
 
-	data "oci_core_images" "img" {
+	data "oci_core_images" "t" {
 		compartment_id = "${var.compartment_id}"
 		operating_system = "Oracle Linux"
 		operating_system_version = "7.3"
 		limit = 1
 	}
 
-	resource "oci_core_instance" "inst" {
+	resource "oci_core_instance" "t" {
 		availability_domain = "${data.oci_identity_availability_domains.ADs.availability_domains.0.name}"
 		compartment_id = "${var.compartment_id}"
-		display_name = "` + instance_display_name + `"
-		subnet_id = "${oci_core_subnet.sb.id}"
-		image = "${data.oci_core_images.img.images.0.id}"
+		display_name = "{{.token}}"
+		subnet_id = "${oci_core_subnet.t.id}"
+		image = "${data.oci_core_images.t.images.0.id}"
 		shape = "VM.Standard1.1"
-		metadata {` +
-			metadata_ssh_key_entry + `= "${var.ssh_public_key}"
+		metadata {
+			ssh_authorized_keys = "${var.ssh_public_key}"
 		}
 		timeouts {
 			create = "15m"
 		}
-	}`
+	}`, nil)
 
-	s.ResourceName = "data.oci_core_instances.inst"
+	s.ResourceName = "data.oci_core_instances.t"
 }
 
 func (s *DatasourceCoreInstanceTestSuite) TestAccDatasourceCoreInstance_basic() {
 
-	resource.Test(s.T(), resource.TestCase {
-		PreventPostDestroyRefresh: 	true,
-		Providers:					s.Providers,
-		Steps:	[]resource.TestStep{
+	resource.Test(s.T(), resource.TestCase{
+		PreventPostDestroyRefresh: true,
+		Providers:                 s.Providers,
+		Steps: []resource.TestStep{
 			{
 				ImportState:       true,
 				ImportStateVerify: true,
 				Config:            s.Config,
 			},
 			{
-				Config: s.Config + `
-				data "oci_core_instances" "inst" {
+				Config: s.Config + s.TokenFn(`
+				data "oci_core_instances" "t" {
 					compartment_id = "${var.compartment_id}"
 					availability_domain = "${data.oci_identity_availability_domains.ADs.availability_domains.0.name}"
-					display_name = "` + instance_display_name + `"
+					display_name = "{{.token}}"
 					limit = 1
-				}`,
+				}`, nil),
 				Check: resource.ComposeTestCheckFunc(
-					// check to make sure that the display_name matches what we set it to first.
-					// Otherwise, the rest of the check could produce a false positive
-					resource.TestCheckResourceAttrSet(s.ResourceName, "instances.0.display_name"),
 					resource.TestCheckResourceAttr(s.ResourceName, "instances.#", "1"),
-					resource.TestCheckResourceAttrSet(s.ResourceName,"instances.0.availability_domain"),
-					resource.TestCheckResourceAttrSet(s.ResourceName,"instances.0.id"),
+					resource.TestCheckResourceAttr(s.ResourceName, "instances.0.display_name", s.Token),
+					resource.TestCheckResourceAttr(s.ResourceName, "instances.0.state", "RUNNING"),
+					resource.TestCheckResourceAttr(s.ResourceName, "instances.0.shape", "VM.Standard1.1"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "instances.0.availability_domain"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "instances.0.id"),
 					resource.TestCheckResourceAttrSet(s.ResourceName, "instances.0.region"),
-					resource.TestCheckResourceAttrSet(s.ResourceName, "instances.0.state"),
-					resource.TestCheckResourceAttrSet(s.ResourceName, "instances.0.shape"),
 					resource.TestCheckResourceAttrSet(s.ResourceName, "instances.0.image"),
 					resource.TestCheckResourceAttrSet(s.ResourceName, "instances.0.metadata.%"),
-					resource.TestCheckResourceAttrSet(s.ResourceName, "instances.0.metadata." + metadata_ssh_key_entry),
 				),
 			},
 		},


### PR DESCRIPTION
Adding test for data_source_obmcs_core_instance.

**TESTS**

TF_ACC=1 TF_ORACLE_ENV=test go test -v -timeout 120m -run TestDatasourceCore
2017/10/04 14:09:28 [WARN] USING INSECURE TLS
2017/10/04 14:09:28 User Agent: Oracle-GoSDK/20160918 (go/go1.9; darwin/amd64; terraform/0.9.4-dev) Oracle-TerraformProvider/0.0.0
2017/10/04 14:09:28 User Agent: Oracle-GoSDK/20160918 (go/go1.9; darwin/amd64; terraform/0.9.4-dev) Oracle-TerraformProvider/0.0.0
=== RUN   TestDatasourceCoreConsoleHistoryTestSuite
=== RUN   TestAccDatasourceCoreConsoleHistory_basic
--- PASS: TestAccDatasourceCoreConsoleHistory_basic (215.52s)
--- PASS: TestDatasourceCoreConsoleHistoryTestSuite (215.52s)
=== RUN   TestDatasourceCoreCpeTestSuite
=== RUN   TestAccDatasourceCoreCpe_basic
--- PASS: TestAccDatasourceCoreCpe_basic (3.01s)
--- PASS: TestDatasourceCoreCpeTestSuite (3.01s)
=== RUN   TestDatasourceCoreDHCPOptionsTestSuite
=== RUN   TestAccDatasourceCoreDHCPOptions_basic
--- PASS: TestAccDatasourceCoreDHCPOptions_basic (11.17s)
--- PASS: TestDatasourceCoreDHCPOptionsTestSuite (11.17s)
=== RUN   TestDatasourceCoreDrgAttachmentTestSuite
=== RUN   TestAccDatasourceCoreDrgAttachment_basic
--- PASS: TestAccDatasourceCoreDrgAttachment_basic (148.66s)
--- PASS: TestDatasourceCoreDrgAttachmentTestSuite (148.66s)
=== RUN   TestDatasourceCoreDrgsTestSuite
=== RUN   TestAccDatasourceCoreDrg_basic
--- PASS: TestAccDatasourceCoreDrg_basic (142.45s)
--- PASS: TestDatasourceCoreDrgsTestSuite (142.45s)
=== RUN   TestDatasourceCoreImageTestSuite
=== RUN   TestAccImage_basic
--- PASS: TestAccImage_basic (11.67s)
--- PASS: TestDatasourceCoreImageTestSuite (11.67s)
=== RUN   TestDatasourceCoreInstanceCredentialTestSuite
=== RUN   TestAccDatasourceCoreInstanceCredentials_basic
--- PASS: TestAccDatasourceCoreInstanceCredentials_basic (622.59s)
--- PASS: TestDatasourceCoreInstanceCredentialTestSuite (622.60s)
=== RUN   TestDatasourceCoreInstanceTestSuite
=== RUN   TestAccDatasourceCoreInstance_basic
--- PASS: TestAccDatasourceCoreInstance_basic (201.32s)
--- PASS: TestDatasourceCoreInstanceTestSuite (201.32s)
=== RUN   TestDatasourceCoreInternetGatewayTestSuite
=== RUN   TestAccDatasourceCoreInternetGateway_basic
--- PASS: TestAccDatasourceCoreInternetGateway_basic (12.04s)
--- PASS: TestDatasourceCoreInternetGatewayTestSuite (12.05s)
=== RUN   TestDatasourceCoreIPSecConnectionConfigTestSuite
=== RUN   TestAccDatasourceCoreIPSecConnectionConfig_basic
--- PASS: TestAccDatasourceCoreIPSecConnectionConfig_basic (270.83s)
--- PASS: TestDatasourceCoreIPSecConnectionConfigTestSuite (270.84s)
=== RUN   TestDatasourceCoreIPSecConnectionsTestSuite
=== RUN   TestAccDatasourceCoreIPConnections_basic
--- PASS: TestAccDatasourceCoreIPConnections_basic (394.22s)
--- PASS: TestDatasourceCoreIPSecConnectionsTestSuite (394.22s)
=== RUN   TestDatasourceCoreIPSecStatusTestSuite
=== RUN   TestAccDatasourceCoreIPSecStatus_basic
--- PASS: TestAccDatasourceCoreIPSecStatus_basic (353.62s)
--- PASS: TestDatasourceCoreIPSecStatusTestSuite (353.63s)
=== RUN   TestDatasourceCoreRouteTableTestSuite
=== RUN   TestAccDatasourceRouteTable_basic
--- PASS: TestAccDatasourceRouteTable_basic (44.04s)
--- PASS: TestDatasourceCoreRouteTableTestSuite (44.04s)
=== RUN   TestDatasourceCoreSecurityListTestSuite
=== RUN   TestAccDatasourceCoreSecurityLists_basic
--- PASS: TestAccDatasourceCoreSecurityLists_basic (9.90s)
--- PASS: TestDatasourceCoreSecurityListTestSuite (9.91s)
=== RUN   TestDatasourceCoreShapeTestSuite
=== RUN   TestAccDatasourceCoreShape_basic
--- PASS: TestAccDatasourceCoreShape_basic (3.61s)
--- PASS: TestDatasourceCoreShapeTestSuite (3.62s)
=== RUN   TestDatasourceCoreSubnetTestSuite
=== RUN   TestAccDatasourceCoreSubnet_basic
--- PASS: TestAccDatasourceCoreSubnet_basic (64.85s)
--- PASS: TestDatasourceCoreSubnetTestSuite (64.85s)
=== RUN   TestDatasourceCoreVirtualNetworkTestSuite
=== RUN   TestAccDatasourceCoreVirtualNetwork_basic
--- PASS: TestAccDatasourceCoreVirtualNetwork_basic (7.15s)
--- PASS: TestDatasourceCoreVirtualNetworkTestSuite (7.16s)
=== RUN   TestDatasourceCoreVnicAttachmentTestSuite
=== RUN   TestAccDatasourceCoreVnicAttachment_basic
--- PASS: TestAccDatasourceCoreVnicAttachment_basic (192.93s)
--- PASS: TestDatasourceCoreVnicAttachmentTestSuite (192.93s)
=== RUN   TestDatasourceCoreVolumeAttachmentTestSuite
=== RUN   TestAccDatasourceCoreVolumeAttachment_basic
--- PASS: TestAccDatasourceCoreVolumeAttachment_basic (237.04s)
--- PASS: TestDatasourceCoreVolumeAttachmentTestSuite (237.04s)
=== RUN   TestDatasourceCoreVolumeBackupTestSuite
=== RUN   TestAccDatasourceCoreVolumeBackup_basic
--- PASS: TestAccDatasourceCoreVolumeBackup_basic (45.05s)
--- PASS: TestDatasourceCoreVolumeBackupTestSuite (45.05s)
=== RUN   TestDatasourceCoreVolumeTestSuite
=== RUN   TestAccDatasourceCoreVolume_basic
--- PASS: TestAccDatasourceCoreVolume_basic (13.00s)
--- PASS: TestDatasourceCoreVolumeTestSuite (13.01s)
PASS
ok  	github.com/oracle/terraform-provider-oci	3004.771s