### PR TITLE
Data Source filtering core w/ expository identity integration

### DIFF
--- a/data_source_obmcs_identity_availability_domains_test.go
+++ b/data_source_obmcs_identity_availability_domains_test.go
@@ -36,7 +36,7 @@ func (s *DatasourceIdentityAvailabilityDomainsTestSuite) TestAccIdentityAvailabi
 		PreventPostDestroyRefresh: true,
 		Providers:                 s.Providers,
 		Steps: []resource.TestStep{
-			// Verify expected number of ADs
+			// Verify expected number of ADs in expected order
 			{
 				Config: s.Config + `
 				data "oci_identity_availability_domains" "t" {
@@ -44,6 +44,9 @@ func (s *DatasourceIdentityAvailabilityDomainsTestSuite) TestAccIdentityAvailabi
 				}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(s.ResourceName, "availability_domains.#", "3"),
+					resource.TestMatchResourceAttr(s.ResourceName, "availability_domains.0.name", regexp.MustCompile(`\w*:\w{3}-AD-1`)),
+					resource.TestMatchResourceAttr(s.ResourceName, "availability_domains.1.name", regexp.MustCompile(`\w*:\w{3}-AD-2`)),
+					resource.TestMatchResourceAttr(s.ResourceName, "availability_domains.2.name", regexp.MustCompile(`\w*:\w{3}-AD-3`)),
 				),
 			},
 			// Verify regex filtering

--- a/data_source_obmcs_identity_compartments.go
+++ b/data_source_obmcs_identity_compartments.go
@@ -16,6 +16,7 @@ func CompartmentDatasource() *schema.Resource {
 	return &schema.Resource{
 		Read: readCompartments,
 		Schema: map[string]*schema.Schema{
+			"filter": dataSourceFiltersSchema(),
 			"compartment_id": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -65,24 +66,31 @@ func (s *CompartmentDatasourceCrud) Get() (e error) {
 }
 
 func (s *CompartmentDatasourceCrud) SetData() {
-	if s.Res != nil {
-		s.D.SetId(time.Now().UTC().String())
-		resources := []map[string]interface{}{}
-		for _, v := range s.Res.Compartments {
-			res := map[string]interface{}{
-				"compartment_id": v.CompartmentID,
-				"description":    v.Description,
-				"id":             v.ID,
-				"inactive_state": v.InactiveStatus,
-				"name":           v.Name,
-				"state":          v.State,
-				"time_created":   v.TimeCreated.String(),
-			}
-			resources = append(resources, res)
+	if s.Res == nil {
+		return
+	}
+
+	s.D.SetId(time.Now().UTC().String())
+	resources := []map[string]interface{}{}
+	for _, v := range s.Res.Compartments {
+		res := map[string]interface{}{
+			"compartment_id": v.CompartmentID,
+			"description":    v.Description,
+			"id":             v.ID,
+			"inactive_state": v.InactiveStatus,
+			"name":           v.Name,
+			"state":          v.State,
+			"time_created":   v.TimeCreated.String(),
 		}
-		if err := s.D.Set("compartments", resources); err != nil {
-			panic(err)
-		}
+		resources = append(resources, res)
+	}
+
+	if f, fOk := s.D.GetOk("filter"); fOk {
+		resources = ApplyFilters(f.(*schema.Set), resources)
+	}
+
+	if err := s.D.Set("compartments", resources); err != nil {
+		panic(err)
 	}
 	return
 }

--- a/data_source_obmcs_identity_compartments_test.go
+++ b/data_source_obmcs_identity_compartments_test.go
@@ -47,8 +47,26 @@ func (s *DatasourceIdentityCompartmentsTestSuite) TestAccIdentityCompartments_ba
 					compartment_id = "${var.compartment_id}"
 				}`,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(s.ResourceName, "compartments.0.id"),
 					resource.TestCheckResourceAttrSet(s.ResourceName, "compartments.#"),
+				),
+			},
+			{
+				Config: s.Config + `
+				data "oci_identity_compartments" "t" {
+					compartment_id = "${var.compartment_id}"
+					filter {
+						name   = "name"
+						values = ["-tf-compartment"]
+					}
+				}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(s.ResourceName, "compartments.#", "1"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "compartments.0.id"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "compartments.0.compartment_id"),
+					resource.TestCheckResourceAttr(s.ResourceName, "compartments.0.name", "-tf-compartment"),
+					resource.TestCheckResourceAttr(s.ResourceName, "compartments.0.description", "tf test compartment"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "compartments.0.time_created"),
+					resource.TestCheckResourceAttr(s.ResourceName, "compartments.0.inactive_state", "0"),
 				),
 			},
 		},

--- a/data_source_obmcs_identity_groups.go
+++ b/data_source_obmcs_identity_groups.go
@@ -16,6 +16,7 @@ func GroupDatasource() *schema.Resource {
 	return &schema.Resource{
 		Read: readGroups,
 		Schema: map[string]*schema.Schema{
+			"filter": dataSourceFiltersSchema(),
 			"compartment_id": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -65,24 +66,33 @@ func (s *GroupDatasourceCrud) Get() (e error) {
 }
 
 func (s *GroupDatasourceCrud) SetData() {
-	if s.Res != nil {
-		s.D.SetId(time.Now().UTC().String())
-		resources := []map[string]interface{}{}
-		for _, v := range s.Res.Groups {
-			res := map[string]interface{}{
-				"compartment_id": v.CompartmentID,
-				"description":    v.Description,
-				"id":             v.ID,
-				"inactive_state": v.InactiveStatus,
-				"name":           v.Name,
-				"state":          v.State,
-				"time_created":   v.TimeCreated.String(),
-			}
-			resources = append(resources, res)
-		}
-		if err := s.D.Set("groups", resources); err != nil {
-			panic(err)
-		}
+	if s.Res == nil {
+		return
 	}
+
+	s.D.SetId(time.Now().UTC().String())
+	resources := []map[string]interface{}{}
+	for _, v := range s.Res.Groups {
+		res := map[string]interface{}{
+			"compartment_id": v.CompartmentID,
+			"description":    v.Description,
+			"id":             v.ID,
+			"inactive_state": v.InactiveStatus,
+			"name":           v.Name,
+			"state":          v.State,
+			"time_created":   v.TimeCreated.String(),
+		}
+
+		resources = append(resources, res)
+	}
+
+	if f, fOk := s.D.GetOk("filter"); fOk {
+		resources = ApplyFilters(f.(*schema.Set), resources)
+	}
+
+	if err := s.D.Set("groups", resources); err != nil {
+		panic(err)
+	}
+
 	return
 }

--- a/data_source_obmcs_identity_groups_test.go
+++ b/data_source_obmcs_identity_groups_test.go
@@ -19,14 +19,16 @@ type DatasourceIdentityGroupsTestSuite struct {
 	Provider     terraform.ResourceProvider
 	Providers    map[string]terraform.ResourceProvider
 	ResourceName string
+	Token        string
+	TokenFn      TokenFn
 }
 
 func (s *DatasourceIdentityGroupsTestSuite) SetupTest() {
-	_, tokenFn := tokenize()
+	s.Token, s.TokenFn = tokenize()
 	s.Client = testAccClient
 	s.Provider = testAccProvider
 	s.Providers = testAccProviders
-	s.Config = testProviderConfig() + tokenFn(`
+	s.Config = testProviderConfig() + s.TokenFn(`
 	resource "oci_identity_group" "t" {
 		name = "{{.token}}"
 		description = "automated test group"
@@ -51,7 +53,31 @@ func (s *DatasourceIdentityGroupsTestSuite) TestAccDatasourceIdentityGroups_basi
 				}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(s.ResourceName, "groups.#"),
+				),
+			},
+			// Test cascading filters
+			{
+				Config: s.Config + s.TokenFn(`
+				data "oci_identity_groups" "t" {
+					compartment_id = "${var.compartment_id}"
+					filter {
+						name   = "name"
+						values = ["{{.token}}", "Administrators"]
+					}
+					filter {
+						name   = "description"
+						values = ["automated test group"]
+					}
+				}`, nil),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(s.ResourceName, "groups.#", "1"),
 					resource.TestCheckResourceAttrSet(s.ResourceName, "groups.0.id"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "groups.0.compartment_id"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "groups.0.time_created"),
+					resource.TestCheckResourceAttr(s.ResourceName, "groups.0.name", s.Token),
+					resource.TestCheckResourceAttr(s.ResourceName, "groups.0.description", "automated test group"),
+					resource.TestCheckResourceAttr(s.ResourceName, "groups.0.state", "ACTIVE"),
+					resource.TestCheckResourceAttr(s.ResourceName, "groups.0.inactive_state", "0"),
 				),
 			},
 		},

--- a/data_source_obmcs_identity_policies.go
+++ b/data_source_obmcs_identity_policies.go
@@ -16,6 +16,7 @@ func IdentityPolicyDatasource() *schema.Resource {
 	return &schema.Resource{
 		Read: readIdentityPolicies,
 		Schema: map[string]*schema.Schema{
+			"filter": dataSourceFiltersSchema(),
 			"compartment_id": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -67,26 +68,33 @@ func (s *IdentityPolicyDatasourceCrud) Get() (e error) {
 }
 
 func (s *IdentityPolicyDatasourceCrud) SetData() {
-	if s.Res != nil {
-		s.D.SetId(time.Now().UTC().String())
-		resources := []map[string]interface{}{}
-		for _, v := range s.Res.Policies {
-			res := map[string]interface{}{
-				"id":             v.ID,
-				"compartment_id": v.CompartmentID,
-				"name":           v.Name,
-				"statements":     v.Statements,
-				"description":    v.Description,
-				"time_created":   v.TimeCreated.String(),
-				"state":          v.State,
-				"inactive_state": v.InactiveStatus,
-				"version_date":   v.VersionDate,
-			}
-			resources = append(resources, res)
+	if s.Res == nil {
+		return
+	}
+
+	s.D.SetId(time.Now().UTC().String())
+	resources := []map[string]interface{}{}
+	for _, v := range s.Res.Policies {
+		res := map[string]interface{}{
+			"id":             v.ID,
+			"compartment_id": v.CompartmentID,
+			"name":           v.Name,
+			"statements":     v.Statements,
+			"description":    v.Description,
+			"time_created":   v.TimeCreated.String(),
+			"state":          v.State,
+			"inactive_state": v.InactiveStatus,
+			"version_date":   v.VersionDate,
 		}
-		if err := s.D.Set("policies", resources); err != nil {
-			panic(err)
-		}
+		resources = append(resources, res)
+	}
+
+	if f, fOk := s.D.GetOk("filter"); fOk {
+		resources = ApplyFilters(f.(*schema.Set), resources)
+	}
+
+	if err := s.D.Set("policies", resources); err != nil {
+		panic(err)
 	}
 	return
 }

--- a/data_source_obmcs_identity_swift_passwords_test.go
+++ b/data_source_obmcs_identity_swift_passwords_test.go
@@ -44,17 +44,32 @@ func (s *DatasourceIdentitySwiftPasswordsTestSuite) TestAccDatasourceIdentitySwi
 			{
 				ImportState:       true,
 				ImportStateVerify: true,
-				Config:            s.Config,
-			},
-			{
 				Config: s.Config + `
 				data "oci_identity_swift_passwords" "p" {
 					user_id = "${oci_identity_user.t.id}"
 				}`,
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(s.ResourceName, "passwords.#"),
+				),
+			},
+			{
+				Config: s.Config + `
+				data "oci_identity_swift_passwords" "p" {
+					user_id = "${oci_identity_user.t.id}"
+					filter {
+						name   = "description"
+						values = ["${oci_identity_swift_password.t.description}"]
+					}
+				}`,
+				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(s.ResourceName, "passwords.#", "1"),
 					resource.TestCheckResourceAttrSet(s.ResourceName, "passwords.0.id"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "passwords.0.user_id"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "passwords.0.time_created"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "passwords.0.expires_on"),
 					resource.TestCheckResourceAttr(s.ResourceName, "passwords.0.description", "tf test user swift password"),
+					resource.TestCheckResourceAttr(s.ResourceName, "passwords.0.state", "ACTIVE"),
+					resource.TestCheckResourceAttr(s.ResourceName, "passwords.0.inactive_state", "0"),
 				),
 			},
 		},

--- a/data_source_obmcs_identity_user_group_memberships_test.go
+++ b/data_source_obmcs_identity_user_group_memberships_test.go
@@ -55,6 +55,25 @@ func (s *DatasourceIdentityUserGroupMembershipsTestSuite) TestAccIdentityUserGro
 				ImportStateVerify: true,
 				Config:            s.Config,
 			},
+			//verify membership by specifying both user and group id
+			{
+				Config: s.Config + `			
+				data "oci_identity_user_group_memberships" "t" {
+					compartment_id = "${var.tenancy_ocid}"
+					user_id = "${oci_identity_user.t.id}"
+					group_id = "${oci_identity_group.t.id}"
+				}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(s.ResourceName, "memberships.#", "1"),
+					resource.TestCheckResourceAttr(s.ResourceName, "memberships.0.state", "ACTIVE"),
+					resource.TestCheckResourceAttr(s.ResourceName, "memberships.0.inactive_state", "0"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "memberships.0.compartment_id"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "memberships.0.id"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "memberships.0.user_id"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "memberships.0.group_id"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "memberships.0.time_created"),
+				),
+			},
 			// verify membership by group
 			{
 				Config: s.Config + `
@@ -78,13 +97,16 @@ func (s *DatasourceIdentityUserGroupMembershipsTestSuite) TestAccIdentityUserGro
 					resource.TestCheckResourceAttr(s.ResourceName, "memberships.#", "1"),
 				),
 			},
-			//verify membership by specifying both user and group id
+			// verify filtering
 			{
-				Config: s.Config + `			
+				Config: s.Config + `
 				data "oci_identity_user_group_memberships" "t" {
 					compartment_id = "${var.tenancy_ocid}"
-					user_id = "${oci_identity_user.t.id}"
 					group_id = "${oci_identity_group.t.id}"
+					filter {
+						name = "user_id"
+						values = ["${oci_identity_user.t.id}"]
+					}
 				}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(s.ResourceName, "memberships.#", "1"),

--- a/docs/datasources/identity/availability_domain.md
+++ b/docs/datasources/identity/availability_domain.md
@@ -11,6 +11,12 @@ Lists Availability Domains (ADs).
 ```
 data "oci_identity_availability_domains" "t" {
   compartment_id = "compartmentID"
+  
+  filter {
+    name = "name"
+    values = ["\\w*-AD-1"]
+    regex = true
+  }
 }
 ```
 

--- a/docs/examples/iam/ad_multi_region/ad_multi_region.tf
+++ b/docs/examples/iam/ad_multi_region/ad_multi_region.tf
@@ -1,5 +1,6 @@
 /*
- * This example demonstrates how to read AD values from multiple regions and outputs them for display.
+ * This example demonstrates how to read AD values from multiple regions and employ filters
+ * to isolate a specific AD value.
  */
 
 variable "tenancy_ocid" {}
@@ -27,13 +28,25 @@ provider "oci" {
 }
 
 data "oci_identity_availability_domains" "ad-phx" {
-  compartment_id = "${var.tenancy_ocid}"
   provider = "oci.phx"
+  compartment_id = "${var.tenancy_ocid}"
+
+  filter {
+    name = "name"
+    values = ["\\w*-AD-1"]
+    regex = true
+  }
 }
 
 data "oci_identity_availability_domains" "ad-iad" {
-  compartment_id = "${var.tenancy_ocid}"
   provider = "oci.iad"
+  compartment_id = "${var.tenancy_ocid}"
+
+  filter {
+    name = "name"
+    values = ["\\w*-AD-1"]
+    regex = true
+  }
 }
 
 

--- a/filters.go
+++ b/filters.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"regexp"
+
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceFiltersSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeSet,
+		Optional: true,
+		ForceNew: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"name": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+
+				"values": {
+					Type:     schema.TypeList,
+					Required: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+
+				"regex": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Default:  false,
+				},
+			},
+		},
+	}
+}
+
+// Process an entity's properties (string or array of strings) by N filter sets of
+// keyword:values, where each filter set ANDs and each keyword:values set ORs
+func ApplyFilters(filters *schema.Set, items []map[string]interface{}) []map[string]interface{} {
+	if filters == nil || filters.Len() == 0 {
+		return items
+	}
+
+	for _, f := range filters.List() {
+		fSet := f.(map[string]interface{})
+		keyword := fSet["name"].(string)
+
+		isReg := false
+		if regex, regexOk := fSet["regex"]; regexOk && regex != nil {
+			if strVal, strValOk := regex.(string); strValOk {
+				isReg = strVal == "1" || strVal == "true"
+			} else if boolVal, boolValOk := regex.(bool); boolValOk {
+				isReg = boolVal
+			}
+		}
+
+		check := func(filterVal, propertyVal string) bool {
+			if isReg {
+				re, err := regexp.Compile(filterVal)
+				if err != nil {
+					panic(fmt.Errorf(`Invalid regular expression "%s" for "%s" filter`, filterVal, keyword))
+				}
+				return re.MatchString(propertyVal)
+			} else {
+				return filterVal == propertyVal
+			}
+		}
+
+		orComparator := func(item map[string]interface{}) bool {
+			for _, val := range fSet["values"].([]interface{}) {
+
+				// if the property contains an array of strings
+				strArr, strArrOk := item[keyword].([]string)
+				if strArrOk {
+					for _, subStr := range strArr {
+						if check(val.(string), subStr) {
+							return true
+						}
+					}
+				}
+
+				// if the property is a literal string
+				str, strOk := item[keyword].(string)
+				if strOk && check(val.(string), str) {
+					return true
+				}
+			}
+			return false
+		}
+
+		items = filter(items, orComparator)
+	}
+
+	return items
+}
+
+func filter(items []map[string]interface{}, comparator func(map[string]interface{}) bool) []map[string]interface{} {
+	res := make([]map[string]interface{}, 0)
+	for _, item := range items {
+		if comparator(item) {
+			res = append(res, item)
+		}
+	}
+	return res
+}

--- a/filters.go
+++ b/filters.go
@@ -27,7 +27,7 @@ func dataSourceFiltersSchema() *schema.Schema {
 				},
 
 				"regex": {
-					Type:     schema.TypeString,
+					Type:     schema.TypeBool,
 					Optional: true,
 					Default:  false,
 				},

--- a/filters_test.go
+++ b/filters_test.go
@@ -1,0 +1,277 @@
+package main
+
+import (
+	"testing"
+
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// Filter function should select an item for which the compare function returns true
+func TestFilter(t *testing.T) {
+	items := []map[string]interface{}{
+		{"letter": "a"},
+		{"letter": "b"},
+		{"letter": "c"},
+	}
+
+	res := filter(items, func(item map[string]interface{}) bool {
+		return item["letter"] == "b"
+	})
+
+	if len(res) != 1 {
+		t.Errorf("Expected 1 result, got %d", len(res))
+	}
+}
+
+// Not supplying filters should not restrict results
+func TestApplyFilters_passThrough(t *testing.T) {
+	items := []map[string]interface{}{
+		{},
+		{},
+		{},
+	}
+
+	res := ApplyFilters(nil, items)
+	if len(res) != 3 {
+		t.Errorf("Expected 3 results, got %d", len(res))
+	}
+}
+
+// Filtering against a nonexistent property should throw no errors and return no results
+func TestApplyFilters_nonExistentProperty(t *testing.T) {
+	items := []map[string]interface{}{
+		{"letter": "a"},
+	}
+
+	filters := &schema.Set{F: func(interface{}) int { return 1 }}
+	filters.Add(map[string]interface{}{
+		"name":   "number",
+		"values": []interface{}{"1"},
+	})
+
+	res := ApplyFilters(filters, items)
+	if len(res) > 0 {
+		t.Errorf("Expected 0 results, got %d", len(res))
+	}
+}
+
+// Filtering against an empty resource set should not throw errors
+func TestApplyFilters_noResources(t *testing.T) {
+	items := []map[string]interface{}{}
+
+	filters := &schema.Set{F: func(interface{}) int { return 1 }}
+	filters.Add(map[string]interface{}{
+		"name":   "number",
+		"values": []interface{}{"1"},
+	})
+
+	res := ApplyFilters(filters, items)
+	if len(res) != 0 {
+		t.Errorf("Expected 0 results, got %d", len(res))
+	}
+}
+
+func TestApplyFilters_basic(t *testing.T) {
+	items := []map[string]interface{}{
+		{"letter": "a"},
+		{"letter": "b"},
+		{"letter": "c"},
+	}
+
+	filters := &schema.Set{F: func(interface{}) int { return 1 }}
+	filters.Add(map[string]interface{}{
+		"name":   "letter",
+		"values": []interface{}{"b"},
+	})
+
+	res := ApplyFilters(filters, items)
+	if len(res) != 1 {
+		t.Errorf("Expected 1 result, got %d", len(res))
+	}
+}
+
+func TestApplyFilters_duplicates(t *testing.T) {
+	items := []map[string]interface{}{
+		{"letter": "a"},
+		{"letter": "a"},
+		{"letter": "c"},
+	}
+
+	filters := &schema.Set{F: func(v interface{}) int {
+		return schema.HashString(v.(map[string]interface{})["name"])
+	}}
+	filters.Add(map[string]interface{}{
+		"name":   "letter",
+		"values": []interface{}{"a"},
+	})
+
+	res := ApplyFilters(filters, items)
+	if len(res) != 2 {
+		t.Errorf("Expected 2 results, got %d", len(res))
+	}
+}
+
+func TestApplyFilters_cascade(t *testing.T) {
+	items := []map[string]interface{}{
+		{"letter": "a"},
+		{"letter": "b"},
+		{"letter": "c"},
+	}
+
+	filters := &schema.Set{
+		F: func(v interface{}) int {
+			elems := v.(map[string]interface{})["values"].([]interface{})
+			res := make([]string, len(elems))
+			for i, v := range elems {
+				res[i] = v.(string)
+			}
+			return schema.HashString(strings.Join(res, ""))
+		},
+	}
+	filters.Add(map[string]interface{}{
+		"name":   "letter",
+		"values": []interface{}{"a", "b"},
+	})
+	filters.Add(map[string]interface{}{
+		"name":   "letter",
+		"values": []interface{}{"c"},
+	})
+
+	res := ApplyFilters(filters, items)
+	if len(res) != 0 {
+		t.Errorf("Expected 0 results, got %d", len(res))
+	}
+}
+
+func TestApplyFilters_regex(t *testing.T) {
+	items := []map[string]interface{}{
+		{"string": "xblx:PHX-AD-1"},
+		{"string": "xblx:PHX-AD-2"},
+		{"string": "xblx:PHX-AD-3"},
+	}
+
+	filters := &schema.Set{F: func(v interface{}) int {
+		return schema.HashString(v.(map[string]interface{})["name"])
+	}}
+	filters.Add(map[string]interface{}{
+		"name":   "string",
+		"values": []interface{}{"\\w*:PHX-AD-2"},
+		"regex":  true,
+	})
+
+	res := ApplyFilters(filters, items)
+	if len(res) != 1 {
+		t.Errorf("Expected 1 result, got %d", len(res))
+	}
+}
+
+// Invalid regex should throw an error
+func TestApplyFilters_regexPanic(t *testing.T) {
+	defer func() {
+		err := recover()
+		if err == nil {
+			t.Errorf("Expected regex compile error was not thrown")
+		} else {
+			if err.(error).Error() != `Invalid regular expression ")(" for "string" filter` {
+				t.Errorf("Unexpected regex compile error:\n%s", err)
+			}
+		}
+	}()
+
+	items := []map[string]interface{}{
+		{"string": "xblx:PHX-AD-1"},
+	}
+
+	filters := &schema.Set{F: func(v interface{}) int {
+		return schema.HashString(v.(map[string]interface{})["name"])
+	}}
+	filters.Add(map[string]interface{}{
+		"name":   "string",
+		"values": []interface{}{")("},
+		"regex":  true,
+	})
+
+	ApplyFilters(filters, items)
+}
+
+// Filters should test against an array of strings
+func TestApplyFilters_arrayOfStrings(t *testing.T) {
+	items := []map[string]interface{}{
+		{"letters": []string{"a"}},
+		{"letters": []string{"b", "c"}},
+		{"letters": []string{"c", "d", "e"}},
+		{"letters": []string{"e", "f"}},
+	}
+
+	filters := &schema.Set{F: func(interface{}) int { return 1 }}
+	filters.Add(map[string]interface{}{
+		"name":   "letters",
+		"values": []interface{}{"a", "c"},
+	})
+
+	res := ApplyFilters(filters, items)
+	if len(res) != 3 {
+		t.Errorf("Expected 3 result, got %d", len(res))
+	}
+
+	filters = &schema.Set{F: func(interface{}) int { return 1 }}
+	filters.Add(map[string]interface{}{
+		"name":   "letters",
+		"values": []interface{}{"a", "f"},
+	})
+
+	res = ApplyFilters(filters, items)
+	if len(res) != 2 {
+		t.Errorf("Expected 2 result, got %d", len(res))
+	}
+}
+
+func TestApplyFilters_multiProperty(t *testing.T) {
+	items := []map[string]interface{}{
+		{
+			"letter": "a",
+			"number": "1",
+			"symbol": "!",
+		},
+		{
+			"letter": "b",
+			"number": "2",
+			"symbol": "@",
+		},
+		{
+			"letter": "c",
+			"number": "3",
+			"symbol": "#",
+		},
+		{
+			"letter": "d",
+			"number": "4",
+			"symbol": "$",
+		},
+	}
+
+	filters := &schema.Set{
+		F: func(v interface{}) int {
+			return schema.HashString(v.(map[string]interface{})["name"])
+		},
+	}
+	filters.Add(map[string]interface{}{
+		"name":   "letter",
+		"values": []interface{}{"a", "b", "c"},
+	})
+	filters.Add(map[string]interface{}{
+		"name":   "number",
+		"values": []interface{}{"2", "3", "4"},
+	})
+	filters.Add(map[string]interface{}{
+		"name":   "symbol",
+		"values": []interface{}{"#", "$"},
+	})
+
+	res := ApplyFilters(filters, items)
+	if len(res) != 1 {
+		t.Errorf("Expected 1 result, got %d", len(res))
+	}
+}

--- a/filters_test.go
+++ b/filters_test.go
@@ -113,7 +113,35 @@ func TestApplyFilters_duplicates(t *testing.T) {
 	}
 }
 
-func TestApplyFilters_cascade(t *testing.T) {
+func TestApplyFilters_OR(t *testing.T) {
+	items := []map[string]interface{}{
+		{"letter": "a"},
+		{"letter": "b"},
+		{"letter": "c"},
+	}
+
+	filters := &schema.Set{
+		F: func(v interface{}) int {
+			elems := v.(map[string]interface{})["values"].([]interface{})
+			res := make([]string, len(elems))
+			for i, v := range elems {
+				res[i] = v.(string)
+			}
+			return schema.HashString(strings.Join(res, ""))
+		},
+	}
+	filters.Add(map[string]interface{}{
+		"name":   "letter",
+		"values": []interface{}{"a", "b"},
+	})
+
+	res := ApplyFilters(filters, items)
+	if len(res) != 2 {
+		t.Errorf("Expected 2 results, got %d", len(res))
+	}
+}
+
+func TestApplyFilters_cascadeAND(t *testing.T) {
 	items := []map[string]interface{}{
 		{"letter": "a"},
 		{"letter": "b"},

--- a/test_helpers.go
+++ b/test_helpers.go
@@ -28,8 +28,10 @@ func timestamp() string {
 		t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond())
 }
 
+type TokenFn func(string, map[string]string) string
+
 // Creates a form of "apply" above that will always supply the same value for {{.token}}
-func tokenize() (string, func(string, map[string]string) string) {
+func tokenize() (string, TokenFn) {
 	ts := timestamp()
 	return ts, func(template string, values map[string]string) string {
 		if values == nil {


### PR DESCRIPTION
* supports multiple filter declarations that cascade as _and_ filters
* multiple values per filter function as _or_ filters
* optional regex

Tests:
go test -run Test.*Filter
make test run=TestDatasourceIdentity