### PR TITLE
Optimize Private Ip tests

### DIFF
--- a/data_source_obmcs_core_private_ip_test.go
+++ b/data_source_obmcs_core_private_ip_test.go
@@ -19,26 +19,29 @@ type DatasourcePrivateIPTestSuite struct {
 	Provider     terraform.ResourceProvider
 	Providers    map[string]terraform.ResourceProvider
 	ResourceName string
-	List         *baremetal.ListPrivateIPs
 }
 
 func (s *DatasourcePrivateIPTestSuite) SetupTest() {
 	s.Client = testAccClient
 	s.Provider = testAccProvider
 	s.Providers = testAccProviders
-	s.Config = vnicConfig + `
-resource "oci_core_private_ip" "testPrivateIP" {
-	vnic_id = "${lookup(data.oci_core_vnic_attachments.vnics.vnic_attachments[0],"vnic_id")}"
-	ip_address = "10.0.1.23"
-}
-	`
-	s.Config += testProviderConfig()
-	s.ResourceName = "data.oci_core_private_ips.testPrivateIPs"
+	s.Config = testProvider1() + testADs() + testVCN1() + testSubnet1() + testImage1() + testInstance1() + `	
+	data "oci_core_vnic_attachments" "t" {
+		compartment_id = "${var.compartment_ocid}"
+		availability_domain = "${data.oci_identity_availability_domains.t.availability_domains.0.name}"
+		instance_id = "${oci_core_instance.t.id}"
+	}
+	
+	resource "oci_core_private_ip" "t" {
+		vnic_id = "${lookup(data.oci_core_vnic_attachments.t.vnic_attachments[0], "vnic_id")}"
+		ip_address = "10.0.1.23"
+	}`
+
+	s.ResourceName = "data.oci_core_private_ips.t"
 }
 
-func (s *DatasourcePrivateIPTestSuite) TestListPrivateIPsByVnicID() {
-
-	resource.UnitTest(s.T(), resource.TestCase{
+func (s *DatasourcePrivateIPTestSuite) TestAccCorePrivateIPs_basic() {
+	resource.Test(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
 		Providers:                 s.Providers,
 		Steps: []resource.TestStep{
@@ -47,73 +50,41 @@ func (s *DatasourcePrivateIPTestSuite) TestListPrivateIPsByVnicID() {
 				ImportStateVerify: true,
 				Config:            s.Config,
 			},
+			// list by ip address
 			{
 				Config: s.Config + `
-data "oci_core_private_ips" "testPrivateIPs" {
-	vnic_id = "${lookup(data.oci_core_vnic_attachments.vnics.vnic_attachments[0],"vnic_id")}"
-}
-				`,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(s.ResourceName, "private_ips.#", "2"),
-					resource.TestCheckResourceAttrSet(s.ResourceName, "private_ips.0.id"),
-					resource.TestCheckResourceAttrSet(s.ResourceName, "private_ips.1.id"),
-				),
-			},
-		},
-	},
-	)
-}
-
-func (s *DatasourcePrivateIPTestSuite) TestListPrivateIPsBySubnetID() {
-
-	resource.UnitTest(s.T(), resource.TestCase{
-		PreventPostDestroyRefresh: true,
-		Providers:                 s.Providers,
-		Steps: []resource.TestStep{
-			{
-				ImportState:       true,
-				ImportStateVerify: true,
-				Config:            s.Config,
-			},
-			{
-				Config: s.Config + `
-data "oci_core_private_ips" "testPrivateIPs" {
-	subnet_id = "${oci_core_subnet.WebSubnetAD1.id}"
-}
-				`,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(s.ResourceName, "private_ips.#", "2"),
-					resource.TestCheckResourceAttrSet(s.ResourceName, "private_ips.0.id"),
-					resource.TestCheckResourceAttrSet(s.ResourceName, "private_ips.1.id"),
-				),
-			},
-		},
-	},
-	)
-}
-
-func (s *DatasourcePrivateIPTestSuite) TestListPrivateIPsByIPAddress() {
-
-	resource.UnitTest(s.T(), resource.TestCase{
-		PreventPostDestroyRefresh: true,
-		Providers:                 s.Providers,
-		Steps: []resource.TestStep{
-			{
-				ImportState:       true,
-				ImportStateVerify: true,
-				Config:            s.Config,
-			},
-			{
-				Config: s.Config + `
-data "oci_core_private_ips" "testPrivateIPs" {
-	ip_address = "10.0.1.23"
-	subnet_id = "${oci_core_subnet.WebSubnetAD1.id}"
-}
-				`,
+				data "oci_core_private_ips" "t" {
+					ip_address = "10.0.1.23"
+					subnet_id = "${oci_core_subnet.t.id}"
+				}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(s.ResourceName, "private_ips.0.id"),
-					resource.TestCheckResourceAttr(s.ResourceName, "private_ips.0.ip_address", "10.0.1.23"),
 					resource.TestCheckResourceAttr(s.ResourceName, "private_ips.#", "1"),
+					resource.TestCheckResourceAttr(s.ResourceName, "private_ips.0.ip_address", "10.0.1.23"),
+				),
+			},
+			// list by vnic id
+			{
+				Config: s.Config + `
+				data "oci_core_private_ips" "t" {
+					vnic_id = "${lookup(data.oci_core_vnic_attachments.t.vnic_attachments[0],"vnic_id")}"
+				}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(s.ResourceName, "private_ips.#", "2"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "private_ips.0.id"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "private_ips.1.id"),
+				),
+			},
+			// list by subnet id
+			{
+				Config: s.Config + `
+				data "oci_core_private_ips" "t" {
+					subnet_id = "${oci_core_subnet.t.id}"
+				}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(s.ResourceName, "private_ips.#", "2"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "private_ips.0.id"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "private_ips.1.id"),
 				),
 			},
 		},
@@ -121,6 +92,6 @@ data "oci_core_private_ips" "testPrivateIPs" {
 	)
 }
 
-func TestDatasourcePrivateIPTestSuite(t *testing.T) {
+func TestDatasourceCorePrivateIPTestSuite(t *testing.T) {
 	suite.Run(t, new(DatasourcePrivateIPTestSuite))
 }

--- a/provider_test.go
+++ b/provider_test.go
@@ -82,14 +82,6 @@ resource "oci_core_subnet" "WebSubnetAD1" {
 	dhcp_options_id     = "${oci_core_virtual_network.t.default_dhcp_options_id}"
 }`
 
-var imageConf = `
-data "oci_core_images" "t" {
-	compartment_id = "${var.compartment_id}"
-  	operating_system = "Oracle Linux"
-  	operating_system_version = "7.3"
-  	limit = 1
-}`
-
 var instanceConfig = subnetConfig + `
 data "oci_core_images" "t" {
 	compartment_id = "${var.compartment_id}"
@@ -126,13 +118,6 @@ resource "oci_core_instance" "t" {
 	timeouts {
 		create = "15m"
 	}
-}
-`
-var vnicConfig = instanceConfig + `
-data "oci_core_vnic_attachments" "vnics" {
-    compartment_id = "${var.compartment_id}"
-	availability_domain = "${data.oci_identity_availability_domains.ADs.availability_domains.0.name}"
-    instance_id = "${oci_core_instance.t.id}"
 }
 `
 
@@ -184,40 +169,6 @@ resource "oci_core_instance" "t" {
 	timeouts {
 		create = "15m"
 	}
-}
-`
-
-var certificateConfig = `
-resource "oci_load_balancer_certificate" "t" {
-  load_balancer_id   = "${oci_load_balancer.t.id}"
-  ca_certificate     = "-----BEGIN CERTIFICATE-----\nMIIBNzCB4gIJAKtwJkxUgNpzMA0GCSqGSIb3DQEBCwUAMCMxITAfBgNVBAoTGElu\ndGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0xNzA0MTIyMTU3NTZaFw0xODA0MTIy\nMTU3NTZaMCMxITAfBgNVBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDBcMA0G\nCSqGSIb3DQEBAQUAA0sAMEgCQQDlM8lz3BFJA6zBlsF63k9ajPVq3Q1WQoHQ3j35\n08DRKIfwqfV+CxL63W3dZrwL4TrjqorP5CQ36+I6OWALH2zVAgMBAAEwDQYJKoZI\nhvcNAQELBQADQQCEjHVQJoiiVpIIvDWF+4YDRReVuwzrvq2xduWw7CIsDWlYuGZT\nQKVY6tnTy2XpoUk0fqUvMB/M2HGQ1WqZGHs6\n-----END CERTIFICATE-----"
-  certificate_name   = "stub_certificate_name"
-  private_key        = "-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBAOUzyXPcEUkDrMGWwXreT1qM9WrdDVZCgdDePfnTwNEoh/Cp9X4L\nEvrdbd1mvAvhOuOqis/kJDfr4jo5YAsfbNUCAwEAAQJAJz8k4bfvJceBT2zXGIj0\noZa9d1z+qaSdwfwsNJkzzRyGkj/j8yv5FV7KNdSfsBbStlcuxUm4i9o5LXhIA+iQ\ngQIhAPzStAN8+Rz3dWKTjRWuCfy+Pwcmyjl3pkMPSiXzgSJlAiEA6BUZWHP0b542\nu8AizBT3b3xKr1AH2nkIx9OHq7F/QbECIHzqqpDypa8/QVuUZegpVrvvT/r7mn1s\nddS6cDtyJgLVAiEA1Z5OFQeuL2sekBRbMyP9WOW7zMBKakLL3TqL/3JCYxECIAkG\nl96uo1MjK/66X5zQXBG7F2DN2CbcYEz0r3c3vvfq\n-----END RSA PRIVATE KEY-----"
-  public_certificate = "-----BEGIN CERTIFICATE-----\nMIIBNzCB4gIJAKtwJkxUgNpzMA0GCSqGSIb3DQEBCwUAMCMxITAfBgNVBAoTGElu\ndGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0xNzA0MTIyMTU3NTZaFw0xODA0MTIy\nMTU3NTZaMCMxITAfBgNVBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDBcMA0G\nCSqGSIb3DQEBAQUAA0sAMEgCQQDlM8lz3BFJA6zBlsF63k9ajPVq3Q1WQoHQ3j35\n08DRKIfwqfV+CxL63W3dZrwL4TrjqorP5CQ36+I6OWALH2zVAgMBAAEwDQYJKoZI\nhvcNAQELBQADQQCEjHVQJoiiVpIIvDWF+4YDRReVuwzrvq2xduWw7CIsDWlYuGZT\nQKVY6tnTy2XpoUk0fqUvMB/M2HGQ1WqZGHs6\n-----END CERTIFICATE-----"
-}
-`
-
-var loadbalancerConfig = subnetConfig + `
-
-resource "oci_core_subnet" "WebSubnetAD2" {
-  availability_domain = "${data.oci_identity_availability_domains.ADs.availability_domains.1.name}"
-  cidr_block = "10.0.2.0/24"
-  display_name = "WebSubnetAD2"
-  compartment_id = "${var.compartment_id}"
-  vcn_id = "${oci_core_virtual_network.t.id}"
-  route_table_id      = "${oci_core_virtual_network.t.default_route_table_id}"
-  security_list_ids = ["${oci_core_virtual_network.t.default_security_list_id}"]
-  dhcp_options_id     = "${oci_core_virtual_network.t.default_dhcp_options_id}"
-}
-
-data "oci_load_balancer_shapes" "t" {
-  compartment_id = "${var.compartment_id}"
-}
-resource "oci_load_balancer" "t" {
-  shape          = "${data.oci_load_balancer_shapes.t.shapes.0.name}"
-  compartment_id = "${var.compartment_id}"
-  display_name   = "lb_display_name"
-  subnet_ids     = ["${oci_core_subnet.WebSubnetAD1.id}", "${oci_core_subnet.WebSubnetAD2.id}"]
 }
 `
 

--- a/test_helpers.go
+++ b/test_helpers.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+
+package main
+
+func testProvider1() string {
+	return `
+	variable "tenancy_ocid" { default = "` + getRequiredEnvSetting("tenancy_ocid") + `" }
+	variable "user_ocid" {default = "` + getRequiredEnvSetting("user_ocid") + `"}
+	variable "fingerprint" {default = "` + getRequiredEnvSetting("fingerprint") + `"}
+	variable "private_key_path" {default = "` + getRequiredEnvSetting("private_key_path") + `"}
+	variable "region" {default = "` + getRequiredEnvSetting("region") + `"}
+	variable "compartment_ocid" {default = "` + getRequiredEnvSetting("compartment_id") + `"}
+	
+	provider "oci" {
+		tenancy_ocid = "${var.tenancy_ocid}"
+		user_ocid = "${var.user_ocid}"
+		fingerprint = "${var.fingerprint}"
+		private_key_path = "${var.private_key_path}"
+		region = "${var.region}"
+	}`
+}
+
+func testADs() string {
+	return `
+	data "oci_identity_availability_domains" "t" {
+		compartment_id = "${var.compartment_ocid}"
+	}`
+}
+
+func testVCN1() string {
+	return `
+	resource "oci_core_virtual_network" "t" {
+		compartment_id = "${var.compartment_ocid}"
+		cidr_block = "10.0.0.0/16"
+		display_name = "-tf-vcn"
+		dns_label    = "vcndns"
+	}`
+}
+
+func testSubnet1() string {
+	return `
+	resource "oci_core_subnet" "t" {
+		compartment_id      = "${var.compartment_ocid}"
+		vcn_id              = "${oci_core_virtual_network.t.id}"
+		availability_domain = "${lookup(data.oci_identity_availability_domains.t.availability_domains[0],"name")}"
+		route_table_id      = "${oci_core_virtual_network.t.default_route_table_id}"
+		security_list_ids = ["${oci_core_virtual_network.t.default_security_list_id}"]
+		dhcp_options_id     = "${oci_core_virtual_network.t.default_dhcp_options_id}"
+		cidr_block          = "10.0.1.0/24"
+		display_name        = "-tf-subnet"
+		dns_label           = "subnetdns"
+	}`
+}
+
+func testImage1() string {
+	return `
+	data "oci_core_images" "t" {
+		compartment_id = "${var.compartment_ocid}"
+		operating_system = "Oracle Linux"
+		operating_system_version = "7.3"
+		limit = 1
+	}`
+}
+
+func testInstance1() string {
+	return `
+	resource "oci_core_instance" "t" {
+		availability_domain = "${data.oci_identity_availability_domains.t.availability_domains.0.name}"
+		compartment_id = "${var.compartment_ocid}"
+		subnet_id = "${oci_core_subnet.t.id}"
+		image = "${data.oci_core_images.t.images.0.id}"
+		shape = "VM.Standard1.1"
+		metadata {}
+		timeouts {
+			create = "15m"
+		}
+	}`
+}


### PR DESCRIPTION
* These tests were taking ~23 minutes, consolidated steps to get ~6 minutes
* Begin test_helpers for systematic approach to test fixture definitions
* Test Provider definition that properly reads in env variables

### TEST
=== RUN   TestResourceCorePrivateIPTestSuite
=== RUN   TestAccCoreResourcePrivateIP_basic
--- PASS: TestAccCoreResourcePrivateIP_basic (209.98s)
--- PASS: TestResourceCorePrivateIPTestSuite (209.98s)
=== RUN   TestDatasourceCorePrivateIPTestSuite
=== RUN   TestAccCorePrivateIPs_basic
--- PASS: TestAccCorePrivateIPs_basic (217.08s)
--- PASS: TestDatasourceCorePrivateIPTestSuite (217.08s)
