### PR TITLE
Additional LB session persistence update test

### DIFF
--- a/resource_obmcs_loadbalancer_backend_set_test.go
+++ b/resource_obmcs_loadbalancer_backend_set_test.go
@@ -159,6 +159,11 @@ func (s *ResourceLoadBalancerBackendSetTestSuite) TestAccResourceLoadBalancerBac
 						url_path = "/"
 					}
 				
+					session_persistence_configuration {
+						cookie_name = "lb-session2"
+						disable_fallback = false
+					}
+				
 					ssl_configuration {
 						certificate_name = "${oci_load_balancer_certificate.t.certificate_name}"
 						verify_depth = 6
@@ -167,6 +172,8 @@ func (s *ResourceLoadBalancerBackendSetTestSuite) TestAccResourceLoadBalancerBac
 				}
 				`,
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(s.ResourceName, "session_persistence_configuration.0.cookie_name", "lb-session2"),
+					resource.TestCheckResourceAttr(s.ResourceName, "session_persistence_configuration.0.disable_fallback", "false"),
 					resource.TestCheckResourceAttr(s.ResourceName, "ssl_configuration.0.certificate_name", "tf_cert_name"),
 					resource.TestCheckResourceAttr(s.ResourceName, "ssl_configuration.0.verify_depth", "6"),
 					resource.TestCheckResourceAttr(s.ResourceName, "ssl_configuration.0.verify_peer_certificate", "false"),


### PR DESCRIPTION
* Verify session persistence values update correctly

TESTS
=== RUN   TestResourceLoadBalancerBackendSetTestSuite
=== RUN   TestAccResourceLoadBalancerBackendSet_basic
--- PASS: TestAccResourceLoadBalancerBackendSet_basic (246.67s)
--- PASS: TestResourceLoadBalancerBackendSetTestSuite (246.67s)
