### PR TITLE
Update example image version to Oracle Linux 7.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .terraform
 terraform.tfstate*
+.terraform.tfstate.lock.info
 tf.plan
 *.tfvars
 *.orig

--- a/data_source_obmcs_core_images_test.go
+++ b/data_source_obmcs_core_images_test.go
@@ -41,7 +41,7 @@ func (s *DatasourceCoreImageTestSuite) TestAccImage_basic() {
 				data "oci_core_images" "t" {
 					compartment_id = "${var.compartment_id}"
 					operating_system = "Oracle Linux"
-					operating_system_version = "7.3"
+					operating_system_version = "7.4"
 				
 					filter {
 						name = "display_name"
@@ -56,7 +56,7 @@ func (s *DatasourceCoreImageTestSuite) TestAccImage_basic() {
 					resource.TestCheckResourceAttr(s.ResourceName, "images.0.display_name", "Oracle-Linux-7.3-2017.07.17-1"),
 					resource.TestCheckResourceAttr(s.ResourceName, "images.0.state", "AVAILABLE"),
 					resource.TestCheckResourceAttr(s.ResourceName, "images.0.operating_system", "Oracle Linux"),
-					resource.TestCheckResourceAttr(s.ResourceName, "images.0.operating_system_version", "7.3"),
+					resource.TestCheckResourceAttr(s.ResourceName, "images.0.operating_system_version", "7.4"),
 					resource.TestCheckResourceAttrSet(s.ResourceName, "images.0.time_created"),
 				),
 			},

--- a/data_source_obmcs_core_instances_test.go
+++ b/data_source_obmcs_core_instances_test.go
@@ -53,7 +53,7 @@ func (s *DatasourceCoreInstanceTestSuite) SetupTest() {
 	data "oci_core_images" "t" {
 		compartment_id = "${var.compartment_id}"
 		operating_system = "Oracle Linux"
-		operating_system_version = "7.3"
+		operating_system_version = "7.4"
 		limit = 1
 	}
 

--- a/docs/examples/clusters/Mongodb/variables.tf
+++ b/docs/examples/clusters/Mongodb/variables.tf
@@ -22,7 +22,7 @@ variable "InstanceOS" {
 }
 
 variable "InstanceOSVersion" {
-    default = "7.3"
+    default = "7.4"
 }
 
 variable "VPC-CIDR" {

--- a/docs/examples/compute/extended_metadata/extended_metadata.tf
+++ b/docs/examples/compute/extended_metadata/extended_metadata.tf
@@ -32,7 +32,7 @@ data "oci_identity_availability_domains" "ADs" {
 data "oci_core_images" "OLImageOCID" {
     compartment_id = "${var.compartment_ocid}"
     operating_system = "Oracle Linux"
-    operating_system_version = "7.3"
+    operating_system_version = "7.4"
 }
 
 # Gets a list of vNIC attachments on the instance

--- a/docs/examples/compute/instance/variables.tf
+++ b/docs/examples/compute/instance/variables.tf
@@ -24,7 +24,7 @@ variable "InstanceOS" {
 }
 
 variable "InstanceOSVersion" {
-    default = "7.3"
+    default = "7.4"
 }
 
 variable "DBSize" {

--- a/docs/examples/compute/instance_lite/instance_lite.tf
+++ b/docs/examples/compute/instance_lite/instance_lite.tf
@@ -30,7 +30,7 @@ data "oci_identity_availability_domains" "ADs" {
 data "oci_core_images" "image-list" {
   compartment_id = "${var.compartment_ocid}"
   operating_system = "Oracle Linux"
-  operating_system_version = "7.3"
+  operating_system_version = "7.4"
 }
 
 resource "oci_core_instance" "instance1" {

--- a/docs/examples/compute/multi_vnic/multi_vnic.tf
+++ b/docs/examples/compute/multi_vnic/multi_vnic.tf
@@ -24,7 +24,7 @@ variable "InstanceOS" {
 }
 
 variable "InstanceOSVersion" {
-    default = "7.3"
+    default = "7.4"
 }
 
 provider "oci" {

--- a/docs/examples/compute/private_ip/private_ip.tf
+++ b/docs/examples/compute/private_ip/private_ip.tf
@@ -33,7 +33,7 @@ data "oci_identity_availability_domains" "ADs" {
 data "oci_core_images" "OLImageOCID" {
     compartment_id = "${var.compartment_ocid}"
     operating_system = "Oracle Linux"
-    operating_system_version = "7.3"
+    operating_system_version = "7.4"
 }
 
 # Create Instance

--- a/docs/examples/load_balancer/lb_full/lb_full.tf
+++ b/docs/examples/load_balancer/lb_full/lb_full.tf
@@ -123,7 +123,7 @@ resource "oci_core_security_list" "securitylist1" {
 data "oci_core_images" "image-list" {
   compartment_id = "${var.compartment_ocid}"
   operating_system = "Oracle Linux"
-  operating_system_version = "7.3"
+  operating_system_version = "7.4"
 }
 
 resource "oci_core_instance" "instance1" {

--- a/docs/examples/storage/nfs/variables.tf
+++ b/docs/examples/storage/nfs/variables.tf
@@ -24,7 +24,7 @@ variable "InstanceOS" {
 }
 
 variable "InstanceOSVersion" {
-    default = "7.3"
+    default = "7.4"
 }
 
 variable "2TB" {

--- a/docs/solutions/chef/variables.tf
+++ b/docs/solutions/chef/variables.tf
@@ -24,7 +24,7 @@ variable "InstanceOS" {
 }
 
 variable "InstanceOSVersion" {
-  default = "7.3"
+  default = "7.4"
 }
 
 variable "BootStrapFile" {

--- a/provider_test.go
+++ b/provider_test.go
@@ -82,7 +82,7 @@ var instanceConfig = subnetConfig + `
 data "oci_core_images" "t" {
 	compartment_id = "${var.compartment_id}"
   	operating_system = "Oracle Linux"
-  	operating_system_version = "7.3"
+  	operating_system_version = "7.4"
   	limit = 1
 }
 
@@ -144,7 +144,7 @@ resource "oci_core_subnet" "t" {
 data "oci_core_images" "t" {
 	compartment_id = "${var.compartment_id}"
   	operating_system = "Oracle Linux"
-  	operating_system_version = "7.3"
+  	operating_system_version = "7.4"
   	limit = 1
 }
 

--- a/resource_obmcs_core_instance_test.go
+++ b/resource_obmcs_core_instance_test.go
@@ -59,7 +59,7 @@ func (s *ResourceCoreInstanceTestSuite) SetupTest() {
 	data "oci_core_images" "t" {
 		compartment_id = "${var.compartment_id}"
 		operating_system = "Oracle Linux"
-		operating_system_version = "7.3"
+		operating_system_version = "7.4"
 		limit = 1
 	}`
 

--- a/resource_obmcs_core_volume_attachment_test.go
+++ b/resource_obmcs_core_volume_attachment_test.go
@@ -52,7 +52,7 @@ func (s *ResourceCoreVolumeAttachmentTestSuite) SetupTest() {
 	data "oci_core_images" "t" {
 		compartment_id = "${var.compartment_id}"
 		operating_system = "Oracle Linux"
-		operating_system_version = "7.3"
+		operating_system_version = "7.4"
 		limit = 1
 	}
 	

--- a/test_templates.go
+++ b/test_templates.go
@@ -57,7 +57,7 @@ func testImage1() string {
 	data "oci_core_images" "t" {
 		compartment_id = "${var.compartment_ocid}"
 		operating_system = "Oracle Linux"
-		operating_system_version = "7.3"
+		operating_system_version = "7.4"
 		limit = 1
 	}`
 }


### PR DESCRIPTION
Many of our examples and tests default to using Oracle Linux 7.3.
While 7.3 images can still be used if you know the OCID, they are no longer
returned by ListImages. Updating to 7.4 for now, but this is a short term
solution while we determine the correct way to handle updates to ListImages.