### PR TITLE
Avoid name collisions with concurrent tests

### DIFF
--- a/provider_test.go
+++ b/provider_test.go
@@ -3,12 +3,8 @@
 package main
 
 import (
-	"errors"
 	"testing"
 
-	"fmt"
-
-	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/oracle/bmcs-go-sdk"
@@ -261,44 +257,4 @@ func TestProviderConfig(t *testing.T) {
 	assert.NotNil(t, client)
 	_, ok := client.(*OracleClients)
 	assert.True(t, ok)
-}
-
-// TestNoInstanceState determines if there is any state for a given name.
-func testNoInstanceState(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		ms := s.RootModule()
-		rs, ok := ms.Resources[name]
-		if !ok {
-			return nil
-		}
-
-		is := rs.Primary
-		if is == nil {
-			return nil
-		}
-
-		return errors.New("State exists for primary resource " + name)
-	}
-}
-
-// custom TestCheckFunc helper, returns a value associated with a key from an instance in the current state
-func fromInstanceState(s *terraform.State, name, key string) (string, error) {
-	ms := s.RootModule()
-	rs, ok := ms.Resources[name]
-	if !ok {
-		return "", fmt.Errorf("Not found: %s", name)
-	}
-
-	is := rs.Primary
-	if is == nil {
-		return "", fmt.Errorf("No primary instance: %s", name)
-	}
-
-	v, ok := is.Attributes[key]
-
-	if ok {
-		return v, nil
-	} else {
-		return "", fmt.Errorf("%s: Attribute '%s' not found", name, key)
-	}
 }

--- a/resource_obmcs_core_vnic_attachment_test.go
+++ b/resource_obmcs_core_vnic_attachment_test.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 
 	"fmt"
+
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/oracle/bmcs-go-sdk"

--- a/resource_obmcs_identity_group_test.go
+++ b/resource_obmcs_identity_group_test.go
@@ -30,6 +30,7 @@ func (s *ResourceIdentityGroupTestSuite) SetupTest() {
 }
 
 func (s *ResourceIdentityGroupTestSuite) TestAccResourceIdentityGroup_basic() {
+	var token, tokenFn = tokenize()
 	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
@@ -37,13 +38,13 @@ func (s *ResourceIdentityGroupTestSuite) TestAccResourceIdentityGroup_basic() {
 			{
 				ImportState:       true,
 				ImportStateVerify: true,
-				Config: s.Config + `
+				Config: s.Config + tokenFn(`
 				resource "oci_identity_group" "t" {
-					name = "-tf-group"
+					name = "{{.token}}"
 					description = "tf test group"
-				}`,
+				}`, nil),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(s.ResourceName, "name", "-tf-group"),
+					resource.TestCheckResourceAttr(s.ResourceName, "name", token),
 					resource.TestCheckResourceAttr(s.ResourceName, "description", "tf test group"),
 					resource.TestCheckResourceAttr(s.ResourceName, "state", baremetal.ResourceActive),
 					resource.TestCheckResourceAttrSet(s.ResourceName, "time_created"),
@@ -51,11 +52,11 @@ func (s *ResourceIdentityGroupTestSuite) TestAccResourceIdentityGroup_basic() {
 			},
 			// verify update
 			{
-				Config: s.Config + `
+				Config: s.Config + tokenFn(`
 				resource "oci_identity_group" "t" {
-					name = "-tf-group"
+					name = "{{.token}}"
 					description = "tf test group (updated)"
-				}`,
+				}`, nil),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(s.ResourceName, "description", "tf test group (updated)"),
 				),

--- a/resource_obmcs_identity_user_group_membership_test.go
+++ b/resource_obmcs_identity_user_group_membership_test.go
@@ -21,19 +21,20 @@ type ResourceIdentityUserGroupMembershipTestSuite struct {
 }
 
 func (s *ResourceIdentityUserGroupMembershipTestSuite) SetupTest() {
+	var _, tokenFn = tokenize()
 	s.Client = testAccClient
 	s.Provider = testAccProvider
 	s.Providers = testAccProviders
-	s.Config = testProviderConfig() + `
+	s.Config = testProviderConfig() + tokenFn(`
 	resource "oci_identity_user" "t" {
-		name = "-tf-user"
+		name = "{{.token}}"
 		description = "tf test user"
 	}
 	
 	resource "oci_identity_group" "t" {
-		name = "-tf-group"
+		name = "{{.token}}"
 		description = "tf test group"
-	}`
+	}`, nil)
 	s.ResourceName = "oci_identity_user_group_membership.t"
 }
 

--- a/resource_obmcs_identity_user_test.go
+++ b/resource_obmcs_identity_user_test.go
@@ -31,6 +31,7 @@ func (s *ResourceIdentityUserTestSuite) SetupTest() {
 }
 
 func (s *ResourceIdentityUserTestSuite) TestAccResourceIdentityUser_basic() {
+	token, tokenFn := tokenize()
 	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
@@ -38,25 +39,28 @@ func (s *ResourceIdentityUserTestSuite) TestAccResourceIdentityUser_basic() {
 			{
 				ImportState:       true,
 				ImportStateVerify: true,
-				Config: s.Config + `
-				resource "oci_identity_user" "t" {
-					name = "-tf-user"
-					description = "automated test user"
-				}`,
+				Config: s.Config +
+					tokenFn(
+						`resource "oci_identity_user" "t" {
+							name = "{{.token}}"
+							description = "{{.description}}"
+						}`,
+						map[string]string{"description": "automated test user"}),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(s.ResourceName, "time_created"),
-					resource.TestCheckResourceAttr(s.ResourceName, "name", "-tf-user"),
+					resource.TestCheckResourceAttr(s.ResourceName, "name", token),
 					resource.TestCheckResourceAttr(s.ResourceName, "description", "automated test user"),
 					resource.TestCheckResourceAttr(s.ResourceName, "state", baremetal.ResourceActive),
 				),
 			},
 			// verify update
 			{
-				Config: s.Config + `
-				resource "oci_identity_user" "t" {
-					name = "-tf-user"
-					description = "automated test user (updated)"
-				}`,
+				Config: s.Config + tokenFn(
+					`resource "oci_identity_user" "t" {
+						name = "{{.token}}"
+						description = "{{.description}}"
+					}`,
+					map[string]string{"description": "automated test user (updated)"}),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(s.ResourceName, "description", "automated test user (updated)"),
 				),

--- a/test_helpers.go
+++ b/test_helpers.go
@@ -2,77 +2,62 @@
 
 package main
 
-func testProvider1() string {
-	return `
-	variable "tenancy_ocid" { default = "` + getRequiredEnvSetting("tenancy_ocid") + `" }
-	variable "user_ocid" {default = "` + getRequiredEnvSetting("user_ocid") + `"}
-	variable "fingerprint" {default = "` + getRequiredEnvSetting("fingerprint") + `"}
-	variable "private_key_path" {default = "` + getRequiredEnvSetting("private_key_path") + `"}
-	variable "region" {default = "` + getRequiredEnvSetting("region") + `"}
-	variable "compartment_ocid" {default = "` + getRequiredEnvSetting("compartment_id") + `"}
-	
-	provider "oci" {
-		tenancy_ocid = "${var.tenancy_ocid}"
-		user_ocid = "${var.user_ocid}"
-		fingerprint = "${var.fingerprint}"
-		private_key_path = "${var.private_key_path}"
-		region = "${var.region}"
-	}`
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+	"time"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+var tmpl template.Template = *template.New("tmpl")
+
+// Applies values from a map to a string template
+func apply(template string, values map[string]string) string {
+	b := new(bytes.Buffer)
+	t, _ := tmpl.Parse(template)
+	t.Execute(b, values)
+	return b.String()
 }
 
-func testADs() string {
-	return `
-	data "oci_identity_availability_domains" "t" {
-		compartment_id = "${var.compartment_ocid}"
-	}`
+// Returns date-time formatted as a string, ex: 2017-10-12-000934-119299083"
+func timestamp() string {
+	t := time.Now()
+	return fmt.Sprintf("%d-%02d-%02d-%02d%02d%02d-%d",
+		t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond())
 }
 
-func testVCN1() string {
-	return `
-	resource "oci_core_virtual_network" "t" {
-		compartment_id = "${var.compartment_ocid}"
-		cidr_block = "10.0.0.0/16"
-		display_name = "-tf-vcn"
-		dns_label    = "vcndns"
-	}`
-}
-
-func testSubnet1() string {
-	return `
-	resource "oci_core_subnet" "t" {
-		compartment_id      = "${var.compartment_ocid}"
-		vcn_id              = "${oci_core_virtual_network.t.id}"
-		availability_domain = "${lookup(data.oci_identity_availability_domains.t.availability_domains[0],"name")}"
-		route_table_id      = "${oci_core_virtual_network.t.default_route_table_id}"
-		security_list_ids = ["${oci_core_virtual_network.t.default_security_list_id}"]
-		dhcp_options_id     = "${oci_core_virtual_network.t.default_dhcp_options_id}"
-		cidr_block          = "10.0.1.0/24"
-		display_name        = "-tf-subnet"
-		dns_label           = "subnetdns"
-	}`
-}
-
-func testImage1() string {
-	return `
-	data "oci_core_images" "t" {
-		compartment_id = "${var.compartment_ocid}"
-		operating_system = "Oracle Linux"
-		operating_system_version = "7.3"
-		limit = 1
-	}`
-}
-
-func testInstance1() string {
-	return `
-	resource "oci_core_instance" "t" {
-		availability_domain = "${data.oci_identity_availability_domains.t.availability_domains.0.name}"
-		compartment_id = "${var.compartment_ocid}"
-		subnet_id = "${oci_core_subnet.t.id}"
-		image = "${data.oci_core_images.t.images.0.id}"
-		shape = "VM.Standard1.1"
-		metadata {}
-		timeouts {
-			create = "15m"
+// Creates a form of "apply" above that will always supply the same value for {{.token}}
+func tokenize() (string, func(string, map[string]string) string) {
+	ts := timestamp()
+	return ts, func(template string, values map[string]string) string {
+		if values == nil {
+			values = map[string]string{}
 		}
-	}`
+		values["token"] = ts
+		return apply(template, values)
+	}
+}
+
+// custom TestCheckFunc helper, returns a value associated with a key from an instance in the current state
+func fromInstanceState(s *terraform.State, name, key string) (string, error) {
+	ms := s.RootModule()
+	rs, ok := ms.Resources[name]
+	if !ok {
+		return "", fmt.Errorf("Not found: %s", name)
+	}
+
+	is := rs.Primary
+	if is == nil {
+		return "", fmt.Errorf("No primary instance: %s", name)
+	}
+
+	v, ok := is.Attributes[key]
+
+	if ok {
+		return v, nil
+	} else {
+		return "", fmt.Errorf("%s: Attribute '%s' not found", name, key)
+	}
 }

--- a/test_templates.go
+++ b/test_templates.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+
+package main
+
+func testProvider1() string {
+	return `
+	variable "tenancy_ocid" { default = "` + getRequiredEnvSetting("tenancy_ocid") + `" }
+	variable "user_ocid" {default = "` + getRequiredEnvSetting("user_ocid") + `"}
+	variable "fingerprint" {default = "` + getRequiredEnvSetting("fingerprint") + `"}
+	variable "private_key_path" {default = "` + getRequiredEnvSetting("private_key_path") + `"}
+	variable "region" {default = "` + getRequiredEnvSetting("region") + `"}
+	variable "compartment_ocid" {default = "` + getRequiredEnvSetting("compartment_id") + `"}
+	
+	provider "oci" {
+		tenancy_ocid = "${var.tenancy_ocid}"
+		user_ocid = "${var.user_ocid}"
+		fingerprint = "${var.fingerprint}"
+		private_key_path = "${var.private_key_path}"
+		region = "${var.region}"
+	}`
+}
+
+func testADs() string {
+	return `
+	data "oci_identity_availability_domains" "t" {
+		compartment_id = "${var.compartment_ocid}"
+	}`
+}
+
+func testVCN1() string {
+	return `
+	resource "oci_core_virtual_network" "t" {
+		compartment_id = "${var.compartment_ocid}"
+		cidr_block = "10.0.0.0/16"
+		display_name = "-tf-vcn"
+		dns_label    = "vcndns"
+	}`
+}
+
+func testSubnet1() string {
+	return `
+	resource "oci_core_subnet" "t" {
+		compartment_id      = "${var.compartment_ocid}"
+		vcn_id              = "${oci_core_virtual_network.t.id}"
+		availability_domain = "${lookup(data.oci_identity_availability_domains.t.availability_domains[0],"name")}"
+		route_table_id      = "${oci_core_virtual_network.t.default_route_table_id}"
+		security_list_ids = ["${oci_core_virtual_network.t.default_security_list_id}"]
+		dhcp_options_id     = "${oci_core_virtual_network.t.default_dhcp_options_id}"
+		cidr_block          = "10.0.1.0/24"
+		display_name        = "-tf-subnet"
+		dns_label           = "subnetdns"
+	}`
+}
+
+func testImage1() string {
+	return `
+	data "oci_core_images" "t" {
+		compartment_id = "${var.compartment_ocid}"
+		operating_system = "Oracle Linux"
+		operating_system_version = "7.3"
+		limit = 1
+	}`
+}
+
+func testInstance1() string {
+	return `
+	resource "oci_core_instance" "t" {
+		availability_domain = "${data.oci_identity_availability_domains.t.availability_domains.0.name}"
+		compartment_id = "${var.compartment_ocid}"
+		subnet_id = "${oci_core_subnet.t.id}"
+		image = "${data.oci_core_images.t.images.0.id}"
+		shape = "VM.Standard1.1"
+		metadata {}
+		timeouts {
+			create = "15m"
+		}
+	}`
+}


### PR DESCRIPTION
* Helpers + test integration for creating unique, repeatable values to inject in template strings
* There are a few more integration points (remaining identity tests + object store) that we can integrate if this approach is acceptable

Tests: 
make test run=TestResourceIdentity