### PR TITLE
Allow configuration of default resources under VCNs

### DIFF
--- a/docs/Managing Default Resources.md
+++ b/docs/Managing Default Resources.md
@@ -1,0 +1,70 @@
+## Managing Default Virtual Cloud Network Resources
+
+When you create an [oci_core_virtual_network](https://github.com/oracle/terraform-provider-oci/blob/master/docs/resources/core/virtual_networks.md)
+resource, it will also create the following associated resources by default.
+
+- [oci_core_security_list](https://github.com/oracle/terraform-provider-oci/blob/master/docs/resources/core/security_list.md)
+- [oci_core_dhcp_options](https://github.com/oracle/terraform-provider-oci/blob/master/docs/resources/core/dhcp_option.md)
+- [oci_core_route_table](https://github.com/oracle/terraform-provider-oci/blob/master/docs/resources/core/route_table.md)
+
+These default resources will be implicitly created even if they are not specified in the Terraform configuration.
+Their OCIDs are returned by the following attributes under the `oci_core_virtual_network` resource:
+
+- `default_security_list_id`
+- `default_dhcp_options_id`
+- `default_route_table_id`
+
+Default resources must be configured in Terraform using a separate resource type. Here are
+the mappings between the resource and the new resource type to use for configuring default
+resources:
+- `oci_core_security_list` => `oci_core_default_security_list`
+- `oci_core_dhcp_options` => `oci_core_default_dhcp_options`
+- `oci_core_route_table` => `oci_core_default_route_table`
+
+Default resources types are configured in the same way as their non-default counterparts. 
+The only difference is specifying the ID of the default resource using the
+`manage_default_resource_id` argument.
+
+Consequently, the `compartment_id` and `vcn_id` are no longer necessary for default resources.
+
+
+### Example Usage
+#### Modifying a VCN's default DHCP options
+
+```
+resource "oci_core_virtual_network" "vcn1" {
+  cidr_block = "10.0.0.0/16"
+  dns_label = "vcn1"
+  compartment_id = "${var.compartment_ocid}"
+  display_name = "vcn1"
+}
+
+resource "oci_core_default_dhcp_options" "default-dhcp-options" {
+  manage_default_resource_id = "${oci_core_virtual_network.vcn1.default_dhcp_options_id}"
+
+  // required
+  options {
+    type = "DomainNameServer"
+    server_type = "VcnLocalPlusInternet"
+  }
+
+  // optional
+  options {
+    type = "SearchDomain"
+    search_domain_names = [ "abc.com" ]
+  }
+}
+```
+
+For more detailed examples, refer to [docs/examples/networking/vcn_default](https://github.com/oracle/terraform-provider-oci/tree/master/docs/examples/networking/vcn_default/vcn_default.tf)
+
+### Limitations
+
+Default resources can only be removed when the associated `oci_core_virtual_network resource` is removed. When attempting
+a targeted removal of a default resource, the resource will be removed from the Terraform state file but the resource may
+still exist in OCI with empty settings.
+ 
+Examples of targeted removal include:
+- Removing a default resource from a Terraform configuration that was previously applied
+- Running a `terraform destroy -target=<default resource>` command
+- Changing the `manage_default_resource_id` for a default resource that was previously applied

--- a/docs/examples/networking/vcn_default/vcn.tf
+++ b/docs/examples/networking/vcn_default/vcn.tf
@@ -1,0 +1,128 @@
+variable "tenancy_ocid" {}
+variable "user_ocid" {}
+variable "fingerprint" {}
+variable "private_key_path" {}
+variable "compartment_ocid" {}
+variable "region" {}
+
+provider "oci" {
+  tenancy_ocid = "${var.tenancy_ocid}"
+  user_ocid = "${var.user_ocid}"
+  fingerprint = "${var.fingerprint}"
+  private_key_path = "${var.private_key_path}"
+  region = "${var.region}"
+}
+
+resource "oci_core_virtual_network" "tf-vcn1" {
+  cidr_block = "10.0.0.0/16"
+  dns_label = "vcn1"
+  compartment_id = "${var.compartment_ocid}"
+  display_name = "tf-vcn1"
+}
+
+resource "oci_core_internet_gateway" "tf-ig1" {
+  compartment_id = "${var.compartment_ocid}"
+  display_name = "tf-ig1"
+  vcn_id = "${oci_core_virtual_network.tf-vcn1.id}"
+}
+
+resource "oci_core_default_route_table" "tf-default-route-table" {
+  manage_default_resource_id = "${oci_core_virtual_network.tf-vcn1.default_route_table_id}"
+  display_name = "tf-default-route-table"
+  route_rules {
+    cidr_block = "0.0.0.0/0"
+    network_entity_id = "${oci_core_internet_gateway.tf-ig1.id}"
+  }
+}
+
+resource "oci_core_route_table" "tf-route-table1" {
+  compartment_id = "${var.compartment_ocid}"
+  vcn_id = "${oci_core_virtual_network.tf-vcn1.id}"
+  display_name = "tf-route-table1"
+  route_rules {
+    cidr_block = "0.0.0.0/0"
+    network_entity_id = "${oci_core_internet_gateway.tf-ig1.id}"
+  }
+}
+
+resource "oci_core_default_dhcp_options" "tf-default-dhcp-options" {
+  manage_default_resource_id = "${oci_core_virtual_network.tf-vcn1.default_dhcp_options_id}"
+  display_name = "tf-default-dhcp-options"
+
+  // required
+  options {
+    type = "DomainNameServer"
+    server_type = "VcnLocalPlusInternet"
+  }
+
+  // optional
+  options {
+    type = "SearchDomain"
+    search_domain_names = [ "abc.com" ]
+  }
+}
+
+resource "oci_core_dhcp_options" "tf-dhcp-options1" {
+  compartment_id = "${var.compartment_ocid}"
+  vcn_id = "${oci_core_virtual_network.tf-vcn1.id}"
+  display_name = "tf-dhcp-options1"
+
+  // required
+  options {
+    type = "DomainNameServer"
+    server_type = "VcnLocalPlusInternet"
+  }
+
+  // optional
+  options {
+    type = "SearchDomain"
+    search_domain_names = [ "test123.com" ]
+  }
+}
+
+resource "oci_core_default_security_list" "tf-default-security-list" {
+  manage_default_resource_id = "${oci_core_virtual_network.tf-vcn1.default_security_list_id}"
+  display_name = "tf-default-security-list"
+
+  // allow outbound tcp traffic on all ports
+  egress_security_rules {
+    destination = "0.0.0.0/0"
+    protocol = "6"
+  }
+
+  // allow outbound udp traffic on a port range
+  egress_security_rules {
+    destination = "0.0.0.0/0"
+    protocol = "17" // udp
+    stateless = true
+
+    udp_options {
+      "min" = 319
+      "max" = 320
+    }
+  }
+
+  // allow inbound ssh traffic
+  ingress_security_rules {
+    protocol = "6" // tcp
+    source = "0.0.0.0/0"
+    stateless = false
+
+    tcp_options {
+      "min" = 22
+      "max" = 22
+    }
+  }
+
+  // allow inbound icmp traffic of a specific type
+  ingress_security_rules {
+    protocol  = 1
+    source    = "0.0.0.0/0"
+    stateless = true
+
+    icmp_options {
+      "type" = 3
+      "code" = 4
+    }
+  }
+}

--- a/docs/resources/core/dhcp_option.md
+++ b/docs/resources/core/dhcp_option.md
@@ -9,6 +9,8 @@ Provide a DHCP options resource.
 For more information, see
 [DNS in Your Virtual Cloud Network](https://docs.us-phoenix-1.oraclecloud.com/Content/Network/Concepts/dns.htm)
 
+For more information on configuring a VCN's default DHCP options, see [Managing Default VCN Resources](https://github.com/oracle/terraform-provider-oci/blob/master/docs/Managing%20Default%20Resources.md)
+
 ## Example Usage
 
 #### VCN Local with Internet

--- a/docs/resources/core/route_table.md
+++ b/docs/resources/core/route_table.md
@@ -6,6 +6,9 @@
 
 Provide a route table resource.
 
+For more information on configuring a VCN's default route table, 
+see [Managing Default VCN Resources](https://github.com/oracle/terraform-provider-oci/blob/master/docs/Managing%20Default%20Resources.md)
+
 ## Example Usage
 
 ```
@@ -28,10 +31,10 @@ resource "oci_core_route_table" "t" {
 
 The following arguments are supported:
 
-* `compartment_id` - (Required) The OCID of the compartment.
+* `compartment_id` - (Required) The OCID of the compartment containing the route table.
+* `vcn_id` - (Required) The OCID of the VCN the route table list belongs to.
 * `display_name` - (Optional) A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
 * `route_rules` - (Required) The collection of rules for routing destination IPs to network devices.
-* `vcn_id` - (Required) The OCID of the VCN the route table list belongs to.
 
 ## Attributes reference
 

--- a/docs/resources/core/security_list.md
+++ b/docs/resources/core/security_list.md
@@ -8,6 +8,9 @@ Provides a security list resource.
 See the [Security Lists](https://docs.us-phoenix-1.oraclecloud.com/Content/Network/Concepts/securitylists.htm)
 overview for more information.
 
+For more information on configuring a VCN's default security list, 
+see [Managing Default VCN Resources](https://github.com/oracle/terraform-provider-oci/blob/master/docs/Managing%20Default%20Resources.md)
+
 ## Example Usage
 
 Protocols are specified as protocol numbers. For information about protocol numbers, see
@@ -58,10 +61,10 @@ resource "oci_core_security_list" "t" {
 The following arguments are supported:
 
 * `compartment_id` - (Required) The OCID of the compartment to contain the security list.
-* `display_name` - (Optional) The OCID of the VCN.
+* `vcn_id` - (Required) The OCID of the VCN the security list belongs to.
+* `display_name` - (Optional) A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
 * `egress_security_rules` - (Required) Rules for allowing egress IP packets. [EgressSecurityRule API Docs](https://docs.us-phoenix-1.oraclecloud.com/api/#/en/iaas/20160918/EgressSecurityRule/)
 * `ingress_security_rules` - (Required) Rules for allowing ingress IP packets. [IngressSecurityRule API Docs](https://docs.us-phoenix-1.oraclecloud.com/api/#/en/iaas/20160918/IngressSecurityRule/)
-* `vcn_id` - (Required) The OCID of the VCN the security list belongs to.
 
 ## Attributes Reference
 

--- a/docs/resources/core/virtual_networks.md
+++ b/docs/resources/core/virtual_networks.md
@@ -6,6 +6,8 @@
 
 Provides a Virtual Cloud Network (VCN) resource.
 
+VCN resources have a default set of DHCP options, security list, and route table.
+To learn more about managing these resources, see [Managing Default Virtual Cloud Network Resources](https://github.com/oracle/terraform-provider-oci/blob/master/docs/Managing%20Default%20Resources.md).
 
 ## Example Usage
 

--- a/provider/core_dhcp_options_resource.go
+++ b/provider/core_dhcp_options_resource.go
@@ -9,6 +9,69 @@ import (
 	"github.com/oracle/terraform-provider-oci/crud"
 )
 
+func DefaultDHCPOptionsResource() *schema.Resource {
+	return &schema.Resource{
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: crud.DefaultTimeout,
+		Create:   createDHCPOptions,
+		Read:     readDHCPOptions,
+		Update:   updateDHCPOptions,
+		Delete:   deleteDHCPOptions,
+		Schema: map[string]*schema.Schema{
+			"display_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"manage_default_resource_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"options": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"custom_dns_servers": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"server_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"search_domain_names": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"time_created": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
 func DHCPOptionsResource() *schema.Resource {
 	return &schema.Resource{
 		Importer: &schema.ResourceImporter{
@@ -139,6 +202,14 @@ func (s *DHCPOptionsResourceCrud) State() string {
 }
 
 func (s *DHCPOptionsResourceCrud) Create() (e error) {
+	// If we are creating a default resource, then don't have to
+	// actually create it. Just set the ID and update it.
+	if defaultId, ok := s.D.GetOk("manage_default_resource_id"); ok {
+		s.D.SetId(defaultId.(string))
+		e = s.Update()
+		return
+	}
+
 	compartmentID := s.D.Get("compartment_id").(string)
 	vcnID := s.D.Get("vcn_id").(string)
 
@@ -154,6 +225,16 @@ func (s *DHCPOptionsResourceCrud) Get() (e error) {
 	res, e := s.Client.GetDHCPOptions(s.D.Id())
 	if e == nil {
 		s.Res = res
+
+		// If this is a default resource that we removed earlier, then
+		// we need to assume that the parent resource will remove it
+		// and notify terraform of it. Otherwise, terraform will
+		// see that the resource is still available and error out
+		deleteTargetState := s.DeletedTarget()[0]
+		if _, ok := s.D.GetOk("manage_default_resource_id"); ok &&
+			s.D.Get("state") == deleteTargetState {
+			s.Res.State = deleteTargetState
+		}
 	}
 	return
 }
@@ -186,7 +267,29 @@ func (s *DHCPOptionsResourceCrud) SetData() {
 	s.D.Set("time_created", s.Res.TimeCreated.String())
 }
 
+func (s *DHCPOptionsResourceCrud) reset() (e error) {
+	opts := &baremetal.UpdateDHCPDNSOptions{
+		Options: []baremetal.DHCPDNSOption{
+			{
+				Type:       "DomainNameServer",
+				ServerType: "VcnLocalPlusInternet",
+			},
+		},
+	}
+
+	_, e = s.Client.UpdateDHCPOptions(s.D.Id(), opts)
+	return
+}
+
 func (s *DHCPOptionsResourceCrud) Delete() (e error) {
+	if _, ok := s.D.GetOk("manage_default_resource_id"); ok {
+		// We can't actually delete a default resource.
+		// Clear out its settings and mark it as deleted.
+		e = s.reset()
+		s.D.Set("state", s.DeletedTarget()[0])
+		return
+	}
+
 	return s.Client.DeleteDHCPOptions(s.D.Id(), nil)
 }
 

--- a/provider/core_dhcp_options_resource_test.go
+++ b/provider/core_dhcp_options_resource_test.go
@@ -21,6 +21,21 @@ type ResourceCoreDHCPOptionsTestSuite struct {
 	ResourceName string
 }
 
+var defaultDhcpOpts = `
+resource "oci_core_default_dhcp_options" "default" {
+	manage_default_resource_id = "${oci_core_virtual_network.t.default_dhcp_options_id}"
+	options {
+		type = "DomainNameServer"
+		server_type = "CustomDnsServer"
+		custom_dns_servers = [  "8.8.4.4", "8.8.8.8" ]
+	}
+	options {
+		type = "SearchDomain"
+		search_domain_names = [ "test.com" ]
+	}
+}
+`
+
 func (s *ResourceCoreDHCPOptionsTestSuite) SetupTest() {
 	s.Client = testAccClient
 	s.Provider = testAccProvider
@@ -91,7 +106,7 @@ func (s *ResourceCoreDHCPOptionsTestSuite) TestAccResourceCoreDHCPOptions_basic(
 			{
 				ImportState:       true,
 				ImportStateVerify: true,
-				Config:            s.Config,
+				Config:            s.Config + defaultDhcpOpts,
 				Check: resource.ComposeTestCheckFunc(
 
 					resource.TestCheckResourceAttr("oci_core_dhcp_options.opt1", "display_name", "display_name"),
@@ -109,6 +124,24 @@ func (s *ResourceCoreDHCPOptionsTestSuite) TestAccResourceCoreDHCPOptions_basic(
 					resource.TestCheckResourceAttr("oci_core_dhcp_options.opt4", "options.0.type", "DomainNameServer"),
 					resource.TestCheckResourceAttr("oci_core_dhcp_options.opt4", "options.0.server_type", "CustomDnsServer"),
 					resource.TestCheckResourceAttr("oci_core_dhcp_options.opt4", "options.1.type", "SearchDomain"),
+
+					resource.TestCheckResourceAttr("oci_core_default_dhcp_options.default", "options.0.type", "DomainNameServer"),
+					resource.TestCheckResourceAttr("oci_core_default_dhcp_options.default", "options.0.server_type", "CustomDnsServer"),
+					resource.TestCheckResourceAttr("oci_core_default_dhcp_options.default", "options.1.type", "SearchDomain"),
+				),
+			},
+			// Verify removing default DHCP options
+			{
+				Config: s.Config,
+				Check:  nil,
+			},
+			// Verify adding default DHCP options again
+			{
+				Config: s.Config + defaultDhcpOpts,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("oci_core_dhcp_options.default", "options.0.type", "DomainNameServer"),
+					resource.TestCheckResourceAttr("oci_core_dhcp_options.default", "options.0.server_type", "CustomDnsServer"),
+					resource.TestCheckResourceAttr("oci_core_dhcp_options.default", "options.1.type", "SearchDomain"),
 				),
 			},
 		},

--- a/provider/core_route_table_resource_test.go
+++ b/provider/core_route_table_resource_test.go
@@ -14,12 +14,23 @@ import (
 
 type ResourceCoreRouteTableTestSuite struct {
 	suite.Suite
-	Client       *baremetal.Client
-	Provider     terraform.ResourceProvider
-	Providers    map[string]terraform.ResourceProvider
-	Config       string
-	ResourceName string
+	Client              *baremetal.Client
+	Provider            terraform.ResourceProvider
+	Providers           map[string]terraform.ResourceProvider
+	Config              string
+	ResourceName        string
+	DefaultResourceName string
 }
+
+var defaultRouteTable = `
+resource "oci_core_default_route_table" "default" {
+	manage_default_resource_id = "${oci_core_virtual_network.t.default_route_table_id}"
+	route_rules {
+		cidr_block = "0.0.0.0/0"
+		network_entity_id = "${oci_core_internet_gateway.internet-gateway1.id}"
+	}
+}
+`
 
 func (s *ResourceCoreRouteTableTestSuite) SetupTest() {
 	s.Client = testAccClient
@@ -31,6 +42,7 @@ func (s *ResourceCoreRouteTableTestSuite) SetupTest() {
 			cidr_block = "10.0.0.0/16"
 			display_name = "-tf-vcn"
 		}
+
 		resource "oci_core_internet_gateway" "internet-gateway1" {
 			compartment_id = "${var.compartment_id}"
 			vcn_id = "${oci_core_virtual_network.t.id}"
@@ -38,6 +50,7 @@ func (s *ResourceCoreRouteTableTestSuite) SetupTest() {
 		}`
 
 	s.ResourceName = "oci_core_route_table.t"
+	s.DefaultResourceName = "oci_core_default_route_table.default"
 }
 
 func (s *ResourceCoreRouteTableTestSuite) TestAccResourceCoreRouteTable_basic() {
@@ -52,10 +65,16 @@ func (s *ResourceCoreRouteTableTestSuite) TestAccResourceCoreRouteTable_basic() 
 					resource "oci_core_route_table" "t" {
 						compartment_id = "${var.compartment_id}"
 						vcn_id = "${oci_core_virtual_network.t.id}"
+					}
+
+					resource "oci_core_default_route_table" "default" {
+						manage_default_resource_id = "${oci_core_virtual_network.t.default_route_table_id}"
 					}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(s.ResourceName, "display_name"),
 					resource.TestCheckResourceAttr(s.ResourceName, "route_rules.#", "0"),
+					resource.TestCheckResourceAttrSet(s.DefaultResourceName, "display_name"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "route_rules.#", "0"),
 				),
 			},
 			// verify add rule
@@ -68,12 +87,16 @@ func (s *ResourceCoreRouteTableTestSuite) TestAccResourceCoreRouteTable_basic() 
 							cidr_block = "0.0.0.0/0"
 							network_entity_id = "${oci_core_internet_gateway.internet-gateway1.id}"
 						}
-					}`,
+					}` + defaultRouteTable,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(s.ResourceName, "display_name"),
 					resource.TestCheckResourceAttrSet(s.ResourceName, "route_rules.0.network_entity_id"),
 					resource.TestCheckResourceAttr(s.ResourceName, "route_rules.#", "1"),
 					resource.TestCheckResourceAttr(s.ResourceName, "route_rules.0.cidr_block", "0.0.0.0/0"),
+					resource.TestCheckResourceAttrSet(s.DefaultResourceName, "display_name"),
+					resource.TestCheckResourceAttrSet(s.DefaultResourceName, "route_rules.0.network_entity_id"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "route_rules.#", "1"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "route_rules.0.cidr_block", "0.0.0.0/0"),
 				),
 			},
 			// verify update
@@ -91,12 +114,43 @@ func (s *ResourceCoreRouteTableTestSuite) TestAccResourceCoreRouteTable_basic() 
 							cidr_block = "10.0.0.0/8"
 							network_entity_id = "${oci_core_internet_gateway.internet-gateway1.id}"
 						}
+					}
+					resource "oci_core_default_route_table" "default" {
+						manage_default_resource_id = "${oci_core_virtual_network.t.default_route_table_id}"
+						display_name = "default-tf-route-table"
+						route_rules {
+							cidr_block = "0.0.0.0/0"
+							network_entity_id = "${oci_core_internet_gateway.internet-gateway1.id}"
+						}
+						route_rules {
+							cidr_block = "10.0.0.0/8"
+							network_entity_id = "${oci_core_internet_gateway.internet-gateway1.id}"
+						}
 					}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(s.ResourceName, "display_name", "-tf-route-table"),
 					resource.TestCheckResourceAttr(s.ResourceName, "route_rules.#", "2"),
 					resource.TestCheckResourceAttr(s.ResourceName, "route_rules.0.cidr_block", "0.0.0.0/0"),
 					resource.TestCheckResourceAttr(s.ResourceName, "route_rules.1.cidr_block", "10.0.0.0/8"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "display_name", "default-tf-route-table"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "route_rules.#", "2"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "route_rules.0.cidr_block", "0.0.0.0/0"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "route_rules.1.cidr_block", "10.0.0.0/8"),
+				),
+			},
+			// verify default resource delete
+			{
+				Config: s.Config,
+				Check:  nil,
+			},
+			// verify adding the default resource back to the config
+			{
+				Config: s.Config + defaultRouteTable,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(s.DefaultResourceName, "display_name"),
+					resource.TestCheckResourceAttrSet(s.DefaultResourceName, "route_rules.0.network_entity_id"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "route_rules.#", "1"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "route_rules.0.cidr_block", "0.0.0.0/0"),
 				),
 			},
 		},

--- a/provider/core_security_list_resource.go
+++ b/provider/core_security_list_resource.go
@@ -45,6 +45,91 @@ var icmpSchema = &schema.Schema{
 	},
 }
 
+func DefaultSecurityListResource() *schema.Resource {
+	return &schema.Resource{
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: crud.DefaultTimeout,
+		Create:   createSecurityList,
+		Read:     readSecurityList,
+		Update:   updateSecurityList,
+		Delete:   deleteSecurityList,
+		Schema: map[string]*schema.Schema{
+			"display_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+			"egress_security_rules": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"destination": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"icmp_options": icmpSchema,
+						"protocol": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"tcp_options": transportSchema,
+						"udp_options": transportSchema,
+						"stateless": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+					},
+				},
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"manage_default_resource_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"ingress_security_rules": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"icmp_options": icmpSchema,
+						"protocol": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"source": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"tcp_options": transportSchema,
+						"udp_options": transportSchema,
+						"stateless": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+					},
+				},
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"time_created": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
 func SecurityListResource() *schema.Resource {
 	return &schema.Resource{
 		Importer: &schema.ResourceImporter{
@@ -197,6 +282,14 @@ func (s *SecurityListResourceCrud) State() string {
 }
 
 func (s *SecurityListResourceCrud) Create() (e error) {
+	// If we are creating a default resource, then don't have to
+	// actually create it. Just set the ID and update it.
+	if defaultId, ok := s.D.GetOk("manage_default_resource_id"); ok {
+		s.D.SetId(defaultId.(string))
+		e = s.Update()
+		return
+	}
+
 	compartmentID := s.D.Get("compartment_id").(string)
 	egress := s.buildEgressRules()
 	ingress := s.buildIngressRules()
@@ -214,6 +307,16 @@ func (s *SecurityListResourceCrud) Get() (e error) {
 	res, e := s.Client.GetSecurityList(s.D.Id())
 	if e == nil {
 		s.Res = res
+
+		// If this is a default resource that we removed earlier, then
+		// we need to assume that the parent resource will remove it
+		// and notify terraform of it. Otherwise, terraform will
+		// see that the resource is still available and error out
+		deleteTargetState := s.DeletedTarget()[0]
+		if _, ok := s.D.GetOk("manage_default_resource_id"); ok &&
+			s.D.Get("state") == deleteTargetState {
+			s.Res.State = deleteTargetState
+		}
 	}
 	return
 }
@@ -277,7 +380,25 @@ func (s *SecurityListResourceCrud) SetData() {
 	s.D.Set("vcn_id", s.Res.VcnID)
 }
 
+func (s *SecurityListResourceCrud) reset() (e error) {
+	opts := &baremetal.UpdateSecurityListOptions{
+		IngressRules: []baremetal.IngressSecurityRule{},
+		EgressRules:  []baremetal.EgressSecurityRule{},
+	}
+
+	_, e = s.Client.UpdateSecurityList(s.D.Id(), opts)
+	return
+}
+
 func (s *SecurityListResourceCrud) Delete() (e error) {
+	if _, ok := s.D.GetOk("manage_default_resource_id"); ok {
+		// We can't actually delete a default resource.
+		// Clear out its settings and mark it as deleted.
+		e = s.reset()
+		s.D.Set("state", s.DeletedTarget()[0])
+		return
+	}
+
 	return s.Client.DeleteSecurityList(s.D.Id(), nil)
 }
 

--- a/provider/core_security_list_resource_test.go
+++ b/provider/core_security_list_resource_test.go
@@ -15,12 +15,47 @@ import (
 
 type ResourceCoreSecurityListTestSuite struct {
 	suite.Suite
-	Client       *baremetal.Client
-	Provider     terraform.ResourceProvider
-	Providers    map[string]terraform.ResourceProvider
-	Config       string
-	ResourceName string
+	Client              *baremetal.Client
+	Provider            terraform.ResourceProvider
+	Providers           map[string]terraform.ResourceProvider
+	Config              string
+	ResourceName        string
+	DefaultResourceName string
 }
+
+var defaultSecurityList = `
+resource "oci_core_default_security_list" "default" {
+	manage_default_resource_id = "${oci_core_virtual_network.t.default_security_list_id}"
+	display_name = "default-tf-security_list"
+	egress_security_rules = [{
+		destination = "0.0.0.0/0"
+		protocol = "6"
+	}]
+	ingress_security_rules = [{
+		protocol = "1"
+		source = "0.0.0.0/0"
+		icmp_options {
+			"type" = 3
+			"code" = 4
+		}
+	},
+	{
+		protocol = "6"
+		source = "0.0.0.0/0"
+		tcp_options {
+			"min" = 80
+			"max" = 80
+		}
+	},
+	{
+		protocol = "17"
+		source = "10.0.0.0/16"
+		udp_options {
+			"min" = 319
+			"max" = 320
+		}
+	}]
+}`
 
 func extraWait(ew crud.ExtraWaitPostCreateDelete) {
 	return
@@ -37,6 +72,7 @@ func (s *ResourceCoreSecurityListTestSuite) SetupTest() {
 			display_name = "-tf-vcn"
 		}`
 	s.ResourceName = "oci_core_security_list.t"
+	s.DefaultResourceName = "oci_core_default_security_list.default"
 }
 
 func (s *ResourceCoreSecurityListTestSuite) TestAccResourceCoreSecurityList_basic() {
@@ -81,8 +117,7 @@ func (s *ResourceCoreSecurityListTestSuite) TestAccResourceCoreSecurityList_basi
 								"max" = 320
 							}
 						}]
-					}
-				`,
+					}` + defaultSecurityList,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(s.ResourceName, "display_name", "-tf-security_list"),
 					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.#", "1"),
@@ -91,6 +126,13 @@ func (s *ResourceCoreSecurityListTestSuite) TestAccResourceCoreSecurityList_basi
 					resource.TestCheckResourceAttr(s.ResourceName, "ingress_security_rules.0.icmp_options.0.type", "3"),
 					resource.TestCheckResourceAttr(s.ResourceName, "ingress_security_rules.1.tcp_options.0.max", "80"),
 					resource.TestCheckResourceAttr(s.ResourceName, "ingress_security_rules.2.udp_options.0.max", "320"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "display_name", "default-tf-security_list"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "egress_security_rules.#", "1"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "egress_security_rules.0.stateless", "false"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.#", "3"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.0.icmp_options.0.type", "3"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.1.tcp_options.0.max", "80"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.2.udp_options.0.max", "320"),
 				),
 			},
 			// verify update
@@ -100,6 +142,39 @@ func (s *ResourceCoreSecurityListTestSuite) TestAccResourceCoreSecurityList_basi
 						compartment_id = "${var.compartment_id}"
 						display_name = "-tf-security_list-updated"
 						vcn_id = "${oci_core_virtual_network.t.id}"
+						egress_security_rules = [{
+							destination = "0.0.0.0/0"
+							protocol = "17"
+							stateless = true
+						}]
+						ingress_security_rules = [{
+							protocol = "1"
+							source = "0.0.0.0/0"
+							stateless = true
+							icmp_options {
+								"type" = 5
+								"code" = 0
+							}
+						},
+						{
+							protocol = "6"
+							source = "0.0.0.0/0"
+							stateless = true
+							tcp_options {
+								"min" = 80
+								"max" = 82
+							}
+						},
+						{
+							protocol = "17"
+							source = "10.0.0.0/16"
+							stateless = true
+						}]
+					}
+
+					resource "oci_core_default_security_list" "default" {
+						manage_default_resource_id = "${oci_core_virtual_network.t.default_security_list_id}"
+						display_name = "default-tf-security_list-updated"
 						egress_security_rules = [{
 							destination = "0.0.0.0/0"
 							protocol = "17"
@@ -140,6 +215,33 @@ func (s *ResourceCoreSecurityListTestSuite) TestAccResourceCoreSecurityList_basi
 					resource.TestCheckResourceAttr(s.ResourceName, "ingress_security_rules.1.stateless", "true"),
 					resource.TestCheckResourceAttr(s.ResourceName, "ingress_security_rules.2.stateless", "true"),
 					resource.TestCheckNoResourceAttr(s.ResourceName, "ingress_security_rules.2.udp_options"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "display_name", "default-tf-security_list-updated"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "egress_security_rules.0.protocol", "17"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "egress_security_rules.0.stateless", "true"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.0.stateless", "true"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.0.icmp_options.0.type", "5"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.1.tcp_options.0.max", "82"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.1.stateless", "true"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.2.stateless", "true"),
+					resource.TestCheckNoResourceAttr(s.DefaultResourceName, "ingress_security_rules.2.udp_options"),
+				),
+			},
+			// Verify removing the default resource
+			{
+				Config: s.Config,
+				Check:  nil,
+			},
+			// verify adding the default resource again
+			{
+				Config: s.Config + defaultSecurityList,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "display_name", "default-tf-security_list"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "egress_security_rules.#", "1"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "egress_security_rules.0.stateless", "false"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.#", "3"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.0.icmp_options.0.type", "3"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.1.tcp_options.0.max", "80"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.2.udp_options.0.max", "320"),
 				),
 			},
 			// todo: consistent 500 error from server without this step
@@ -158,10 +260,19 @@ func (s *ResourceCoreSecurityListTestSuite) TestAccResourceCoreSecurityList_basi
 						egress_security_rules = []
 						ingress_security_rules = []
 					}
+
+					resource "oci_core_default_security_list" "default" {
+						manage_default_resource_id = "${oci_core_virtual_network.t.default_security_list_id}"
+						display_name = "default-tf-security_list-updated"
+						egress_security_rules = []
+						ingress_security_rules = []
+					}
 				`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.#", "0"),
 					resource.TestCheckResourceAttr(s.ResourceName, "ingress_security_rules.#", "0"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "egress_security_rules.#", "0"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.#", "0"),
 				),
 			},
 		},

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -163,6 +163,7 @@ func resourcesMap() map[string]*schema.Resource {
 	return map[string]*schema.Resource{
 		"oci_core_console_history":           ConsoleHistoryResource(),
 		"oci_core_cpe":                       CpeResource(),
+		"oci_core_default_dhcp_options":      DefaultDHCPOptionsResource(),
 		"oci_core_dhcp_options":              DHCPOptionsResource(),
 		"oci_core_drg":                       DrgResource(),
 		"oci_core_drg_attachment":            DrgAttachmentResource(),
@@ -171,7 +172,9 @@ func resourcesMap() map[string]*schema.Resource {
 		"oci_core_internet_gateway":          InternetGatewayResource(),
 		"oci_core_ipsec":                     IPSecConnectionResource(),
 		"oci_core_private_ip":                PrivateIPResource(),
+		"oci_core_default_route_table":       DefaultRouteTableResource(),
 		"oci_core_route_table":               RouteTableResource(),
+		"oci_core_default_security_list":     DefaultSecurityListResource(),
 		"oci_core_security_list":             SecurityListResource(),
 		"oci_core_subnet":                    SubnetResource(),
 		"oci_core_virtual_network":           VirtualNetworkResource(),


### PR DESCRIPTION
This addresses issue #322. Creating a VCN typically generates a
default DHCP option, route table, and security list resource. Allow
configuration of these default resources in the same way that they
are currently configured for non-default resources. Default
resources are identified via a new "default_id" field that marks
them as such.

To support this, we make following changes:
- Change Create, Get, Delete request handling for default resources
- Only allow compartment_id/vcn_id or default_id, but not both
- Add unit tests for default resources
- Add example TF file for configuring default VCN resources

One issue we may want to fix after this change:
- If we try to remove an updated default resource, nothing will happen to it and it retains its updated settings. The user may expect this to revert it to default settings. We can consider implementing this logic instead.