### PR TITLE
Filter image on display name

### DIFF
--- a/data_source_obmcs_core_instances_test.go
+++ b/data_source_obmcs_core_instances_test.go
@@ -52,9 +52,7 @@ func (s *DatasourceCoreInstanceTestSuite) SetupTest() {
 
 	data "oci_core_images" "t" {
 		compartment_id = "${var.compartment_id}"
-		operating_system = "Oracle Linux"
-		operating_system_version = "7.4"
-		limit = 1
+		display_name = "Oracle-Linux-7.4-2017.10.25-0"
 	}
 
 	resource "oci_core_instance" "t" {

--- a/docs/examples/clusters/Mongodb/datasources.tf
+++ b/docs/examples/clusters/Mongodb/datasources.tf
@@ -3,11 +3,11 @@ data "oci_identity_availability_domains" "ADs" {
   compartment_id = "${var.tenancy_ocid}"
 }
 
-# Gets the OCID of the OS image to use
+# Gets the OCID of the image. This technique is for example purposes only. The results of oci_core_images may
+# change over time for Oracle-provided images, so the only sure way to get the correct OCID is to supply it directly.
 data "oci_core_images" "OLImageOCID" {
     compartment_id = "${var.compartment_ocid}"
-    operating_system = "${var.InstanceOS}"
-    operating_system_version = "${var.InstanceOSVersion}"
+    display_name = "${var.InstanceImageDisplayName}"
 }
 
 # Gets a list of vNIC attachments on the bastion host

--- a/docs/examples/clusters/Mongodb/variables.tf
+++ b/docs/examples/clusters/Mongodb/variables.tf
@@ -17,12 +17,8 @@ variable "MongoDBShape" {
     default = "BM.DenseIO1.36"
 }
 
-variable "InstanceOS" {
-    default = "Oracle Linux"
-}
-
-variable "InstanceOSVersion" {
-    default = "7.4"
+variable "InstanceImageDisplayName" {
+    default = "Oracle-Linux-7.4-2017.10.25-0"
 }
 
 variable "VPC-CIDR" {

--- a/docs/examples/compute/extended_metadata/extended_metadata.tf
+++ b/docs/examples/compute/extended_metadata/extended_metadata.tf
@@ -28,11 +28,11 @@ data "oci_identity_availability_domains" "ADs" {
     compartment_id = "${var.tenancy_ocid}"
 }
 
-# Gets the OCID of the OS image to use
+# Gets the OCID of the image. This technique is for example purposes only. The results of oci_core_images may
+# change over time for Oracle-provided images, so the only sure way to get the correct OCID is to supply it directly.
 data "oci_core_images" "OLImageOCID" {
     compartment_id = "${var.compartment_ocid}"
-    operating_system = "Oracle Linux"
-    operating_system_version = "7.4"
+    display_name = "Oracle-Linux-7.4-2017.10.25-0"
 }
 
 # Gets a list of vNIC attachments on the instance

--- a/docs/examples/compute/instance/datasources.tf
+++ b/docs/examples/compute/instance/datasources.tf
@@ -3,11 +3,11 @@ data "oci_identity_availability_domains" "ADs" {
   compartment_id = "${var.tenancy_ocid}"
 }
 
-# Gets the OCID of the OS image to use
+# Gets the OCID of the image. This technique is for example purposes only. The results of oci_core_images may
+# change over time for Oracle-provided images, so the only sure way to get the correct OCID is to supply it directly.
 data "oci_core_images" "OLImageOCID" {
     compartment_id = "${var.compartment_ocid}"
-    operating_system = "${var.InstanceOS}"
-    operating_system_version = "${var.InstanceOSVersion}"
+    display_name = "${var.InstanceImageDisplayName}"
 }
 
 # Gets a list of vNIC attachments on the instance

--- a/docs/examples/compute/instance/variables.tf
+++ b/docs/examples/compute/instance/variables.tf
@@ -19,12 +19,8 @@ variable "InstanceShape" {
     default = "VM.Standard1.2"
 }
 
-variable "InstanceOS" {
-    default = "Oracle Linux"
-}
-
-variable "InstanceOSVersion" {
-    default = "7.4"
+variable "InstanceImageDisplayName" {
+    default = "Oracle-Linux-7.4-2017.10.25-0"
 }
 
 variable "DBSize" {

--- a/docs/examples/compute/instance_lite/instance_lite.tf
+++ b/docs/examples/compute/instance_lite/instance_lite.tf
@@ -27,10 +27,11 @@ data "oci_identity_availability_domains" "ADs" {
 
 /* Instances */
 
+# Gets the OCID of the image. This technique is for example purposes only. The results of oci_core_images may
+# change over time for Oracle-provided images, so the only sure way to get the correct OCID is to supply it directly.
 data "oci_core_images" "image-list" {
-  compartment_id = "${var.compartment_ocid}"
-  operating_system = "Oracle Linux"
-  operating_system_version = "7.4"
+    compartment_id = "${var.compartment_ocid}"
+    display_name = "Oracle-Linux-7.4-2017.10.25-0"
 }
 
 resource "oci_core_instance" "instance1" {

--- a/docs/examples/compute/multi_vnic/multi_vnic.tf
+++ b/docs/examples/compute/multi_vnic/multi_vnic.tf
@@ -19,12 +19,8 @@ variable "InstanceShape" {
     default = "VM.Standard1.8"
 }
 
-variable "InstanceOS" {
-    default = "Oracle Linux"
-}
-
-variable "InstanceOSVersion" {
-    default = "7.4"
+variable "InstanceImageDisplayName" {
+    default = "Oracle-Linux-7.4-2017.10.25-0"
 }
 
 provider "oci" {
@@ -58,11 +54,11 @@ resource "oci_core_subnet" "ExampleSubnet" {
   dns_label = "examplesubnet"
 }
 
-# Gets the OCID of the OS image to use
+# Gets the OCID of the image. This technique is for example purposes only. The results of oci_core_images may
+# change over time for Oracle-provided images, so the only sure way to get the correct OCID is to supply it directly.
 data "oci_core_images" "OLImageOCID" {
     compartment_id = "${var.compartment_ocid}"
-    operating_system = "${var.InstanceOS}"
-    operating_system_version = "${var.InstanceOSVersion}"
+    display_name = "${var.InstanceImageDisplayName}"
 }
 
 resource "oci_core_instance" "ExampleInstance" {

--- a/docs/examples/compute/private_ip/private_ip.tf
+++ b/docs/examples/compute/private_ip/private_ip.tf
@@ -29,11 +29,11 @@ data "oci_identity_availability_domains" "ADs" {
     compartment_id = "${var.tenancy_ocid}"
 }
 
-# Gets the OCID of the OS image to use
+# Gets the OCID of the image. This technique is for example purposes only. The results of oci_core_images may
+# change over time for Oracle-provided images, so the only sure way to get the correct OCID is to supply it directly.
 data "oci_core_images" "OLImageOCID" {
     compartment_id = "${var.compartment_ocid}"
-    operating_system = "Oracle Linux"
-    operating_system_version = "7.4"
+    display_name = "Oracle-Linux-7.4-2017.10.25-0"
 }
 
 # Create Instance

--- a/docs/examples/load_balancer/lb_full/lb_full.tf
+++ b/docs/examples/load_balancer/lb_full/lb_full.tf
@@ -120,10 +120,11 @@ resource "oci_core_security_list" "securitylist1" {
 
 /* Instances */
 
+# Gets the OCID of the image. This technique is for example purposes only. The results of oci_core_images may
+# change over time for Oracle-provided images, so the only sure way to get the correct OCID is to supply it directly.
 data "oci_core_images" "image-list" {
-  compartment_id = "${var.compartment_ocid}"
-  operating_system = "Oracle Linux"
-  operating_system_version = "7.4"
+    compartment_id = "${var.compartment_ocid}"
+    display_name = "Oracle-Linux-7.4-2017.10.25-0"
 }
 
 resource "oci_core_instance" "instance1" {

--- a/docs/examples/networking/hybrid_dns/dns.tf
+++ b/docs/examples/networking/hybrid_dns/dns.tf
@@ -21,12 +21,8 @@ variable "InstanceShape" {
     default = "VM.Standard1.1"
 }
 
-variable "InstanceOS" {
-    default = "Oracle Linux"
-}
-
-variable "InstanceOSVersion" {
-    default = "7.4"
+variable "InstanceImageDisplayName" {
+    default = "Oracle-Linux-7.4-2017.10.25-0"
 }
 
 variable "vcn_cidr" {
@@ -187,11 +183,11 @@ resource "oci_core_subnet" "MgmtSubnet2" {
     dhcp_options_id = "${oci_core_dhcp_options.MgmtDhcpOptions.id}"
 }
 
-# Gets the OCID of the OS image to use
+# Gets the OCID of the image. This technique is for example purposes only. The results of oci_core_images may
+# change over time for Oracle-provided images, so the only sure way to get the correct OCID is to supply it directly.
 data "oci_core_images" "OLImageOCID" {
     compartment_id = "${var.compartment_ocid}"
-    operating_system = "${var.InstanceOS}"
-    operating_system_version = "${var.InstanceOSVersion}"
+    display_name = "${var.InstanceImageDisplayName}"
 }
 
 resource "oci_core_instance" "DnsVM" {

--- a/docs/examples/networking/hybrid_dns/env-vars
+++ b/docs/examples/networking/hybrid_dns/env-vars
@@ -20,8 +20,7 @@ export TF_VAR_private_subnet_cidr=""
 
 ### Instance configuration
 export TF_VAR_InstanceShape=""
-export TF_VAR_InstanceOS=""
-export TF_VAR_InstanceOSVersion=""
+export TF_VAR_InstanceImageDisplayName=""
 
 ### Instance credentials
 export TF_VAR_ssh_public_key=$(cat .../id_rsa.pub)

--- a/docs/examples/networking/nat/nat.tf
+++ b/docs/examples/networking/nat/nat.tf
@@ -15,12 +15,8 @@ variable "InstanceShape" {
     default = "VM.Standard1.2"
 }
 
-variable "InstanceOS" {
-    default = "Oracle Linux"
-}
-
-variable "InstanceOSVersion" {
-    default = "7.4"
+variable "InstanceImageDisplayName" {
+    default = "Oracle-Linux-7.4-2017.10.25-0"
 }
 
 variable "vcn_cidr" {
@@ -128,11 +124,11 @@ resource "oci_core_subnet" "MgmtSubnet" {
     dhcp_options_id = "${oci_core_virtual_network.CoreVCN.default_dhcp_options_id}"
 }
 
-# Gets the OCID of the OS image to use
+# Gets the OCID of the image. This technique is for example purposes only. The results of oci_core_images may
+# change over time for Oracle-provided images, so the only sure way to get the correct OCID is to supply it directly.
 data "oci_core_images" "OLImageOCID" {
     compartment_id = "${var.compartment_ocid}"
-    operating_system = "${var.InstanceOS}"
-    operating_system_version = "${var.InstanceOSVersion}"
+    display_name = "${var.InstanceImageDisplayName}"
 }
 
 resource "oci_core_instance" "NatInstance" {

--- a/docs/examples/storage/nfs/datasources.tf
+++ b/docs/examples/storage/nfs/datasources.tf
@@ -3,11 +3,11 @@ data "oci_identity_availability_domains" "ADs" {
   compartment_id = "${var.tenancy_ocid}"
 }
 
-# Gets the OCID of the OS image to use
+# Gets the OCID of the image. This technique is for example purposes only. The results of oci_core_images may
+# change over time for Oracle-provided images, so the only sure way to get the correct OCID is to supply it directly.
 data "oci_core_images" "OLImageOCID" {
     compartment_id = "${var.compartment_ocid}"
-    operating_system = "${var.InstanceOS}"
-    operating_system_version = "${var.InstanceOSVersion}"
+    display_name = "${var.InstanceImageDisplayName}"
 }
 
 # Gets a list of vNIC attachments on the instance

--- a/docs/examples/storage/nfs/variables.tf
+++ b/docs/examples/storage/nfs/variables.tf
@@ -19,12 +19,8 @@ variable "InstanceShape" {
     default = "VM.Standard1.4"
 }
 
-variable "InstanceOS" {
-    default = "Oracle Linux"
-}
-
-variable "InstanceOSVersion" {
-    default = "7.4"
+variable "InstanceImageDisplayName" {
+    default = "Oracle-Linux-7.4-2017.10.25-0"
 }
 
 variable "2TB" {

--- a/docs/solutions/chef/datasources.tf
+++ b/docs/solutions/chef/datasources.tf
@@ -3,11 +3,11 @@ data "oci_identity_availability_domains" "ADs" {
   compartment_id = "${var.tenancy_ocid}"
 }
 
-# Gets the OCID of the OS image to use
+# Gets the OCID of the image. This technique is for example purposes only. The results of oci_core_images may
+# change over time for Oracle-provided images, so the only sure way to get the correct OCID is to supply it directly.
 data "oci_core_images" "OLImageOCID" {
-  compartment_id = "${var.compartment_ocid}"
-  operating_system = "${var.InstanceOS}"
-  operating_system_version = "${var.InstanceOSVersion}"
+    compartment_id = "${var.compartment_ocid}"
+    display_name = "${var.InstanceImageDisplayName}"
 }
 
 # Gets a list of vNIC attachments on the instance

--- a/docs/solutions/chef/variables.tf
+++ b/docs/solutions/chef/variables.tf
@@ -19,12 +19,8 @@ variable "InstanceShape" {
   default = "VM.Standard1.2"
 }
 
-variable "InstanceOS" {
-  default = "Oracle Linux"
-}
-
-variable "InstanceOSVersion" {
-  default = "7.4"
+variable "InstanceImageDisplayName" {
+    default = "Oracle-Linux-7.4-2017.10.25-0"
 }
 
 variable "BootStrapFile" {

--- a/provider_test.go
+++ b/provider_test.go
@@ -81,9 +81,7 @@ resource "oci_core_subnet" "WebSubnetAD1" {
 var instanceConfig = subnetConfig + `
 data "oci_core_images" "t" {
 	compartment_id = "${var.compartment_id}"
-  	operating_system = "Oracle Linux"
-  	operating_system_version = "7.4"
-  	limit = 1
+  	display_name = "Oracle-Linux-7.4-2017.10.25-0"
 }
 
 data "oci_identity_policies" "policies" {
@@ -143,9 +141,7 @@ resource "oci_core_subnet" "t" {
 
 data "oci_core_images" "t" {
 	compartment_id = "${var.compartment_id}"
-  	operating_system = "Oracle Linux"
-  	operating_system_version = "7.4"
-  	limit = 1
+  	display_name = "Oracle-Linux-7.4-2017.10.25-0"
 }
 
 resource "oci_core_instance" "t" {

--- a/resource_obmcs_core_instance_test.go
+++ b/resource_obmcs_core_instance_test.go
@@ -58,9 +58,7 @@ func (s *ResourceCoreInstanceTestSuite) SetupTest() {
 	
 	data "oci_core_images" "t" {
 		compartment_id = "${var.compartment_id}"
-		operating_system = "Oracle Linux"
-		operating_system_version = "7.4"
-		limit = 1
+		display_name = "Oracle-Linux-7.4-2017.10.25-0"
 	}`
 
 	s.ResourceName = "oci_core_instance.t"

--- a/resource_obmcs_core_volume_attachment_test.go
+++ b/resource_obmcs_core_volume_attachment_test.go
@@ -51,9 +51,7 @@ func (s *ResourceCoreVolumeAttachmentTestSuite) SetupTest() {
 
 	data "oci_core_images" "t" {
 		compartment_id = "${var.compartment_id}"
-		operating_system = "Oracle Linux"
-		operating_system_version = "7.4"
-		limit = 1
+		display_name = "Oracle-Linux-7.4-2017.10.25-0"
 	}
 	
 	resource "oci_core_instance" "t" {

--- a/test_templates.go
+++ b/test_templates.go
@@ -56,9 +56,7 @@ func testImage1() string {
 	return `
 	data "oci_core_images" "t" {
 		compartment_id = "${var.compartment_ocid}"
-		operating_system = "Oracle Linux"
-		operating_system_version = "7.4"
-		limit = 1
+		display_name = "Oracle-Linux-7.4-2017.10.25-0"
 	}`
 }
 


### PR DESCRIPTION
This is temporary fix for issue #345. As noted in each example usage
of oci_core_images, the images returned may change over time - a longer
term solution is in the works.

I've applied a sampling of these examples, but I have run plan on all of them which should find any mistakes with variable naming.