### PR TITLE
Issue #320: user_data cloud-init script in docs/examples/networking/nat

### DIFF
--- a/docs/examples/networking/nat/user_data.tpl
+++ b/docs/examples/networking/nat/user_data.tpl
@@ -1,16 +1,14 @@
-#
-# Create file to be used when enabling ip forwarding
-#
+#cloud-config
+
 write_files:
+  # Create file to be used when enabling ip forwarding
   - path: /etc/sysctl.d/98-ip-forward.conf
     content: |
       net.ipv4.ip_forward = 1
 
-#
-# Run firewall commands to enable masquerading and port forwarding
-# Enable ip forwarding by setting sysctl kernel parameter
-#
 runcmd:
+  # Run firewall commands to enable masquerading and port forwarding
+  # Enable ip forwarding by setting sysctl kernel parameter
   - firewall-offline-cmd --direct --add-rule ipv4 nat POSTROUTING 0 -o ens3 -j MASQUERADE
   - firewall-offline-cmd --direct --add-rule ipv4 filter FORWARD 0 -i ens3 -j ACCEPT
   - /bin/systemctl restart firewalld


### PR DESCRIPTION
I needed to reformat the comments to get cloud-init to run the user_data. Added the `#cloud-config` for good measure. Tested with a successful `terraform apply` as well as validating the private instances ability to connect to the Internet.

```
[opc@PrivateInstance ~]$ ping oracle.com
PING oracle.com (137.254.120.50) 56(84) bytes of data.
64 bytes from vp-ocoma-cms-adc.oracle.com (137.254.120.50): icmp_seq=1 ttl=245 time=69.9 ms
64 bytes from vp-ocoma-cms-adc.oracle.com (137.254.120.50): icmp_seq=2 ttl=245 time=69.9 ms
```