### PR TITLE
Update and Refresh for create_vnic_details

### DIFF
--- a/docs/examples/compute/multi_vnic/multi_vnic.tf
+++ b/docs/examples/compute/multi_vnic/multi_vnic.tf
@@ -7,7 +7,7 @@ variable "region" {}
 variable "ssh_public_key" {}
 
 variable "SecondaryVnicCount" {
-    default = 2
+    default = 1
 }
 
 # Choose an Availability Domain

--- a/helpers_core.go
+++ b/helpers_core.go
@@ -44,6 +44,7 @@ var createVnicDetailsSchema = &schema.Resource{
 	},
 }
 
+// vnicDetailsList is assumed to be non-nil and non-empty.
 func SetCreateVnicOptions(vnicDetailsList []interface{}) (vnicOpts *baremetal.CreateVnicOptions) {
 	vnic := vnicDetailsList[0].(map[string]interface{})
 
@@ -80,6 +81,7 @@ func SetCreateVnicOptions(vnicDetailsList []interface{}) (vnicOpts *baremetal.Cr
 	return
 }
 
+// vnicDetailsList is assumed to be non-nil and non-empty.
 func SetUpdateVnicOptions(vnicDetailsList []interface{}) (vnicOpts *baremetal.UpdateVnicOptions) {
 	vnic := vnicDetailsList[0].(map[string]interface{})
 	vnicOpts = &baremetal.UpdateVnicOptions{}

--- a/resource_obmcs_core_instance.go
+++ b/resource_obmcs_core_instance.go
@@ -30,43 +30,14 @@ func InstanceResource() *schema.Resource {
 		Delete: deleteInstance,
 		Schema: map[string]*schema.Schema{
 			"create_vnic_details": {
-				Type:     schema.TypeMap,
+				Type:     schema.TypeList,
 				Optional: true,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"assign_public_ip": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							ForceNew: true,
-						},
-						"display_name": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-						},
-						"hostname_label": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-						},
-						"private_ip": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-						},
-						"skip_source_dest_check": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							ForceNew: true,
-						},
-						"subnet_id": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-						},
-					},
-				},
+				// This must be set to computed, since it's optional and required subnet_id param is being refreshed.
+				// If this isn't computed, then that would always force a change on users who do not set create_vnic_details.
+				Computed: true,
+				MaxItems: 1,
+				MinItems: 1,
+				Elem:     createVnicDetailsSchema,
 			},
 			"availability_domain": {
 				Type:     schema.TypeString,
@@ -260,7 +231,7 @@ func (s *InstanceResourceCrud) Create() (e error) {
 	}
 
 	if rawVnic, ok := s.D.GetOk("create_vnic_details"); ok {
-		opts.CreateVnicOptions, e = SetCreateVnicOptions(rawVnic)
+		opts.CreateVnicOptions = SetCreateVnicOptions(rawVnic.([]interface{}))
 	}
 
 	if e == nil {
@@ -277,12 +248,11 @@ func (s *InstanceResourceCrud) Create() (e error) {
 }
 
 /*
- * Return the public, private IP pair associated with the instance's primary Vnic.
+ * Return the primary VNIC for this instance.
  *
- * NOTE while the instance is still being created, calls to this function
- * can return  an error priort to the Vnic being attached.
+ * Note that this may return an error during instance creation or deletion.
  */
-func (s *InstanceResourceCrud) getInstanceIPs() (public_ip string, private_ip string, e error) {
+func (s *InstanceResourceCrud) getPrimaryVnic() (vnic *baremetal.Vnic, e error) {
 	compartmentID := s.Resource.CompartmentID
 
 	opts := &baremetal.ListVnicAttachmentsOptions{}
@@ -303,7 +273,7 @@ func (s *InstanceResourceCrud) getInstanceIPs() (public_ip string, private_ip st
 	}
 
 	if len(attachments) < 1 {
-		return "", "", errors.New("No VNIC attachments found.")
+		return nil, errors.New("No VNIC attachments found.")
 	}
 
 	for _, attachment := range attachments {
@@ -312,12 +282,12 @@ func (s *InstanceResourceCrud) getInstanceIPs() (public_ip string, private_ip st
 
 			// Ignore errors on GetVnic, since we might not have permissions to view some secondary VNICs.
 			if vnic != nil && vnic.IsPrimary {
-				return vnic.PublicIPAddress, vnic.PrivateIPAddress, nil
+				return vnic, nil
 			}
 		}
 	}
 
-	return "", "", errors.New("Primary VNIC not found.")
+	return nil, errors.New("Primary VNIC not found.")
 }
 
 func (s *InstanceResourceCrud) Get() (e error) {
@@ -326,25 +296,6 @@ func (s *InstanceResourceCrud) Get() (e error) {
 		s.Resource = res
 	}
 
-	if e != nil {
-		return e
-	}
-
-	// Compute instance IPs through attached Vnic
-	if s.Resource.State != baremetal.ResourceRunning {
-		return
-	}
-	public_ip, private_ip, e2 := s.getInstanceIPs()
-	if e2 != nil {
-		log.Printf("[DEBUG] Primary VNIC could not be found: %q (InstanceID: %q, State: %q)", e2, s.Resource.ID, s.Resource.State)
-	}
-
-	if public_ip != "" {
-		s.public_ip = public_ip
-	}
-	if private_ip != "" {
-		s.private_ip = private_ip
-	}
 	return
 }
 
@@ -355,6 +306,27 @@ func (s *InstanceResourceCrud) Update() (e error) {
 	}
 
 	s.Resource, e = s.Client.UpdateInstance(s.D.Id(), opts)
+	if e != nil {
+		return
+	}
+
+	// HasChange returns true for any changes within create_vnic_details.
+	if !s.D.HasChange("create_vnic_details") {
+		log.Printf("[DEBUG] No changes to primary VNIC. Instance ID: %q", s.Resource.ID)
+		return
+	}
+
+	log.Printf("[DEBUG] Updating instance's primary VNIC. Instance ID: %q", s.Resource.ID)
+	vnic, e := s.getPrimaryVnic()
+	if e != nil {
+		log.Printf("[ERROR] Primary VNIC could not be found during instance update: %q (Instance ID: %q, State: %q)", e, s.Resource.ID, s.Resource.State)
+		return
+	}
+
+	if rawVnic, ok := s.D.GetOk("create_vnic_details"); ok {
+		_, e = s.Client.UpdateVnic(vnic.ID, SetUpdateVnicOptions(rawVnic.([]interface{})))
+	}
+
 	return
 }
 
@@ -369,8 +341,21 @@ func (s *InstanceResourceCrud) SetData() {
 	s.D.Set("shape", s.Resource.Shape)
 	s.D.Set("state", s.Resource.State)
 	s.D.Set("time_created", s.Resource.TimeCreated.String())
-	s.D.Set("public_ip", s.public_ip)
-	s.D.Set("private_ip", s.private_ip)
+
+	if s.Resource.State != baremetal.ResourceRunning {
+		return
+	}
+
+	vnic, vnicError := s.getPrimaryVnic()
+	if vnicError != nil {
+		log.Printf("[WARN] Primary VNIC could not be found during instance refresh: %q (Instance ID: %q, State: %q)", vnicError, s.Resource.ID, s.Resource.State)
+		return
+	}
+
+	s.D.Set("public_ip", vnic.PublicIPAddress)
+	s.D.Set("private_ip", vnic.PrivateIPAddress)
+
+	RefreshCreateVnicDetails(s.D, vnic)
 }
 
 func (s *InstanceResourceCrud) Delete() (e error) {

--- a/resource_obmcs_core_vnic_attachment.go
+++ b/resource_obmcs_core_vnic_attachment.go
@@ -7,6 +7,8 @@ import (
 	"github.com/oracle/bmcs-go-sdk"
 
 	"github.com/oracle/terraform-provider-oci/crud"
+
+	"log"
 )
 
 func VnicAttachmentResource() *schema.Resource {
@@ -17,6 +19,7 @@ func VnicAttachmentResource() *schema.Resource {
 		Timeouts: crud.DefaultTimeout,
 		Create:   createVnicAttachment,
 		Read:     readVnicAttachment,
+		Update:   updateVnicAttachment,
 		Delete:   deleteVnicAttachment,
 		Schema: map[string]*schema.Schema{
 			"availability_domain": {
@@ -28,43 +31,11 @@ func VnicAttachmentResource() *schema.Resource {
 				Computed: true,
 			},
 			"create_vnic_details": {
-				Type:     schema.TypeMap,
+				Type:     schema.TypeList,
 				Required: true,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"assign_public_ip": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							ForceNew: true,
-						},
-						"display_name": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-						},
-						"hostname_label": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-						},
-						"private_ip": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-						},
-						"skip_source_dest_check": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							ForceNew: true,
-						},
-						"subnet_id": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-						},
-					},
-				},
+				MaxItems: 1,
+				MinItems: 1,
+				Elem:     createVnicDetailsSchema,
 			},
 			"display_name": {
 				Type:     schema.TypeString,
@@ -119,6 +90,13 @@ func readVnicAttachment(d *schema.ResourceData, m interface{}) (e error) {
 	return crud.ReadResource(sync)
 }
 
+func updateVnicAttachment(d *schema.ResourceData, m interface{}) (e error) {
+	sync := &VnicAttachmentResourceCrud{}
+	sync.D = d
+	sync.Client = m.(*OracleClients).client
+	return crud.UpdateResource(sync.D, sync)
+}
+
 func deleteVnicAttachment(d *schema.ResourceData, m interface{}) (e error) {
 	sync := &VnicAttachmentResourceCrud{}
 	sync.D = d
@@ -159,11 +137,23 @@ func (s *VnicAttachmentResourceCrud) Create() (e error) {
 		vaOpts.DisplayName = displayName.(string)
 	}
 
-	vnicOpts, e := SetCreateVnicOptions(s.D.Get("create_vnic_details"))
-	if e == nil {
-		s.Resource, e = s.Client.AttachVnic(instanceID, vnicOpts, vaOpts)
+	vnicOpts := SetCreateVnicOptions(s.D.Get("create_vnic_details").([]interface{}))
+
+	s.Resource, e = s.Client.AttachVnic(instanceID, vnicOpts, vaOpts)
+	return
+}
+
+func (s *VnicAttachmentResourceCrud) Update() (e error) {
+	// The VNIC ID is also available at s.D.Get("vnic_id"). However,
+	// the VnicAttachment resources must be fetched anyway in order to update
+	// the state data after the update call.
+	s.Resource, e = s.Client.GetVnicAttachment(s.D.Id())
+	if e != nil {
+		return
 	}
 
+	opts := SetUpdateVnicOptions(s.D.Get("create_vnic_details").([]interface{}))
+	_, e = s.Client.UpdateVnic(s.Resource.VnicID, opts)
 	return
 }
 
@@ -185,6 +175,15 @@ func (s *VnicAttachmentResourceCrud) SetData() {
 	s.D.Set("time_created", s.Resource.TimeCreated.String())
 	s.D.Set("vlan_tag", s.Resource.VlanTag)
 	s.D.Set("vnic_id", s.Resource.VnicID)
+
+	vnic, err := s.Client.GetVnic(s.Resource.VnicID)
+	if vnic == nil {
+		// VNIC might not be found when attaching or detaching.
+		log.Printf("[DEBUG] VNIC not found during VNIC Attachment refresh. (VNIC ID: %q, Error: %q)", s.Resource.VnicID, err)
+		return
+	}
+
+	RefreshCreateVnicDetails(s.D, vnic)
 }
 
 func (s *VnicAttachmentResourceCrud) Delete() (e error) {

--- a/resource_obmcs_core_vnic_attachment_test.go
+++ b/resource_obmcs_core_vnic_attachment_test.go
@@ -83,8 +83,6 @@ func (s *ResourceCoreVnicAttachmentTestSuite) TestAccResourceCoreVnicAttachment_
 			},
 			{
 				// Update the VNIC
-				ImportState:       true,
-				ImportStateVerify: true,
 				Config: s.Config + `
 					resource "oci_core_vnic_attachment" "va" {
 						instance_id = "${oci_core_instance.t.id}"
@@ -128,8 +126,6 @@ func (s *ResourceCoreVnicAttachmentTestSuite) TestAccResourceCoreVnicAttachment_
 			},
 			{
 				// Create a new VNIC and VNIC Attachment with different options.
-				ImportState:       true,
-				ImportStateVerify: true,
 				Config: s.Config + `
 						resource "oci_core_vnic_attachment" "va" {
 							instance_id = "${oci_core_instance.t.id}"

--- a/resource_obmcs_core_vnic_attachment_test.go
+++ b/resource_obmcs_core_vnic_attachment_test.go
@@ -7,6 +7,7 @@ import (
 
 	"regexp"
 
+	"fmt"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/oracle/bmcs-go-sdk"
@@ -35,6 +36,8 @@ func (s *ResourceCoreVnicAttachmentTestSuite) SetupTest() {
 }
 
 func (s *ResourceCoreVnicAttachmentTestSuite) TestAccResourceCoreVnicAttachment_basic() {
+
+	var vaId string
 
 	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
@@ -72,6 +75,55 @@ func (s *ResourceCoreVnicAttachmentTestSuite) TestAccResourceCoreVnicAttachment_
 					resource.TestCheckResourceAttrSet(s.VnicResourceName, "private_ip_address"),
 					resource.TestCheckResourceAttr(s.VnicResourceName, "public_ip_address", ""),
 					resource.TestCheckResourceAttr(s.VnicResourceName, "skip_source_dest_check", "false"),
+					func(ts *terraform.State) (err error) {
+						vaId, err = fromInstanceState(ts, s.ResourceName, "id")
+						return err
+					},
+				),
+			},
+			{
+				// Update the VNIC
+				ImportState:       true,
+				ImportStateVerify: true,
+				Config: s.Config + `
+					resource "oci_core_vnic_attachment" "va" {
+						instance_id = "${oci_core_instance.t.id}"
+						display_name = "-tf-va1"
+						create_vnic_details {
+							subnet_id = "${oci_core_subnet.t.id}"
+							display_name = "-tf-vnic-2"
+							assign_public_ip = false
+							hostname_label = "myvnichostname"
+							skip_source_dest_check = true
+						}
+					}
+					data "oci_core_vnic" "v" {
+						vnic_id = "${oci_core_vnic_attachment.va.vnic_id}"
+					}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(s.ResourceName, "availability_domain"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "compartment_id"),
+					resource.TestCheckResourceAttr(s.ResourceName, "display_name", "-tf-va1"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "id"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "instance_id"),
+					resource.TestCheckResourceAttr(s.ResourceName, "state", baremetal.ResourceAttached),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "instance_id"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "subnet_id"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "time_created"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "vlan_tag"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "vnic_id"),
+					resource.TestCheckResourceAttrSet(s.VnicResourceName, "id"),
+					resource.TestCheckResourceAttr(s.ResourceName, "create_vnic_details.0.display_name", "-tf-vnic-2"),
+					resource.TestCheckResourceAttrSet(s.VnicResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttr(s.VnicResourceName, "public_ip_address", ""),
+					resource.TestCheckResourceAttr(s.ResourceName, "create_vnic_details.0.skip_source_dest_check", "true"),
+					func(ts *terraform.State) (err error) {
+						newId, err := fromInstanceState(ts, s.ResourceName, "id")
+						if newId != vaId {
+							return fmt.Errorf("Expected same ocid, got different.")
+						}
+						return err
+					},
 				),
 			},
 			{
@@ -103,6 +155,14 @@ func (s *ResourceCoreVnicAttachmentTestSuite) TestAccResourceCoreVnicAttachment_
 					resource.TestMatchResourceAttr(s.VnicResourceName, "public_ip_address", regexp.MustCompile(`[0-9]+\.[0-9]+\.[0-9]+\.[0-9]`)),
 					resource.TestCheckResourceAttr(s.VnicResourceName, "hostname_label", "myvnichostname"),
 					resource.TestCheckResourceAttr(s.VnicResourceName, "skip_source_dest_check", "true"),
+					func(ts *terraform.State) (err error) {
+						newId, err := fromInstanceState(ts, s.ResourceName, "id")
+						if newId == vaId {
+							return fmt.Errorf("Expected new ocid, got the same.")
+						}
+						vaId = newId
+						return err
+					},
 				),
 			},
 			{
@@ -131,6 +191,13 @@ func (s *ResourceCoreVnicAttachmentTestSuite) TestAccResourceCoreVnicAttachment_
 					resource.TestCheckResourceAttr(s.ResourceName, "state", baremetal.ResourceAttached),
 					resource.TestCheckResourceAttr(s.VnicResourceName, "private_ip_address", "10.0.1.20"),
 					resource.TestCheckResourceAttr(s.VnicResourceName, "skip_source_dest_check", "true"),
+					func(ts *terraform.State) (err error) {
+						newId, err := fromInstanceState(ts, s.ResourceName, "id")
+						if newId != vaId {
+							return fmt.Errorf("Expected same ocid, got different.")
+						}
+						return err
+					},
 				),
 			},
 		},


### PR DESCRIPTION
Schema TypeMap as is currently used for create_vnic_details does not support properties such
as Computed and ForceNew, which prevented using this with update and refresh. TypeList
does appear to handle these correctly, and switching does not require any changes from users.

Tests run:
make test run=ResourceCoreVnicAttachmentTestSuite debug=1
make test run=ResourceCoreInstanceTestSuite debug=1