### PR TITLE
Prevent block volume fast clones from being ready until hydrated

### DIFF
--- a/resource_obmcs_core_volume_test.go
+++ b/resource_obmcs_core_volume_test.go
@@ -63,6 +63,7 @@ func (s *ResourceCoreVolumeTestSuite) TestCreateResourceCoreVolume_basic() {
 					resource.TestCheckResourceAttrSet(s.ResourceName, "id"),
 					resource.TestCheckResourceAttrSet(s.ResourceName, "availability_domain"),
 					resource.TestCheckResourceAttrSet(s.ResourceName, "display_name"),
+					resource.TestCheckResourceAttr(s.ResourceName, "is_hydrated", "true"),
 					resource.TestCheckResourceAttr(s.ResourceName, "size_in_mbs", "51200"),
 					resource.TestCheckResourceAttr(s.ResourceName, "state", baremetal.ResourceAvailable),
 				),
@@ -122,6 +123,7 @@ func (s *ResourceCoreVolumeTestSuite) TestCreateResourceCoreVolume_basic() {
 				}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("oci_core_volume.u", "source_details.0.id"),
+					resource.TestCheckResourceAttr("oci_core_volume.u", "is_hydrated", "true"),
 					resource.TestCheckResourceAttr("oci_core_volume.u", "display_name", "-tf-volume-clone"),
 					resource.TestCheckResourceAttr("oci_core_volume.u", "source_details.0.type", "volume"),
 					resource.TestCheckResourceAttr("oci_core_volume.u", "state", baremetal.ResourceAvailable),

--- a/vendor/github.com/oracle/bmcs-go-sdk/core_volume.go
+++ b/vendor/github.com/oracle/bmcs-go-sdk/core_volume.go
@@ -15,6 +15,7 @@ type Volume struct {
 	CompartmentID       string               `json:"compartmentId"`
 	DisplayName         string               `json:"displayName"`
 	ID                  string               `json:"id"`
+	IsHydrated          bool                 `json:"isHydrated"`
 	SizeInMBs           int                  `json:"sizeInMBs"`
 	SizeInGBs           int                  `json:"sizeInGBs"`
 	State               string               `json:"lifecycleState"`


### PR DESCRIPTION
* will update vendor.json when related sdk PR is landed

Tests:
ccushing-mac:terraform-provider-oci ccushing$ make test run=Test.*CoreVolume.*
TF_ACC=1 TF_ORACLE_ENV=test go test -v -timeout 120m -run Test.*CoreVolume.*
=== RUN   TestDatasourceCoreVolumeAttachmentTestSuite
=== RUN   TestAccDatasourceCoreVolumeAttachment_basic
--- PASS: TestAccDatasourceCoreVolumeAttachment_basic (210.11s)
--- PASS: TestDatasourceCoreVolumeAttachmentTestSuite (210.12s)
=== RUN   TestDatasourceCoreVolumeBackupTestSuite
=== RUN   TestAccDatasourceCoreVolumeBackup_basic
--- PASS: TestAccDatasourceCoreVolumeBackup_basic (71.29s)
--- PASS: TestDatasourceCoreVolumeBackupTestSuite (71.29s)
=== RUN   TestDatasourceCoreVolumeTestSuite
=== RUN   TestAccDatasourceCoreVolume_basic
--- PASS: TestAccDatasourceCoreVolume_basic (33.88s)
--- PASS: TestDatasourceCoreVolumeTestSuite (33.89s)
=== RUN   TestResourceCoreVolumeAttachmentTestSuite
=== RUN   TestResourceCoreVolumeAttachment_basic
--- PASS: TestResourceCoreVolumeAttachment_basic (211.71s)
--- PASS: TestResourceCoreVolumeAttachmentTestSuite (211.71s)
=== RUN   TestResourceCoreVolumeBackupTestSuite
=== RUN   TestAccResourceCoreVolumeBackup_basic
--- PASS: TestAccResourceCoreVolumeBackup_basic (87.36s)
--- PASS: TestResourceCoreVolumeBackupTestSuite (87.36s)
=== RUN   TestResourceCoreVolumeTestSuite
=== RUN   TestCreateResourceCoreVolume_basic
--- PASS: TestCreateResourceCoreVolume_basic (76.42s)
=== RUN   TestCreateResourceCoreVolume_destructive
--- PASS: TestCreateResourceCoreVolume_destructive (31.31s)
--- PASS: TestResourceCoreVolumeTestSuite (107.73s)
PASS
ok      github.com/oracle/terraform-provider-oci        722.107s
