### PR TITLE
Add support for block volume fast clones

### DIFF
--- a/data_source_obmcs_core_volumes.go
+++ b/data_source_obmcs_core_volumes.go
@@ -103,6 +103,14 @@ func (s *VolumeDatasourceCrud) SetData() {
 			"state":               v.State,
 			"time_created":        v.TimeCreated.String(),
 		}
+
+		if vsdRaw := v.VolumeSourceDetails; vsdRaw != nil {
+			vsd := make(map[string]interface{})
+			vsd["id"] = vsdRaw.Id
+			vsd["type"] = vsdRaw.Type
+			vol["source_details"] = []interface{}{vsd}
+		}
+
 		resources = append(resources, vol)
 	}
 

--- a/docs/datasources/core/volumes.md
+++ b/docs/datasources/core/volumes.md
@@ -38,3 +38,4 @@ The following attributes are exported:
 * `state` - The current state of the volume. Allowed values are: [PROVISIONING, RESTORING, AVAILABLE, TERMINATING, TERMINATED, FAULTY]
 * `size_in_gbs` - The size of the volume, in GBs. The size must be a multiple of 1024.
 * `time_created` - The date and time the Volume was created, in the format defined by RFC3339.  Example: `2016-08-25T21:10:29.600Z`.
+* `source_details` - Specifies the volume source details for a new Block Volume.

--- a/docs/resources/core/volume.md
+++ b/docs/resources/core/volume.md
@@ -1,6 +1,6 @@
 # oci\_core\_volumes
 
-Gets a list of volumes in a compartment.
+Create a volume.
 
 ## Example Usage
 
@@ -8,8 +8,8 @@ Gets a list of volumes in a compartment.
 resource "oci_core_volume" "t" {
     availability_domain = "availability_domain"
     compartment_id = "compartment_id"
-    size_in_gbs = 50
     volume_backup_id = "volume_id"
+    size_in_gbs = 50
 }
 ```
 
@@ -21,6 +21,27 @@ The following arguments are supported:
 * `compartment_id` - (Required) The OCID of the compartment.
 * `display_name` - (Optional) A user-friendly name. Does not have to be unique, and it's changeable.
 * `volume_backup_id` - (Optional) The OCID of the volume backup from which the data should be restored on the newly created volume.
+* `source_details` - (Optional) Specifies the volume source details for a new Block Volume. 
+See [Source Details](https://docs.us-phoenix-1.oraclecloud.com/api/#/en/iaas/20160918/requests/CreateVolumeDetails) documentation.
+Example usage: 
+```
+resource "oci_core_volume" "t" {
+    
+    source_details {
+        type = "volume"
+        id = "${var.volume_id}"
+    }
+     
+    // or
+     
+    source_details {
+        type = "volumeBackup"
+        id = "${var.volume_backup_id}" // note: this requires an oci_core_volume_backup resource OCID
+    }
+    ...
+}
+```
+
 
 ## Attributes Reference
 * `availability_domain` - The availability domain of the volume.
@@ -31,3 +52,4 @@ The following arguments are supported:
 * `size_in_mbs` - (Deprecated) The size of the volume, in MBs.
 * `size_in_gbs` - The size of the volume, in GBs.
 * `time_created` - The date and time the Volume was created.
+* `source_details` - Specifies the volume source details for a new Block Volume.

--- a/vendor/github.com/oracle/bmcs-go-sdk/core_volume.go
+++ b/vendor/github.com/oracle/bmcs-go-sdk/core_volume.go
@@ -10,14 +10,15 @@ import "net/http"
 type Volume struct {
 	OPCRequestIDUnmarshaller
 	ETagUnmarshaller
-	AvailabilityDomain string `json:"availabilityDomain"`
-	CompartmentID      string `json:"compartmentId"`
-	DisplayName        string `json:"displayName"`
-	ID                 string `json:"id"`
-	SizeInMBs          int    `json:"sizeInMBs"`
-	SizeInGBs          int    `json:"sizeInGBs"`
-	State              string `json:"lifecycleState"`
-	TimeCreated        Time   `json:"timeCreated"`
+	VolumeSourceDetails *VolumeSourceDetails `json:"sourceDetails,omitempty"`
+	AvailabilityDomain  string               `json:"availabilityDomain"`
+	CompartmentID       string               `json:"compartmentId"`
+	DisplayName         string               `json:"displayName"`
+	ID                  string               `json:"id"`
+	SizeInMBs           int                  `json:"sizeInMBs"`
+	SizeInGBs           int                  `json:"sizeInGBs"`
+	State               string               `json:"lifecycleState"`
+	TimeCreated         Time                 `json:"timeCreated"`
 }
 
 // ListVolumes contains a list of block volumes

--- a/vendor/github.com/oracle/bmcs-go-sdk/request_options.go
+++ b/vendor/github.com/oracle/bmcs-go-sdk/request_options.go
@@ -159,11 +159,17 @@ type UpdateVnicOptions struct {
 	SkipSourceDestCheck *bool  `header:"-" json:"skipSourceDestCheck,omitempty" url:"-"`
 }
 
+type VolumeSourceDetails struct {
+	Id   string `header:"-" json:"id" url:"-"`
+	Type string `header:"-" json:"type" url:"-"`
+}
+
 type CreateVolumeOptions struct {
 	CreateOptions
-	SizeInMBs      int    `header:"-" json:"sizeInMBs,omitempty" url:"-"`
-	SizeInGBs      int    `header:"-" json:"sizeInGBs,omitempty" url:"-"`
-	VolumeBackupID string `header:"-" json:"volumeBackupId,omitempty" url:"-"`
+	SizeInMBs           int                  `header:"-" json:"sizeInMBs,omitempty" url:"-"`
+	SizeInGBs           int                  `header:"-" json:"sizeInGBs,omitempty" url:"-"`
+	VolumeBackupID      string               `header:"-" json:"volumeBackupId,omitempty" url:"-"`
+	VolumeSourceDetails *VolumeSourceDetails `header:"-" json:"sourceDetails,omitempty" url:"-"`
 }
 
 type CreatePolicyOptions struct {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2972,10 +2972,10 @@
 			"revisionTime": "2017-01-25T16:36:56Z"
 		},
 		{
-			"checksumSHA1": "Swv3Qr8tQWyEN9KlAYC6eyD1J8E=",
+			"checksumSHA1": "FZuTNT1Cksd4WxwAFXS42LvbOtA=",
 			"path": "github.com/oracle/bmcs-go-sdk",
-			"revision": "b4d4e32d4024fff11c732f5e3721c86c418b35ff",
-			"revisionTime": "2017-10-20T22:37:45Z",
+			"revision": "79eba688b52b26d9b38e71860e69cd671fed7979",
+			"revisionTime": "2017-11-01T22:20:57Z",
 			"version": "add-db-license-model",
 			"versionExact": "add-db-license-model"
 		},


### PR DESCRIPTION
* Support creating clones from a running instance or a volume backup

Tests run: 
`make test run=Test.*CoreVolume.*`

specifically: 
* TestResourceCoreVolumeTestSuite
* TestResourceCoreVolumeBackupTestSuite
* TestDatasourceCoreVolumeTestSuite