### PR TITLE
Sync instance subnet and hostname_label

### DIFF
--- a/resource_obmcs_core_instance.go
+++ b/resource_obmcs_core_instance.go
@@ -58,6 +58,7 @@ func InstanceResource() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				ForceNew: true,
 			},
 			"id": {
 				Type:     schema.TypeString,
@@ -71,6 +72,7 @@ func InstanceResource() *schema.Resource {
 			"ipxe_script": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 			},
 			"metadata": {
 				Type:     schema.TypeMap,
@@ -100,6 +102,7 @@ func InstanceResource() *schema.Resource {
 			"subnet_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 			"time_created": {
@@ -108,12 +111,10 @@ func InstanceResource() *schema.Resource {
 			},
 			"public_ip": {
 				Type:     schema.TypeString,
-				Required: false,
 				Computed: true,
 			},
 			"private_ip": {
 				Type:     schema.TypeString,
-				Required: false,
 				Computed: true,
 			},
 		},
@@ -352,8 +353,10 @@ func (s *InstanceResourceCrud) SetData() {
 		return
 	}
 
+	s.D.Set("hostname_label", vnic.HostnameLabel)
 	s.D.Set("public_ip", vnic.PublicIPAddress)
 	s.D.Set("private_ip", vnic.PrivateIPAddress)
+	s.D.Set("subnet_id", vnic.SubnetID)
 
 	RefreshCreateVnicDetails(s.D, vnic)
 }


### PR DESCRIPTION
An instances have 2 ways to set subnet_id and hostname_label: either at the
root level, or in create_vnic_details. By syncing both sets of properties with
the VNIC and setting all of these to computed, this change allows users to
switch between which version is used without causing changes to their plan.
This was partly in place before, but this change puts a few missing pieces in
place.
Note that hostname_label is updatable if specified in create_vnic_details, but not when
specified directly in the instance. I think that's fine for now - we could either add logic 
to work around that, or - what I would prefer - we can deprecate the instance version of
hostname_label (and subnet_id). 