### PR TITLE
Add glusterfs sample configuration

### DIFF
--- a/docs/solutions/glusterfs/README.md
+++ b/docs/solutions/glusterfs/README.md
@@ -1,0 +1,45 @@
+    #     ___  ____     _    ____ _     _____
+    #    / _ \|  _ \   / \  / ___| |   | ____|
+    #   | | | | |_) | / _ \| |   | |   |  _|
+    #   | |_| |  _ < / ___ | |___| |___| |___
+    #    \___/|_| \_/_/   \_\____|_____|_____|
+***
+## GlusterFS Infrastructure
+This configuration creates a glusterfs volume that is replicated across 3 GlusterFS servers.
+
+It creates a VCN with a route table, internet gateway, and security list.
+The VCN spans 3 ADs with each AD containing a subnet and 2 instances: a GlusterFS server and a GlusterFS client. 
+
+### Using this example
+* Update env-vars with the required information. Most examples use the same set of environment variables so you only need to do this once.
+* Source env-vars
+  * `$ . env-vars`
+* Update `variables.tf` with your instance options.
+* Update `./userdata/bootstrap` by replacing instances of `baremetal.oraclevcn.com` with `[Your VCN's DnsLabel].oraclevcn.com`.
+
+### Files in the configuration
+
+#### `env-vars`
+Is used to export the environmental variables used in the configuration. These are usually authentication related, be sure to exclude this file from your version control system. It's typical to keep this file outside of the configuration.
+
+Before you plan, apply, or destroy the configuration source the file -  
+`$ . env-vars`
+
+#### `compute.tf`
+Defines the compute resources
+
+#### `networking.tf`
+Defines the virtual cloud network resources used in the configuration
+
+#### `variables.tf`
+Defines the variables used in the configuration
+
+#### `datasources.tf`
+Defines the datasources used in the configuration
+
+#### `provider.tf`
+Specifies and passes authentication details to the OCI TF provider
+
+#### `./userdata/bootstrap`
+The script gets injected into an instance on launch.
+The script configures the glusterfs volumes on each server and sets up the glusterfs clients.

--- a/docs/solutions/glusterfs/compute.tf
+++ b/docs/solutions/glusterfs/compute.tf
@@ -1,0 +1,85 @@
+resource "oci_core_instance" "GlusterServerInstance" {
+  availability_domain = "${oci_core_subnet.SubnetAD1.availability_domain}"
+  compartment_id = "${var.compartment_ocid}"
+  display_name = "glusterfs-server1"
+  hostname_label = "glusterfs-server1"
+  image = "${lookup(data.oci_core_images.ServerImageList.images[0], "id")}"
+  shape = "${var.ServerInstanceShape}"
+  subnet_id = "${oci_core_subnet.SubnetAD1.id}"
+  metadata {
+    ssh_authorized_keys = "${var.ssh_public_key}"
+    user_data = "${base64encode(file(var.ServerBootStrapFile))}"
+  }
+}
+
+resource "oci_core_instance" "GlusterServerInstance2" {
+  availability_domain = "${oci_core_subnet.SubnetAD2.availability_domain}"
+  compartment_id = "${var.compartment_ocid}"
+  display_name = "glusterfs-server2"
+  hostname_label = "glusterfs-server2"
+  image = "${lookup(data.oci_core_images.ServerImageList.images[0], "id")}"
+  shape = "${var.ServerInstanceShape}"
+  subnet_id = "${oci_core_subnet.SubnetAD2.id}"
+  metadata {
+    ssh_authorized_keys = "${var.ssh_public_key}"
+    user_data = "${base64encode(file(var.ServerBootStrapFile))}"
+  }
+}
+
+resource "oci_core_instance" "GlusterServerInstance3" {
+  availability_domain = "${oci_core_subnet.SubnetAD3.availability_domain}"
+  compartment_id = "${var.compartment_ocid}"
+  display_name = "glusterfs-server3"
+  hostname_label = "glusterfs-server3"
+  image = "${lookup(data.oci_core_images.ServerImageList.images[0], "id")}"
+  shape = "${var.ServerInstanceShape}"
+  subnet_id = "${oci_core_subnet.SubnetAD3.id}"
+  metadata {
+    ssh_authorized_keys = "${var.ssh_public_key}"
+    user_data = "${base64encode(file(var.ServerBootStrapFile))}"
+  }
+}
+
+
+resource "oci_core_instance" "GlusterClientInstance" {
+  availability_domain = "${oci_core_subnet.SubnetAD1.availability_domain}"
+  compartment_id = "${var.compartment_ocid}"
+  display_name = "glusterfs-client1"
+  hostname_label = "glusterfs-client1"
+  image = "${lookup(data.oci_core_images.ClientImageList.images[0], "id")}"
+  shape = "${var.ClientInstanceShape}"
+  subnet_id = "${oci_core_subnet.SubnetAD1.id}"
+  metadata {
+    ssh_authorized_keys = "${var.ssh_public_key}"
+    user_data = "${base64encode(file(var.ClientBootStrapFile))}"
+  }
+}
+
+resource "oci_core_instance" "GlusterClientInstance2" {
+  availability_domain = "${oci_core_subnet.SubnetAD2.availability_domain}"
+  compartment_id = "${var.compartment_ocid}"
+  display_name = "glusterfs-client2"
+  hostname_label = "glusterfs-client2"
+  image = "${lookup(data.oci_core_images.ClientImageList.images[0], "id")}"
+  shape = "${var.ClientInstanceShape}"
+  subnet_id = "${oci_core_subnet.SubnetAD2.id}"
+  metadata {
+    ssh_authorized_keys = "${var.ssh_public_key}"
+    user_data = "${base64encode(file(var.ClientBootStrapFile))}"
+  }
+}
+
+resource "oci_core_instance" "GlusterClientInstance3" {
+  availability_domain = "${oci_core_subnet.SubnetAD3.availability_domain}"
+  compartment_id = "${var.compartment_ocid}"
+  display_name = "glusterfs-client3"
+  hostname_label = "glusterfs-client3"
+  image = "${lookup(data.oci_core_images.ClientImageList.images[0], "id")}"
+  shape = "${var.ClientInstanceShape}"
+  subnet_id = "${oci_core_subnet.SubnetAD3.id}"
+  metadata {
+    ssh_authorized_keys = "${var.ssh_public_key}"
+    user_data = "${base64encode(file(var.ClientBootStrapFile))}"
+  }
+}
+

--- a/docs/solutions/glusterfs/datasources.tf
+++ b/docs/solutions/glusterfs/datasources.tf
@@ -1,0 +1,15 @@
+data "oci_identity_availability_domains" "ADs" {
+  compartment_id = "${var.compartment_ocid}"
+}
+
+# Gets the OCID of the image. This technique is for example purposes only. The results of oci_core_images may
+# change over time for Oracle-provided images, so the only sure way to get the correct OCID is to supply it directly.
+data "oci_core_images" "ServerImageList" {
+  compartment_id = "${var.compartment_ocid}"
+  display_name = "${var.ServerInstanceImage}"
+}
+
+data "oci_core_images" "ClientImageList" {
+  compartment_id = "${var.compartment_ocid}"
+  display_name = "${var.ClientInstanceImage}"
+}

--- a/docs/solutions/glusterfs/env-vars
+++ b/docs/solutions/glusterfs/env-vars
@@ -1,0 +1,12 @@
+### Authentication details
+export TF_VAR_tenancy_ocid="<tenancy OCID>"
+export TF_VAR_user_ocid="<user OCID>"
+export TF_VAR_fingerprint="<PEM key fingerprint>"
+export TF_VAR_private_key_path="<path to the private key that matches the fingerprint above>"
+export TF_VAR_private_key_password="<password for your private key>"
+
+### Compartment
+export TF_VAR_compartment_ocid="<compartment OCID>"
+
+### Public/private keys used on the instance
+export TF_VAR_ssh_public_key=$(cat <path to public key>)

--- a/docs/solutions/glusterfs/networking.tf
+++ b/docs/solutions/glusterfs/networking.tf
@@ -1,0 +1,73 @@
+resource "oci_core_virtual_network" "CompleteVCN" {
+  cidr_block = "10.0.0.0/16"
+  compartment_id = "${var.compartment_ocid}"
+  dns_label = "${var.DnsLabel}"
+  display_name = "CompleteVCN"
+}
+
+resource "oci_core_internet_gateway" "CompleteIG" {
+  compartment_id = "${var.compartment_ocid}"
+  display_name = "CompleteIG"
+  vcn_id = "${oci_core_virtual_network.CompleteVCN.id}"
+}
+
+resource "oci_core_route_table" "RouteForComplete" {
+  compartment_id = "${var.compartment_ocid}"
+  vcn_id = "${oci_core_virtual_network.CompleteVCN.id}"
+  display_name = "RouteTableForComplete"
+  route_rules {
+    cidr_block = "0.0.0.0/0"
+    network_entity_id = "${oci_core_internet_gateway.CompleteIG.id}"
+  }
+}
+
+resource "oci_core_security_list" "Subnet" {
+  compartment_id = "${var.compartment_ocid}"
+  display_name = "Subnet"
+  vcn_id = "${oci_core_virtual_network.CompleteVCN.id}"
+  egress_security_rules = [{
+    protocol = "all"
+    destination = "0.0.0.0/0"
+  }]
+  ingress_security_rules = [{
+    protocol = "all"
+    source = "0.0.0.0/0"
+  }]
+}
+
+resource "oci_core_subnet" "SubnetAD1" {
+  availability_domain = "${lookup(data.oci_identity_availability_domains.ADs.availability_domains[0],"name")}"
+  cidr_block = "10.0.4.0/24"
+  display_name = "SubnetAD1"
+  compartment_id = "${var.compartment_ocid}"
+  vcn_id = "${oci_core_virtual_network.CompleteVCN.id}"
+  route_table_id = "${oci_core_route_table.RouteForComplete.id}"
+  security_list_ids = ["${oci_core_security_list.Subnet.id}"]
+  dhcp_options_id = "${oci_core_virtual_network.CompleteVCN.default_dhcp_options_id}"
+  dns_label = "publicsubnetad1"
+}
+
+resource "oci_core_subnet" "SubnetAD2" {
+  availability_domain = "${lookup(data.oci_identity_availability_domains.ADs.availability_domains[1],"name")}"
+  cidr_block = "10.0.5.0/24"
+  display_name = "SubnetAD2"
+  compartment_id = "${var.compartment_ocid}"
+  vcn_id = "${oci_core_virtual_network.CompleteVCN.id}"
+  route_table_id = "${oci_core_route_table.RouteForComplete.id}"
+  security_list_ids = ["${oci_core_security_list.Subnet.id}"]
+  dhcp_options_id = "${oci_core_virtual_network.CompleteVCN.default_dhcp_options_id}"
+  dns_label = "publicsubnetad2"
+}
+
+resource "oci_core_subnet" "SubnetAD3" {
+  availability_domain = "${lookup(data.oci_identity_availability_domains.ADs.availability_domains[2],"name")}"
+  cidr_block = "10.0.6.0/24"
+  display_name = "SubnetAD3"
+  compartment_id = "${var.compartment_ocid}"
+  vcn_id = "${oci_core_virtual_network.CompleteVCN.id}"
+  route_table_id = "${oci_core_route_table.RouteForComplete.id}"
+  security_list_ids = ["${oci_core_security_list.Subnet.id}"]
+  dhcp_options_id = "${oci_core_virtual_network.CompleteVCN.default_dhcp_options_id}"
+  dns_label = "publicsubnetad3"
+}
+

--- a/docs/solutions/glusterfs/provider.tf
+++ b/docs/solutions/glusterfs/provider.tf
@@ -1,0 +1,8 @@
+provider "oci" {
+  tenancy_ocid = "${var.tenancy_ocid}"
+  user_ocid = "${var.user_ocid}"
+  fingerprint = "${var.fingerprint}"
+  private_key_path = "${var.private_key_path}"
+  region = "${var.region}"
+  private_key_password = "${var.private_key_password}"
+}

--- a/docs/solutions/glusterfs/userdata/bootstrap-client.sh
+++ b/docs/solutions/glusterfs/userdata/bootstrap-client.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#yum update -y
+#######################################################################################################################################################
+### This bootstrap script runs on glusterfs clients and does the following
+### 1- install gluster packages on all nodes
+### 2- disable local firewall. Feel free to update this script to open only the required ports.
+### 3- creates a local mount point in the glusterFS clients that maps to the glusterFS servers
+### 4- add a local entry in the clients Fstab with '_netdev' attribute. IMPORTANT to avoid boot issues.
+###
+######################################################################################################################################################
+exec 2>/dev/null
+
+sed -i '/search/d' /etc/resolv.conf
+echo "search baremetal.oraclevcn.com publicsubnetad2.baremetal.oraclevcn.com publicsubnetad1.baremetal.oraclevcn.com publicsubnetad3.baremetal.oraclevcn.com localdomain" >> /etc/resolv.conf
+chattr -R +i /etc/resolv.conf
+#firewall-cmd --zone=public --add-port=111/tcp --add-port=139/tcp --add-port=445/tcp --add-port=965/tcp --add-port=2049/tcp \
+#--add-port=38465-38469/tcp --add-port=631/tcp --add-port=111/udp --add-port=963/udp --add-port=49152-49251/tcp  --permanent
+#firewall-cmd --reload
+systemctl disable firewalld
+systemctl stop firewalld
+yum install glusterfs glusterfs-fuse attr -y
+mkdir /mnt/glustervol
+sleep 4m
+
+glusterfshost=$(hostname -s)
+case $glusterfshost in
+    "glusterfs-client1")
+        echo "glusterfs-server1:/glustervol /mnt/glustervol   glusterfs defaults,_netdev  0 0" >> /etc/fstab
+        mount -a
+        ;;
+    "glusterfs-client2")
+        echo "glusterfs-server2:/glustervol /mnt/glustervol   glusterfs defaults,_netdev  0 0" >> /etc/fstab
+        mount -a
+        ;;
+    "glusterfs-client3")
+        echo "glusterfs-server3:/glustervol /mnt/glustervol   glusterfs defaults,_netdev  0 0" >> /etc/fstab
+        mount -a
+        ;;
+    *)
+        echo "$glusterfshost" >>/tmp/notfound.txt
+        ;;
+esac

--- a/docs/solutions/glusterfs/userdata/bootstrap-server.sh
+++ b/docs/solutions/glusterfs/userdata/bootstrap-server.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#yum update -y
+#######################################################################################################################################################
+### This bootstrap script runs on glusterFS server and configures the following
+### 1- install gluster packages
+### 2- formats the NVME disks (HighIO1.36 shape), creates a LVM LV called "brick" (XFS)
+### 3- fixes the resolve.conf file. GlusterFS needs DNS to work properly so make sure you update the below domains to match your environment
+### 4- disable local firewall. Feel free to update this script to open only the required ports.
+### 5- install and configure a gluster volume called glustervol using server1-mybrick, server2-mybrick and server3-mybrick LVs (replicas)
+###
+######################################################################################################################################################
+exec 2>/dev/null
+
+yum install -y centos-release-gluster310.noarch
+yum install -y glusterfs-server samba
+pvcreate /dev/nvme0n1
+pvcreate /dev/nvme1n1
+pvcreate /dev/nvme2n1
+pvcreate /dev/nvme3n1
+vgcreate vg_gluster /dev/nvme0n1 /dev/nvme1n1 /dev/nvme2n1 /dev/nvme3n1
+lvcreate -L 11.6T -n mybrick vg_gluster
+mkfs.xfs /dev/vg_gluster/mybrick
+mkdir -p /bricks/mybrick
+mount /dev/vg_gluster/mybrick /bricks/mybrick
+echo "/dev/vg_gluster/mybrick  /bricks/mybrick    xfs     defaults,_netdev  0 0" >> /etc/fstab
+sed -i '/search/d' /etc/resolv.conf 
+echo "search baremetal.oraclevcn.com publicsubnetad2.baremetal.oraclevcn.com publicsubnetad1.baremetal.oraclevcn.com publicsubnetad3.baremetal.oraclevcn.com localdomain" >> /etc/resolv.conf
+chattr -R +i /etc/resolv.conf
+#firewall-cmd --zone=public --add-port=24007-24020/tcp --permanent
+#firewall-cmd --reload
+systemctl disable firewalld
+systemctl stop firewalld
+systemctl enable glusterd.service
+systemctl start glusterd.service
+mkdir /bricks/mybrick/brick
+
+if ["$(hostname -s)" == "glusterfs-server3"]; then
+    sleep 20
+    export host3=`hostname`
+    export server1=`host glusterfs-server1 |cut -c1-17`
+    export server2=`host glusterfs-server2 |cut -c1-17`
+    gluster peer probe ${server1}
+    gluster peer probe ${server2}
+    sleep 20
+    gluster volume create glustervol replica 3 transport tcp ${host3}:/bricks/mybrick/brick ${server2}:/bricks/mybrick/brick ${server1}:/bricks/mybrick/brick force
+    sleep 10
+    gluster volume start glustervol
+fi

--- a/docs/solutions/glusterfs/variables.tf
+++ b/docs/solutions/glusterfs/variables.tf
@@ -1,0 +1,41 @@
+// These settings can be populated here or read from your env-vars settings
+
+// Settings for authentication
+variable "tenancy_ocid" {}
+variable "user_ocid" {}
+variable "fingerprint" {}
+variable "region" {}
+variable "private_key_path" {}
+variable "private_key_password" {}
+
+variable "compartment_ocid" {}
+
+// The SSH public key for connecting to the compute instances
+variable "ssh_public_key" {}
+
+// The name DNS label to use for the VCN
+variable "DnsLabel" {}
+
+variable "ServerInstanceShape" {
+  default = "BM.DenseIO1.36"
+}
+
+variable "ClientInstanceShape" {
+  default = "VM.Standard1.2"
+}
+
+variable "ServerInstanceImage" {
+  default = "CentOS-7-2017.07.17-0"
+}
+
+variable "ClientInstanceImage" {
+  default = "Oracle-Linux-7.4-2017.10.25-0"
+}
+
+variable "ServerBootStrapFile" {
+  default = "./userdata/bootstrap-server.sh"
+}
+
+variable "ClientBootStrapFile" {
+  default = "./userdata/bootstrap-client.sh"
+}


### PR DESCRIPTION
This adds a sample configuration for creating a glusterfs volume that's
replicated across 3 ADs. This sample is taken from gilson.melo@oracle.com
with the following changes:

- Add networking resources required by the glusterfs servers and clients
- Rename/Introduce some variables to parameterize the sample more consistently
with the other samples
- Added a README file to explain the configuration