### PR TITLE
Fix string type in oci-tool

### DIFF
--- a/tools/oci-tool/transforms_test.go
+++ b/tools/oci-tool/transforms_test.go
@@ -517,7 +517,7 @@ resource "oci_core_instance" "ExampleInstance" {
 	actual := replaceTemplateTokens(original)
 
 	if expected != actual {
-		t.Errorf("expected %d, got %d ", expected, actual)
+		t.Errorf("expected %s, got %s ", expected, actual)
 	}
 }
 
@@ -541,6 +541,6 @@ resource "oci_identity_policy" "p" {
 	actual := replaceTemplateTokens(original)
 
 	if expected != actual {
-		t.Errorf("expected %d, got %d ", expected, actual)
+		t.Errorf("expected %s, got %s ", expected, actual)
 	}
 }


### PR DESCRIPTION
This is the cause of the wercker failure.