### PR TITLE
Avoid name collisions with concurrent tests pt2

### DIFF
--- a/data_source_obmcs_identity_api_keys_test.go
+++ b/data_source_obmcs_identity_api_keys_test.go
@@ -23,10 +23,11 @@ type DatasourceIdentityAPIKeysTestSuite struct {
 }
 
 func (s *DatasourceIdentityAPIKeysTestSuite) SetupTest() {
+	_, tokenFn := tokenize()
 	s.Client = testAccClient
 	s.Provider = testAccProvider
 	s.Providers = testAccProviders
-	s.Config = testProviderConfig() + `
+	s.Config = testProviderConfig() + tokenFn(`
 	resource "oci_identity_user" "t" {
 		name = "-tf-test"
 		description = "automated test user"
@@ -45,7 +46,7 @@ mXlrQB7nNKsJrrv5fHwaPDrAY4iNP2W0q3LRpyNigJ6cgRuGJhHa82iHPmxgIx8m
 fwIDAQAB
 -----END PUBLIC KEY-----
 EOF
-	}`
+	}`, nil)
 	s.ResourceName = "data.oci_identity_api_keys.t"
 }
 

--- a/data_source_obmcs_identity_groups_test.go
+++ b/data_source_obmcs_identity_groups_test.go
@@ -19,18 +19,18 @@ type DatasourceIdentityGroupsTestSuite struct {
 	Provider     terraform.ResourceProvider
 	Providers    map[string]terraform.ResourceProvider
 	ResourceName string
-	List         *baremetal.ListGroups
 }
 
 func (s *DatasourceIdentityGroupsTestSuite) SetupTest() {
+	_, tokenFn := tokenize()
 	s.Client = testAccClient
 	s.Provider = testAccProvider
 	s.Providers = testAccProviders
-	s.Config = testProviderConfig() + `
+	s.Config = testProviderConfig() + tokenFn(`
 	resource "oci_identity_group" "t" {
-		name = "-tf-group"
+		name = "{{.token}}"
 		description = "automated test group"
-	}`
+	}`, nil)
 	s.ResourceName = "data.oci_identity_groups.t"
 }
 

--- a/data_source_obmcs_identity_policies_test.go
+++ b/data_source_obmcs_identity_policies_test.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -17,32 +16,32 @@ type DatasourceIdentityPolicyTestSuite struct {
 	Client       *baremetal.Client
 	Provider     terraform.ResourceProvider
 	Providers    map[string]terraform.ResourceProvider
-	TimeCreated  time.Time
 	Config       string
 	ResourceName string
 }
 
 func (s *DatasourceIdentityPolicyTestSuite) SetupTest() {
+	_, tokenFn := tokenize()
 	s.Client = testAccClient
 	s.Provider = testAccProvider
 	s.Providers = testAccProviders
-	s.Config = testProviderConfig() + `
+	s.Config = testProviderConfig() + tokenFn(`
 	resource "oci_identity_compartment" "t" {
 		name = "-tf-compartment"
 		description = "tf test compartment"
 	}
 
 	resource "oci_identity_group" "t" {
-		name = "-tf-group"
+		name = "{{.token}}"
 		description = "automated test group"
 	}
 
 	resource "oci_identity_policy" "p" {
-		name = "-tf-policy"
+		name = "{{.token}}"
 		description = "automated test policy"
 		compartment_id = "${oci_identity_compartment.t.id}"
 		statements = ["Allow group ${oci_identity_group.t.name} to read instances in compartment ${oci_identity_compartment.t.name}"]
-	}`
+	}`, nil)
 	s.ResourceName = "data.oci_identity_policies.p"
 }
 

--- a/data_source_obmcs_identity_swift_passwords_test.go
+++ b/data_source_obmcs_identity_swift_passwords_test.go
@@ -21,18 +21,19 @@ type DatasourceIdentitySwiftPasswordsTestSuite struct {
 }
 
 func (s *DatasourceIdentitySwiftPasswordsTestSuite) SetupTest() {
+	_, tokenFn := tokenize()
 	s.Client = testAccClient
 	s.Provider = testAccProvider
 	s.Providers = testAccProviders
-	s.Config = testProviderConfig() + `
+	s.Config = testProviderConfig() + tokenFn(`
 	resource "oci_identity_user" "t" {
-		name = "-tf-user"
+		name = "{{.token}}"
 		description = "tf test user"
 	}
 	resource "oci_identity_swift_password" "t" {
 		user_id = "${oci_identity_user.t.id}"
 		description = "tf test user swift password"
-	}`
+	}`, nil)
 	s.ResourceName = "data.oci_identity_swift_passwords.p"
 }
 

--- a/data_source_obmcs_identity_user_group_memberships_test.go
+++ b/data_source_obmcs_identity_user_group_memberships_test.go
@@ -21,17 +21,18 @@ type DatasourceIdentityUserGroupMembershipsTestSuite struct {
 }
 
 func (s *DatasourceIdentityUserGroupMembershipsTestSuite) SetupTest() {
+	_, tokenFn := tokenize()
 	s.Client = testAccClient
 	s.Provider = testAccProvider
 	s.Providers = testAccProviders
-	s.Config = testProviderConfig() + `
+	s.Config = testProviderConfig() + tokenFn(`
 	resource "oci_identity_user" "t" {
-		name = "-tf-user"
+		name = "{{.token}}"
 		description = "tf test user"
 	}
 	
 	resource "oci_identity_group" "t" {
-		name = "-tf-group"
+		name = "{{.token}}"
 		description = "tf test group"
 	}
 	
@@ -39,7 +40,7 @@ func (s *DatasourceIdentityUserGroupMembershipsTestSuite) SetupTest() {
 		compartment_id = "${var.tenancy_ocid}"
 		user_id = "${oci_identity_user.t.id}"
 		group_id = "${oci_identity_group.t.id}"
-	}`
+	}`, nil)
 	s.ResourceName = "data.oci_identity_user_group_memberships.t"
 }
 

--- a/data_source_obmcs_identity_users_test.go
+++ b/data_source_obmcs_identity_users_test.go
@@ -19,19 +19,18 @@ type DatasourceIdentityUsersTestSuite struct {
 	Provider     terraform.ResourceProvider
 	Providers    map[string]terraform.ResourceProvider
 	ResourceName string
-	List         *baremetal.ListUsers
 }
 
 func (s *DatasourceIdentityUsersTestSuite) SetupTest() {
+	_, tokenFn := tokenize()
 	s.Client = testAccClient
 	s.Provider = testAccProvider
 	s.Providers = testAccProviders
-	s.Config = testProviderConfig() + `
+	s.Config = testProviderConfig() + tokenFn(`
 	resource "oci_identity_user" "t" {
-		name = "-tf-user"
+		name = "{{.token}}"
 		description = "automated test user"
-	}
-	`
+	}`, nil)
 	s.ResourceName = "data.oci_identity_users.t"
 }
 

--- a/data_source_obmcs_objectstorage_bucketsummary_test.go
+++ b/data_source_obmcs_objectstorage_bucketsummary_test.go
@@ -19,21 +19,24 @@ type DatasourceObjectstorageBucketSummaryTestSuite struct {
 	Provider     terraform.ResourceProvider
 	Providers    map[string]terraform.ResourceProvider
 	ResourceName string
+	Token        string
+	TokenFn      func(string, map[string]string) string
 }
 
 func (s *DatasourceObjectstorageBucketSummaryTestSuite) SetupTest() {
+	s.Token, s.TokenFn = tokenize()
 	s.Client = testAccClient
 	s.Provider = testAccProvider
 	s.Providers = testAccProviders
-	s.Config = testProviderConfig() + `
+	s.Config = testProviderConfig() + s.TokenFn(`
 	data "oci_objectstorage_namespace" "t" {
 	}
 	
 	resource "oci_objectstorage_bucket" "t" {
 		compartment_id = "${var.compartment_id}"
 		namespace = "${data.oci_objectstorage_namespace.t.namespace}"
-		name = "-tf-bucket"
-	}`
+		name = "{{.token}}"
+	}`, nil)
 	s.ResourceName = "data.oci_objectstorage_bucket_summaries.t"
 }
 
@@ -58,7 +61,7 @@ func (s *DatasourceObjectstorageBucketSummaryTestSuite) TestAccDatasourceObjects
 					resource.TestCheckResourceAttrSet(s.ResourceName, "namespace"),
 					resource.TestCheckResourceAttrSet(s.ResourceName, "bucket_summaries.#"),
 					resource.TestCheckResourceAttr(s.ResourceName, "bucket_summaries.#", "1"),
-					resource.TestCheckResourceAttr(s.ResourceName, "bucket_summaries.0.name", "-tf-bucket"),
+					resource.TestCheckResourceAttr(s.ResourceName, "bucket_summaries.0.name", s.Token),
 				),
 			},
 		},

--- a/resource_obmcs_identity_api_key_test.go
+++ b/resource_obmcs_identity_api_key_test.go
@@ -22,12 +22,13 @@ type ResourceIdentityAPIKeyTestSuite struct {
 }
 
 func (s *ResourceIdentityAPIKeyTestSuite) SetupTest() {
+	_, tokenFn := tokenize()
 	s.Client = testAccClient
 	s.Provider = testAccProvider
 	s.Providers = testAccProviders
-	s.Config = testProviderConfig() + `
+	s.Config = testProviderConfig() + tokenFn(`
 	resource "oci_identity_user" "t" {
-		name = "-tf-user"
+		name = "{{.token}}"
 		description = "automated test user"
 	}
 	resource "oci_identity_api_key" "t" {
@@ -43,7 +44,7 @@ mXlrQB7nNKsJrrv5fHwaPDrAY4iNP2W0q3LRpyNigJ6cgRuGJhHa82iHPmxgIx8m
 fwIDAQAB
 -----END PUBLIC KEY-----
 EOF
-	}`
+	}`, nil)
 	s.ResourceName = "oci_identity_api_key.t"
 }
 

--- a/resource_obmcs_identity_group_test.go
+++ b/resource_obmcs_identity_group_test.go
@@ -30,7 +30,7 @@ func (s *ResourceIdentityGroupTestSuite) SetupTest() {
 }
 
 func (s *ResourceIdentityGroupTestSuite) TestAccResourceIdentityGroup_basic() {
-	var token, tokenFn = tokenize()
+	token, tokenFn := tokenize()
 	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{

--- a/resource_obmcs_identity_swift_password_test.go
+++ b/resource_obmcs_identity_swift_password_test.go
@@ -21,14 +21,15 @@ type ResourceIdentitySwiftPasswordTestSuite struct {
 }
 
 func (s *ResourceIdentitySwiftPasswordTestSuite) SetupTest() {
+	_, tokenFn := tokenize()
 	s.Client = testAccClient
 	s.Provider = testAccProvider
 	s.Providers = testAccProviders
-	s.Config = testProviderConfig() + `
+	s.Config = testProviderConfig() + tokenFn(`
 	resource "oci_identity_user" "t" {
-		name = "tf-user"
+		name = "{{.token}}"
 		description = "tf test user"
-	}`
+	}`, nil)
 
 	s.ResourceName = "oci_identity_swift_password.t"
 }

--- a/resource_obmcs_identity_ui_password_test.go
+++ b/resource_obmcs_identity_ui_password_test.go
@@ -22,14 +22,15 @@ type ResourceIdentityUIPasswordTestSuite struct {
 }
 
 func (s *ResourceIdentityUIPasswordTestSuite) SetupTest() {
+	_, tokenFn := tokenize()
 	s.Client = testAccClient
 	s.Provider = testAccProvider
 	s.Providers = testAccProviders
-	s.Config = testProviderConfig() + `
+	s.Config = testProviderConfig() + tokenFn(`
 	resource "oci_identity_user" "t" {
 		name = "-tf-user"
 		description = "tf test user"
-	}`
+	}`, nil)
 
 	s.ResourceName = "oci_identity_ui_password.t"
 }

--- a/resource_obmcs_identity_user_group_membership_test.go
+++ b/resource_obmcs_identity_user_group_membership_test.go
@@ -21,7 +21,7 @@ type ResourceIdentityUserGroupMembershipTestSuite struct {
 }
 
 func (s *ResourceIdentityUserGroupMembershipTestSuite) SetupTest() {
-	var _, tokenFn = tokenize()
+	_, tokenFn := tokenize()
 	s.Client = testAccClient
 	s.Provider = testAccProvider
 	s.Providers = testAccProviders

--- a/resource_obmcs_objectstorage_bucket_test.go
+++ b/resource_obmcs_objectstorage_bucket_test.go
@@ -33,25 +33,26 @@ func (s *ResourceObjectstorageBucketTestSuite) SetupTest() {
 }
 
 func (s *ResourceObjectstorageBucketTestSuite) TestAccResourceObjectstorageBucket_basic() {
+	token, tokenFn := tokenize()
 	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
 			{
 				ImportState:       true,
 				ImportStateVerify: true,
-				Config: s.Config + `
+				Config: s.Config + tokenFn(`
 				resource "oci_objectstorage_bucket" "t" {
 					namespace = "${data.oci_objectstorage_namespace.t.namespace}"
 					compartment_id = "${var.compartment_id}"
-					name = "-tf-bucket"
+					name = "{{.token}}"
 					metadata = {
 						"content-type" = "text/plain"
 					}
-				}`,
+				}`, nil),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(s.ResourceName, "namespace"),
 					resource.TestCheckResourceAttrSet(s.ResourceName, "compartment_id"),
-					resource.TestCheckResourceAttr(s.ResourceName, "name", "-tf-bucket"),
+					resource.TestCheckResourceAttr(s.ResourceName, "name", token),
 					resource.TestCheckResourceAttr(s.ResourceName, "metadata.content-type", "text/plain"),
 				),
 			},


### PR DESCRIPTION
* Integrate in remaining areas of potential conflict

Tests run:
make test run=Test.*Identity
make test run=Test.*Objectstorage