### PR TITLE
Add compartment_ocid environment var support in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,9 @@ In your ~/.bash_profile set these variables
 ```
 export TF_VAR_tenancy_ocid=
 export TF_VAR_user_ocid=
+export TF_VAR_compartment_ocid=<The tenancy OCID can be used as the compartment OCID of your root compartment>
 export TF_VAR_fingerprint=
-export TF_VAR_private_key_path=<fully qualified path>`
+export TF_VAR_private_key_path=<fully qualified path>
 ```
 
 Once you've set these values open a new terminal or source your profile changes
@@ -101,19 +102,18 @@ $ source ~/.bash_profile
 ```
 setx TF_VAR_tenancy_ocid <value>
 setx TF_VAR_user_ocid <value>
+setx TF_VAR_compartment_ocid <value>
 setx TF_VAR_fingerprint <value>
 setx TF_VAR_private_key_path <value>
 ```
 The variables won't be set for the current session, exit the terminal and reopen.
 
 ## Deploy an example configuration
-Download the [compute single instance example](https://github.com/oracle/terraform-provider-oci/tree/master/docs/examples/compute/instance).
-
-Edit it to include the OCID of the compartment you want to create the VCN. Remember that the tenancy OCID is the compartment OCID of your root compartment.
+Download the [virtual cloud network example](https://github.com/oracle/terraform-provider-oci/tree/master/docs/examples/networking/vcn).
 
 You should always plan, then apply a configuration -
 ```
-# From the compute/instance directory
+# From the vcn directory
 
 # Initialize the plugin for this template directory
 $ terraform init

--- a/provider_test.go
+++ b/provider_test.go
@@ -28,6 +28,13 @@ func init() {
 }
 
 func testProviderConfig() string {
+	// We should check for "compartment_ocid" to be consistent with our README steps
+	// Some folks might still be using the old "compartment_id" name in their environment, so don't break them
+	var compartmentId string
+	if compartmentId = getEnvSetting("compartment_id", "compartment_id"); compartmentId == "compartment_id" {
+		compartmentId = getRequiredEnvSetting("compartment_ocid")
+	}
+
 	return `
 	provider "oci" {
 		tenancy_ocid = "ocid.tenancy.aaaa"
@@ -39,7 +46,7 @@ func testProviderConfig() string {
 	}
 
 	variable "compartment_id" {
-		default = "` + getEnvSetting("compartment_id", "compartment_id") + `"
+		default = "` + compartmentId + `"
 	}
 
 	variable "tenancy_ocid" {


### PR DESCRIPTION
Tests are using the compartment_id env var while examples use the
compartment_ocid environment var. Avoid having to specify two variables
by using compartment_ocid in tests as well. Tests will still support the
compartment_id name to avoid breaking folks who have this setting.

This should simplify the README steps, which have also been updated to
include the compartment_ocid env var.

This addresses #354 