### PR TITLE
Block volume supports size in gigabytes

### DIFF
--- a/data_source_obmcs_core_volume.go
+++ b/data_source_obmcs_core_volume.go
@@ -95,6 +95,7 @@ func (s *VolumeDatasourceCrud) SetData() {
 				"display_name":        v.DisplayName,
 				"id":                  v.ID,
 				"size_in_mbs":         v.SizeInMBs,
+				"size_in_gbs":         v.SizeInGBs,
 				"state":               v.State,
 				"time_created":        v.TimeCreated.String(),
 			}

--- a/data_source_obmcs_core_volume_attachment_test.go
+++ b/data_source_obmcs_core_volume_attachment_test.go
@@ -29,8 +29,7 @@ func (s *DatasourceCoreVolumeAttachmentTestSuite) SetupTest() {
 	resource "oci_core_volume" "t" {
 		availability_domain = "${data.oci_identity_availability_domains.ADs.availability_domains.0.name}"
 		compartment_id = "${var.compartment_id}"
-		display_name = "display_name"
-		size_in_mbs = 51200
+		display_name = "-tf-volume"
 	}
 	resource "oci_core_volume_attachment" "t" {
 		attachment_type = "iscsi"

--- a/data_source_obmcs_core_volume_backup.go
+++ b/data_source_obmcs_core_volume_backup.go
@@ -95,6 +95,7 @@ func (s *VolumeBackupDatasourceCrud) SetData() {
 				"id":                    v.ID,
 				"state":                 v.State,
 				"size_in_mbs":           v.SizeInMBs,
+				"size_in_gbs":           v.SizeInGBs,
 				"time_created":          v.TimeCreated.String(),
 				"time_request_received": v.TimeRequestReceived.String(),
 				"unique_size_in_mbs":    v.UniqueSizeInMBs,

--- a/data_source_obmcs_core_volume_backup_test.go
+++ b/data_source_obmcs_core_volume_backup_test.go
@@ -60,7 +60,6 @@ func (s *DatasourceCoreVolumeBackupTestSuite) TestAccDatasourceCoreVolumeBackup_
 				}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(s.ResourceName, "volume_id"),
-					resource.TestCheckResourceAttrSet(s.ResourceName, "volume_backups.0.id"),
 					resource.TestCheckResourceAttr(s.ResourceName, "volume_backups.#", "1"),
 					resource.TestCheckResourceAttrSet(s.ResourceName, "volume_backups.0.id"),
 					resource.TestCheckResourceAttrSet(s.ResourceName, "volume_backups.0.volume_id"),

--- a/data_source_obmcs_core_volume_backup_test.go
+++ b/data_source_obmcs_core_volume_backup_test.go
@@ -33,12 +33,10 @@ func (s *DatasourceCoreVolumeBackupTestSuite) SetupTest() {
 	resource "oci_core_volume" "t" {
 		availability_domain = "${data.oci_identity_availability_domains.ADs.availability_domains.0.name}"
 		compartment_id = "${var.compartment_id}"
-		display_name = "display_name"
-		size_in_mbs = 51200
 	}
 	resource "oci_core_volume_backup" "t" {
 		volume_id = "${oci_core_volume.t.id}"
-		display_name = "display_name"
+		display_name = "-tf-volume-backup"
 	}`
 	s.ResourceName = "data.oci_core_volume_backups.t"
 }
@@ -64,6 +62,15 @@ func (s *DatasourceCoreVolumeBackupTestSuite) TestAccDatasourceCoreVolumeBackup_
 					resource.TestCheckResourceAttrSet(s.ResourceName, "volume_id"),
 					resource.TestCheckResourceAttrSet(s.ResourceName, "volume_backups.0.id"),
 					resource.TestCheckResourceAttr(s.ResourceName, "volume_backups.#", "1"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "volume_backups.0.id"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "volume_backups.0.volume_id"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "volume_backups.0.time_created"),
+					resource.TestCheckResourceAttr(s.ResourceName, "volume_backups.0.display_name", "-tf-volume-backup"),
+					resource.TestCheckResourceAttr(s.ResourceName, "volume_backups.0.state", baremetal.ResourceAvailable),
+					resource.TestCheckResourceAttr(s.ResourceName, "volume_backups.0.size_in_mbs", "51200"),
+					resource.TestCheckResourceAttr(s.ResourceName, "volume_backups.0.size_in_gbs", "50"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "volume_backups.0.unique_size_in_mbs"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "volume_backups.0.unique_size_in_gbs"),
 				),
 			},
 		},

--- a/data_source_obmcs_core_volume_test.go
+++ b/data_source_obmcs_core_volume_test.go
@@ -32,8 +32,8 @@ func (s *DatasourceCoreVolumeTestSuite) SetupTest() {
 	resource "oci_core_volume" "t" {
 		availability_domain = "${data.oci_identity_availability_domains.ADs.availability_domains.0.name}"
 		compartment_id = "${var.compartment_id}"
-		display_name = "display_name"
-		size_in_mbs = 262144
+		display_name = "-tf-volume"
+		size_in_gbs = 50
 	}
 	data "oci_core_volumes" "t" {
 		availability_domain = "${data.oci_identity_availability_domains.ADs.availability_domains.0.name}"

--- a/docs/datasources/core/volume_backups.md
+++ b/docs/datasources/core/volume_backups.md
@@ -36,6 +36,5 @@ The following attributes are exported:
 * `time_created` - The date and time the Volume was created.
 * `time_requested` - The date and time the request to create the volume backup was received.
 * `unique_size_in_mbs` - (Deprecated) The size used by the backup, in MBs. It is typically smaller than sizeInMBs, depending on the space consumed on the volume and whether the backup is full or incremental.
-* `unique_size_in_mbs` - The size used by the backup, in GBs. It is typically smaller than sizeInGBs, depending on the space consumed on the volume and whether the backup is full or incremental.
+* `unique_size_in_gbs` - The size used by the backup, in GBs. It is typically smaller than sizeInGBs, depending on the space consumed on the volume and whether the backup is full or incremental.
 * `volume_id` - The OCID of the Volume.
-

--- a/docs/datasources/core/volume_backups.md
+++ b/docs/datasources/core/volume_backups.md
@@ -31,9 +31,11 @@ The following attributes are exported:
 * `display_name` - A user-friendly name. Does not have to be unique.
 * `id` - The OCID of the Volume backup.
 * `state` - The current state of the volume. [CREATING,AVAILABLE,TERMINATING,TERMINATED,FAULTY,REQUEST_RECEIVED]
-* `size_in_mbs` - The size of the volume, in MBs.
+* `size_in_mbs` - (Deprecated) The size of the volume, in MBs.
+* `size_in_gbs` - The size of the volume, in GBs.
 * `time_created` - The date and time the Volume was created.
 * `time_requested` - The date and time the request to create the volume backup was received.
-* `unique_size_in_mbs` - The size used by the backup, in MBs. It is typically smaller than sizeInMBs, depending on the space consumed on the volume and whether the backup is full or incremental.
+* `unique_size_in_mbs` - (Deprecated) The size used by the backup, in MBs. It is typically smaller than sizeInMBs, depending on the space consumed on the volume and whether the backup is full or incremental.
+* `unique_size_in_mbs` - The size used by the backup, in GBs. It is typically smaller than sizeInGBs, depending on the space consumed on the volume and whether the backup is full or incremental.
 * `volume_id` - The OCID of the Volume.
 

--- a/docs/datasources/core/volumes.md
+++ b/docs/datasources/core/volumes.md
@@ -32,5 +32,6 @@ The following attributes are exported:
 * `display_name` - A user-friendly name. Does not have to be unique.
 * `id` - The OCID of the Volume.
 * `state` - The current state of the volume. [PROVISIONING,RESTORING,AVAILABLE,TERMINATING,TERMINATED,FAULTY]
-* `size_in_mbs` - The size of the volume, in MBs.
+* `size_in_mbs` - (Deprecated) The size of the volume, in MBs.
+* `size_in_gbs` - The size of the volume, in GBs.
 * `time_created` - The date and time the Volume was created.

--- a/docs/examples/compute/instance/block.tf
+++ b/docs/examples/compute/instance/block.tf
@@ -2,7 +2,7 @@ resource "oci_core_volume" "TFBlock0" {
   availability_domain = "${lookup(data.oci_identity_availability_domains.ADs.availability_domains[var.AD - 1],"name")}"
   compartment_id = "${var.compartment_ocid}"
   display_name = "TFBlock0"
-  size_in_mbs = "${var.256GB}"
+  size_in_gbs = "${var.DBSize}"
 }
 
 resource "oci_core_volume_attachment" "TFBlock0Attach" {

--- a/docs/examples/compute/instance/variables.tf
+++ b/docs/examples/compute/instance/variables.tf
@@ -27,12 +27,8 @@ variable "InstanceOSVersion" {
     default = "7.3"
 }
 
-variable "2TB" {
-    default = "2097152"
-}
-
-variable "256GB" {
-    default = "262144"
+variable "DBSize" {
+    default = "50" // size in GBs
 }
 
 variable "BootStrapFile" {

--- a/docs/examples/storage/block/README.md
+++ b/docs/examples/storage/block/README.md
@@ -1,8 +1,0 @@
-    #     ___  ____     _    ____ _     _____
-    #    / _ \|  _ \   / \  / ___| |   | ____|
-    #   | | | | |_) | / _ \| |   | |   |  _|
-    #   | |_| |  _ < / ___ | |___| |___| |___
-    #    \___/|_| \_/_/   \_\____|_____|_____|
-***
-## Remote block volumes
-There is a block volume example included in [./docs/examples/compute/instance/.](https://github.com/oracle/terraform-provider-oci/tree/master/docs/examples/compute/instance)

--- a/docs/examples/storage/block/block.tf
+++ b/docs/examples/storage/block/block.tf
@@ -1,0 +1,33 @@
+/*
+ * This example demonstrates how to spin up a block volume
+ *
+ * See docs/examples/compute/instance/ for a real world scenario
+ */
+variable "tenancy_ocid" {}
+variable "user_ocid" {}
+variable "fingerprint" {}
+variable "private_key_path" {}
+variable "region" {}
+
+provider "oci" {
+  tenancy_ocid = "${var.tenancy_ocid}"
+  user_ocid = "${var.user_ocid}"
+  fingerprint = "${var.fingerprint}"
+  private_key_path = "${var.private_key_path}"
+  region = "${var.region}"
+}
+
+variable "DBSize" {
+  default = "50" // size in GBs, min: 50, max 16384
+}
+
+data "oci_identity_availability_domains" "ADs" {
+  compartment_id = "${var.tenancy_ocid}"
+}
+
+resource "oci_core_volume" "t" {
+  availability_domain = "${data.oci_identity_availability_domains.ADs.availability_domains.0.name}"
+  compartment_id = "${var.tenancy_ocid}"
+  display_name = "-tf-volume"
+  size_in_gbs = "${var.DBSize}"
+}

--- a/docs/resources/core/volume.md
+++ b/docs/resources/core/volume.md
@@ -8,7 +8,7 @@ Gets a list of volumes in a compartment.
 resource "oci_core_volume" "t" {
     availability_domain = "availability_domain"
     compartment_id = "compartment_id"
-    size_in_mbs = 262144
+    size_in_gbs = 50
     volume_backup_id = "volume_id"
 }
 ```
@@ -17,8 +17,8 @@ resource "oci_core_volume" "t" {
 
 The following arguments are supported:
 
-* `compartment_id` - (Required) The OCID of the compartment.
 * `availability_domain` - (Required) The Availability Domain of the volume.
+* `compartment_id` - (Required) The OCID of the compartment.
 * `display_name` - (Optional) A user-friendly name. Does not have to be unique, and it's changeable.
 * `volume_backup_id` - (Optional) The OCID of the volume backup from which the data should be restored on the newly created volume.
 
@@ -28,5 +28,6 @@ The following arguments are supported:
 * `display_name` - A user-friendly name. Does not have to be unique.
 * `id` - The OCID of the Volume backup.
 * `state` - The current state of the volume. [PROVISIONING,RESTORING,AVAILABLE,TERMINATING,TERMINATED,FAULTY]
-* `size_in_mbs` - The size of the volume, in MBs.
+* `size_in_mbs` - (Deprecated) The size of the volume, in MBs.
+* `size_in_gbs` - The size of the volume, in GBs.
 * `time_created` - The date and time the Volume was created.

--- a/docs/resources/core/volume_backup.md
+++ b/docs/resources/core/volume_backup.md
@@ -29,6 +29,5 @@ The following arguments are supported:
 * `time_created` - The date and time the Volume was created.
 * `time_requested` - The date and time the request to create the volume backup was received.
 * `unique_size_in_mbs` - (Deprecated) The size used by the backup, in MBs. It is typically smaller than sizeInMBs, depending on the space consumed on the volume and whether the backup is full or incremental.
-* `unique_size_in_mbs` - The size used by the backup, in GBs. It is typically smaller than sizeInGBs, depending on the space consumed on the volume and whether the backup is full or incremental.
+* `unique_size_in_gbs` - The size used by the backup, in GBs. It is typically smaller than sizeInGBs, depending on the space consumed on the volume and whether the backup is full or incremental.
 * `volume_id` - The OCID of the Volume.
-

--- a/docs/resources/core/volume_backup.md
+++ b/docs/resources/core/volume_backup.md
@@ -24,9 +24,11 @@ The following arguments are supported:
 * `display_name` - A user-friendly name. Does not have to be unique.
 * `id` - The OCID of the Volume backup.
 * `state` - The current state of the volume. [CREATING,AVAILABLE,TERMINATING,TERMINATED,FAULTY,REQUEST_RECEIVED]
-* `size_in_mbs` - The size of the volume, in MBs.
+* `size_in_mbs` - (Deprecated) The size of the volume, in MBs.
+* `size_in_gbs` - The size of the volume, in GBs.
 * `time_created` - The date and time the Volume was created.
 * `time_requested` - The date and time the request to create the volume backup was received.
-* `unique_size_in_mbs` - The size used by the backup, in MBs. It is typically smaller than sizeInMBs, depending on the space consumed on the volume and whether the backup is full or incremental.
+* `unique_size_in_mbs` - (Deprecated) The size used by the backup, in MBs. It is typically smaller than sizeInMBs, depending on the space consumed on the volume and whether the backup is full or incremental.
+* `unique_size_in_mbs` - The size used by the backup, in GBs. It is typically smaller than sizeInGBs, depending on the space consumed on the volume and whether the backup is full or incremental.
 * `volume_id` - The OCID of the Volume.
 

--- a/resource_obmcs_core_volume.go
+++ b/resource_obmcs_core_volume.go
@@ -3,6 +3,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/oracle/bmcs-go-sdk"
 
@@ -31,6 +33,13 @@ func VolumeResource() *schema.Resource {
 				ForceNew: true,
 			},
 			"size_in_mbs": {
+				Type:       schema.TypeInt,
+				Optional:   true,
+				ForceNew:   true,
+				Computed:   true,
+				Deprecated: "This property is deprecated, please use size_in_gbs",
+			},
+			"size_in_gbs": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				ForceNew: true,
@@ -136,6 +145,15 @@ func (s *VolumeResourceCrud) Create() (e error) {
 	if ok {
 		opts.SizeInMBs = sizeInMBs.(int)
 	}
+	sizeInGBs, ok := s.D.GetOk("size_in_gbs")
+	if ok {
+		opts.SizeInGBs = sizeInGBs.(int)
+	}
+
+	if opts.SizeInMBs > 0 && opts.SizeInGBs > 0 {
+		return fmt.Errorf("Both size in Megabytes and Gigabytes cannot be set. Specify one or the other, or leave both undefined to use the default size.")
+	}
+
 	volumeBackupID, ok := s.D.GetOk("volume_backup_id")
 	if ok {
 		opts.VolumeBackupID = volumeBackupID.(string)
@@ -171,6 +189,7 @@ func (s *VolumeResourceCrud) SetData() {
 	s.D.Set("compartment_id", s.Res.CompartmentID)
 	s.D.Set("display_name", s.Res.DisplayName)
 	s.D.Set("size_in_mbs", s.Res.SizeInMBs)
+	s.D.Set("size_in_gbs", s.Res.SizeInGBs)
 	s.D.Set("state", s.Res.State)
 	s.D.Set("time_created", s.Res.TimeCreated.String())
 }

--- a/resource_obmcs_core_volume_attachment_test.go
+++ b/resource_obmcs_core_volume_attachment_test.go
@@ -75,7 +75,6 @@ func (s *ResourceCoreVolumeAttachmentTestSuite) SetupTest() {
 		availability_domain = "${data.oci_identity_availability_domains.ADs.availability_domains.0.name}"
 		compartment_id = "${var.compartment_id}"
 		display_name = "display_name"
-		size_in_mbs = 262144
 	}`
 	s.ResourceName = "oci_core_volume_attachment.t"
 }

--- a/resource_obmcs_core_volume_backup.go
+++ b/resource_obmcs_core_volume_backup.go
@@ -38,6 +38,11 @@ func VolumeBackupResource() *schema.Resource {
 				Computed: true,
 			},
 			"size_in_mbs": {
+				Type:       schema.TypeInt,
+				Computed:   true,
+				Deprecated: "This property is deprecated, please use size_in_gbs",
+			},
+			"size_in_gbs": {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
@@ -50,6 +55,11 @@ func VolumeBackupResource() *schema.Resource {
 				Computed: true,
 			},
 			"unique_size_in_mbs": {
+				Type:       schema.TypeInt,
+				Computed:   true,
+				Deprecated: "This property is deprecated, please use unique_size_in_gbs",
+			},
+			"unique_size_in_gbs": {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
@@ -163,11 +173,13 @@ func (s *VolumeBackupResourceCrud) SetData() {
 	s.D.Set("display_name", s.Res.DisplayName)
 	s.D.Set("state", s.Res.State)
 	s.D.Set("size_in_mbs", s.Res.SizeInMBs)
+	s.D.Set("size_in_gbs", s.Res.SizeInGBs)
 	if !s.Res.TimeCreated.IsZero() {
 		s.D.Set("time_created", s.Res.TimeCreated.String())
 	}
 	s.D.Set("time_request_received", s.Res.TimeCreated.String())
-	s.D.Set("unique_size_in_mbs", s.Res.SizeInMBs)
+	s.D.Set("unique_size_in_mbs", s.Res.UniqueSizeInMBs)
+	s.D.Set("unique_size_in_gbs", s.Res.UniqueSizeInGBs)
 	s.D.Set("volume_id", s.Res.VolumeID)
 }
 

--- a/resource_obmcs_core_volume_backup_test.go
+++ b/resource_obmcs_core_volume_backup_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/oracle/bmcs-go-sdk"
-
 	"github.com/stretchr/testify/suite"
 )
 
@@ -35,14 +34,14 @@ func (s *ResourceCoreVolumeBackupTestSuite) SetupTest() {
 			availability_domain = "${data.oci_identity_availability_domains.ADs.availability_domains.0.name}"
 			compartment_id = "${var.compartment_id}"
 			display_name = "-tf-volume"
-			size_in_mbs = 51200
+			size_in_gbs = 50
 		}`
 	s.ResourceName = "oci_core_volume_backup.t"
 }
 
-func (s *ResourceCoreVolumeBackupTestSuite) TestCreateVolumeBackup() {
+func (s *ResourceCoreVolumeBackupTestSuite) TestAccResourceCoreVolumeBackup_basic() {
 
-	resource.UnitTest(s.T(), resource.TestCase{
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			// verify create
@@ -59,6 +58,10 @@ func (s *ResourceCoreVolumeBackupTestSuite) TestCreateVolumeBackup() {
 					resource.TestCheckResourceAttrSet(s.ResourceName, "display_name"),
 					resource.TestCheckResourceAttrSet(s.ResourceName, "time_created"),
 					resource.TestCheckResourceAttr(s.ResourceName, "state", baremetal.ResourceAvailable),
+					resource.TestCheckResourceAttr(s.ResourceName, "size_in_mbs", "51200"),
+					resource.TestCheckResourceAttr(s.ResourceName, "size_in_gbs", "50"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "unique_size_in_mbs"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "unique_size_in_gbs"),
 				),
 			},
 			// verify update
@@ -83,7 +86,7 @@ func (s *ResourceCoreVolumeBackupTestSuite) TestCreateVolumeBackup() {
 						availability_domain = "${data.oci_identity_availability_domains.ADs.availability_domains.0.name}"
 						compartment_id = "${var.compartment_id}"
 						display_name = "-tf-volume-restored"
-						size_in_mbs = 51200
+						size_in_gbs = 50
 						volume_backup_id = "${oci_core_volume_backup.t.id}"
 					}`,
 				Check: resource.ComposeTestCheckFunc(

--- a/resource_obmcs_core_volume_test.go
+++ b/resource_obmcs_core_volume_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 
@@ -28,27 +29,37 @@ func (s *ResourceCoreVolumeTestSuite) SetupTest() {
 	s.Provider = testAccProvider
 	s.Providers = testAccProviders
 	s.Config = testProviderConfig() + `
-		data "oci_identity_availability_domains" "ADs" {
-			compartment_id = "${var.compartment_id}"
-		}`
+	data "oci_identity_availability_domains" "ADs" {
+		compartment_id = "${var.compartment_id}"
+	}`
 
 	s.ResourceName = "oci_core_volume.t"
 }
 
-func (s *ResourceCoreVolumeTestSuite) TestCreateResourceCoreVolume() {
-
-	resource.UnitTest(s.T(), resource.TestCase{
+func (s *ResourceCoreVolumeTestSuite) TestCreateResourceCoreVolume_basic() {
+	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
-			// create volume
+			// specify size in MBs and GBs, expect error
+			{
+				Config: s.Config + `
+				resource "oci_core_volume" "t" {
+					availability_domain = "${data.oci_identity_availability_domains.ADs.availability_domains.0.name}"
+					compartment_id = "${var.compartment_id}"
+					size_in_mbs = 51200	
+					size_in_gbs = 50
+				}`,
+				ExpectError: regexp.MustCompile("Megabytes and Gigabytes"),
+			},
+			// create volume, use default size
 			{
 				ImportState:       true,
 				ImportStateVerify: true,
 				Config: s.Config + `
-					resource "oci_core_volume" "t" {
-						availability_domain = "${data.oci_identity_availability_domains.ADs.availability_domains.0.name}"
-						compartment_id = "${var.compartment_id}"
-					}`,
+				resource "oci_core_volume" "t" {
+					availability_domain = "${data.oci_identity_availability_domains.ADs.availability_domains.0.name}"
+					compartment_id = "${var.compartment_id}"
+				}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(s.ResourceName, "id"),
 					resource.TestCheckResourceAttrSet(s.ResourceName, "availability_domain"),
@@ -60,27 +71,85 @@ func (s *ResourceCoreVolumeTestSuite) TestCreateResourceCoreVolume() {
 			// update volume
 			{
 				Config: s.Config + `
-					resource "oci_core_volume" "t" {
-						availability_domain = "${data.oci_identity_availability_domains.ADs.availability_domains.0.name}"
-						compartment_id = "${var.compartment_id}"
-						display_name = "-tf-volume"
-						size_in_mbs = 51200
-					}`,
+				resource "oci_core_volume" "t" {
+					availability_domain = "${data.oci_identity_availability_domains.ADs.availability_domains.0.name}"
+					compartment_id = "${var.compartment_id}"
+					display_name = "-tf-volume"
+				}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(s.ResourceName, "display_name", "-tf-volume"),
+				),
+			},
+			// explicit volume size in MBs, noop
+			{
+				Config: s.Config + `
+				resource "oci_core_volume" "t" {
+					availability_domain = "${data.oci_identity_availability_domains.ADs.availability_domains.0.name}"
+					compartment_id = "${var.compartment_id}"
+					display_name = "-tf-volume"
+					size_in_mbs = 51200 //specify same size as default value, does nothing
+				}`,
+				ExpectNonEmptyPlan: false,
+			},
+			// migrate size_in_mbs to size_in_gbs
+			{
+				Config: s.Config + `
+				resource "oci_core_volume" "t" {
+					availability_domain = "${data.oci_identity_availability_domains.ADs.availability_domains.0.name}"
+					compartment_id = "${var.compartment_id}"
+					display_name = "-tf-volume"
+					size_in_gbs = 50 //specify same size in GB, does nothing
+				}`,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func (s *ResourceCoreVolumeTestSuite) TestCreateResourceCoreVolume_destructive() {
+	var resId, resId2 string
+	resource.Test(s.T(), resource.TestCase{
+		Providers: s.Providers,
+		Steps: []resource.TestStep{
+			// create volume, use default size
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				Config: s.Config + `
+				resource "oci_core_volume" "t" {
+					availability_domain = "${data.oci_identity_availability_domains.ADs.availability_domains.0.name}"
+					compartment_id = "${var.compartment_id}"
+				}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(s.ResourceName, "id"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "availability_domain"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "display_name"),
+					resource.TestCheckResourceAttr(s.ResourceName, "size_in_mbs", "51200"),
+					resource.TestCheckResourceAttr(s.ResourceName, "state", baremetal.ResourceAvailable),
+					func(s *terraform.State) (err error) {
+						resId, err = fromInstanceState(s, "oci_core_volume.t", "id")
+						return err
+					},
 				),
 			},
 			// verify changing volume size is destructive
 			{
 				Config: s.Config + `
-					resource "oci_core_volume" "t" {
-						availability_domain = "${data.oci_identity_availability_domains.ADs.availability_domains.0.name}"
-						compartment_id = "${var.compartment_id}"
-						size_in_mbs = 102400
-					}`,
+				resource "oci_core_volume" "t" {
+					availability_domain = "${data.oci_identity_availability_domains.ADs.availability_domains.0.name}"
+					compartment_id = "${var.compartment_id}"
+					size_in_mbs = 102400
+				}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(s.ResourceName, "size_in_mbs", "102400"),
 					resource.TestMatchResourceAttr(s.ResourceName, "display_name", regexp.MustCompile(`[^\-tf\-volume]`)),
+					func(s *terraform.State) (err error) {
+						resId2, err = fromInstanceState(s, "oci_core_volume.t", "id")
+						if resId == resId2 {
+							return fmt.Errorf("Expected different ocid, got the same.")
+						}
+						return err
+					},
 				),
 			},
 		},

--- a/vendor/github.com/oracle/bmcs-go-sdk/Makefile
+++ b/vendor/github.com/oracle/bmcs-go-sdk/Makefile
@@ -2,28 +2,48 @@ GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
 PACKAGE=github.com/oracle/bmcs-go-sdk
 
 default: fmt build
-
-deps:
-	go get github.com/kardianos/govendor
-
-fmt:
-	goimports -w -local ${PACKAGE} $(GOFMT_FILES)
-
 build: test
 	@go build ${PACKAGE}
 	@go build ${PACKAGE}/cmd/obmc-container-clean
+fmt: ;goimports -w -local ${PACKAGE} $(GOFMT_FILES)
+test: unit_test acc_test
 
-test:
-	@DEBUG=true go test -v ${PACKAGE}
-
-acceptance_test:
-	@TEST=true go test -v ${PACKAGE}/acceptance-test
+deps:
+	go get github.com/kardianos/govendor
 
 acceptance_cover:
 	@TEST=true go test -v -coverprofile=coverage.out -coverpkg ${PACKAGE} ${PACKAGE}/acceptance-test
 	@go tool cover -html coverage.out
 
-record_acceptance_test:
-	@go test -v -timeout 120m -tags "recording all" ${PACKAGE}/acceptance-test
+### `make unit_test run=TestResourceCore debug=1`
+cmd := go test
+ifdef run
+  cmd := $(cmd) -run $(run)
+endif
+ifdef debug
+  cmd := $(cmd) -v
+endif
+ifdef verbose
+  cmd := DEBUG=true $(cmd)
+endif
+unit_test: ;$(cmd)
 
-.PHONY: build test regression_test acceptance_test record_acceptance_test
+
+### `make acc_test rec=identity_user debug=1 verbose=1`
+cmd2 := TEST=true go test
+ifdef debug
+  cmd2 := $(cmd2) -v
+endif
+ifdef verbose
+  cmd2 := DEBUG=true $(cmd2)
+endif
+ifdef rec
+  cmd2 := $(cmd2) -timeout 120m -tags "recording $(rec)"
+endif
+acc_test: ;$(cmd2) ${PACKAGE}/acceptance-test
+
+test_print:
+	@grep -ohi "TestRun.*$(test).*Tests" *.go
+	@grep -oh "Test.*\*testing.T" *.go | cut -d \( -f 1
+
+.PHONY: build fmt test unit_test acc_test

--- a/vendor/github.com/oracle/bmcs-go-sdk/core_vnic.go
+++ b/vendor/github.com/oracle/bmcs-go-sdk/core_vnic.go
@@ -10,19 +10,19 @@ import "net/http"
 type Vnic struct {
 	OPCRequestIDUnmarshaller
 	ETagUnmarshaller
-	AvailabilityDomain	 string `json:"availabilityDomain"`
-	CompartmentID     	 string `json:"compartmentId"`
-	DisplayName        	 string `json:"displayName"`
-	HostnameLabel      	 string `json:"hostnameLabel"`
-	ID                 	 string `json:"id"`
-	IsPrimary          	 bool   `json:"isPrimary"`
-	MacAddress         	 string `json:"macAddress"`
-	State              	 string `json:"lifecycleState"`
-	PrivateIPAddress   	 string `json:"privateIp"`
-	PublicIPAddress    	 string `json:"publicIp"`
-	SkipSourceDestCheck	 bool   `json:"skipSourceDestCheck"`
-	SubnetID          	 string `json:"subnetId"`
-	TimeCreated       	 Time   `json:"timeCreated"`
+	AvailabilityDomain  string `json:"availabilityDomain"`
+	CompartmentID       string `json:"compartmentId"`
+	DisplayName         string `json:"displayName"`
+	HostnameLabel       string `json:"hostnameLabel"`
+	ID                  string `json:"id"`
+	IsPrimary           bool   `json:"isPrimary"`
+	MacAddress          string `json:"macAddress"`
+	State               string `json:"lifecycleState"`
+	PrivateIPAddress    string `json:"privateIp"`
+	PublicIPAddress     string `json:"publicIp"`
+	SkipSourceDestCheck bool   `json:"skipSourceDestCheck"`
+	SubnetID            string `json:"subnetId"`
+	TimeCreated         Time   `json:"timeCreated"`
 }
 
 // GetVnic retrieves information about a virtual network interface identified

--- a/vendor/github.com/oracle/bmcs-go-sdk/core_volume.go
+++ b/vendor/github.com/oracle/bmcs-go-sdk/core_volume.go
@@ -15,6 +15,7 @@ type Volume struct {
 	DisplayName        string `json:"displayName"`
 	ID                 string `json:"id"`
 	SizeInMBs          int    `json:"sizeInMBs"`
+	SizeInGBs          int    `json:"sizeInGBs"`
 	State              string `json:"lifecycleState"`
 	TimeCreated        Time   `json:"timeCreated"`
 }

--- a/vendor/github.com/oracle/bmcs-go-sdk/core_volume_backup.go
+++ b/vendor/github.com/oracle/bmcs-go-sdk/core_volume_backup.go
@@ -14,10 +14,12 @@ type VolumeBackup struct {
 	DisplayName         string `json:"displayName"`
 	ID                  string `json:"id"`
 	SizeInMBs           uint64 `json:"sizeInMBs"`
+	SizeInGBs           uint64 `json:"sizeInGBs"`
 	State               string `json:"lifecycleState"`
 	TimeCreated         Time   `json:"timeCreated"`
 	TimeRequestReceived Time   `json:"timeRequestReceived"`
 	UniqueSizeInMBs     uint64 `json:"uniqueSizeInMBs"`
+	UniqueSizeInGBs     uint64 `json:"uniqueSizeInGBs"`
 	VolumeID            string `json:"volumeId"`
 }
 

--- a/vendor/github.com/oracle/bmcs-go-sdk/request_options.go
+++ b/vendor/github.com/oracle/bmcs-go-sdk/request_options.go
@@ -162,6 +162,7 @@ type UpdateVnicOptions struct {
 type CreateVolumeOptions struct {
 	CreateOptions
 	SizeInMBs      int    `header:"-" json:"sizeInMBs,omitempty" url:"-"`
+	SizeInGBs      int    `header:"-" json:"sizeInGBs,omitempty" url:"-"`
 	VolumeBackupID string `header:"-" json:"volumeBackupId,omitempty" url:"-"`
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2972,10 +2972,10 @@
 			"revisionTime": "2017-01-25T16:36:56Z"
 		},
 		{
-			"checksumSHA1": "gqijMtR7yMtoJBTQtbLubunv5DI=",
+			"checksumSHA1": "M7kHCtvIVj3qu7Ko0YK7E8hEups=",
 			"path": "github.com/oracle/bmcs-go-sdk",
-			"revision": "9b861514578760cf496b598ce298b37240998328",
-			"revisionTime": "2017-09-28T23:17:12Z"
+			"revision": "8bd0f941051cb0b148782b962b81b5d4f510f30a",
+			"revisionTime": "2017-10-06T23:16:19Z"
 		},
 		{
 			"checksumSHA1": "ImgLNIpeXsGjZGXw4rd+rwzQxpo=",


### PR DESCRIPTION
* adds block volume example
* remove size param where not required in other tests

### Tests
TF_ACC=1 TF_ORACLE_ENV=test go test -v -timeout 120m -run Test.*CoreVolume.*TestSuite
2017/10/05 20:06:43 User Agent: Oracle-GoSDK/20160918 (go/go1.8; darwin/amd64; terraform/0.9.4-dev) Oracle-TerraformProvider/0.0.0
=== RUN   TestDatasourceCoreVolumeAttachmentTestSuite
=== RUN   TestAccDatasourceCoreVolumeAttachment_basic
--- PASS: TestAccDatasourceCoreVolumeAttachment_basic (199.17s)
--- PASS: TestDatasourceCoreVolumeAttachmentTestSuite (199.17s)
=== RUN   TestDatasourceCoreVolumeBackupTestSuite
=== RUN   TestAccDatasourceCoreVolumeBackup_basic
--- PASS: TestAccDatasourceCoreVolumeBackup_basic (39.09s)
--- PASS: TestDatasourceCoreVolumeBackupTestSuite (39.09s)
=== RUN   TestDatasourceCoreVolumeTestSuite
=== RUN   TestAccDatasourceCoreVolume_basic
--- PASS: TestAccDatasourceCoreVolume_basic (25.79s)
--- PASS: TestDatasourceCoreVolumeTestSuite (25.79s)
=== RUN   TestResourceCoreVolumeAttachmentTestSuite
=== RUN   TestResourceCoreVolumeAttachment_basic
--- PASS: TestResourceCoreVolumeAttachment_basic (202.51s)
--- PASS: TestResourceCoreVolumeAttachmentTestSuite (202.51s)
=== RUN   TestResourceCoreVolumeBackupTestSuite
=== RUN   TestAccResourceCoreVolumeBackup_basic
--- PASS: TestAccResourceCoreVolumeBackup_basic (55.34s)
--- PASS: TestResourceCoreVolumeBackupTestSuite (55.34s)
=== RUN   TestResourceCoreVolumeTestSuite
=== RUN   TestCreateResourceCoreVolume_basic
--- PASS: TestCreateResourceCoreVolume_basic (24.12s)
=== RUN   TestCreateResourceCoreVolume_destructive
--- PASS: TestCreateResourceCoreVolume_destructive (20.87s)
--- PASS: TestResourceCoreVolumeTestSuite (44.99s)
PASS
ok      github.com/oracle/terraform-provider-oci        566.928s