### PR TITLE
Add support for DBHomes

### DIFF
--- a/docs/datasources/database/db_homes.md
+++ b/docs/datasources/database/db_homes.md
@@ -1,33 +1,38 @@
-# oci\_database\_db\_homes
+# oci\_database\_db_homes
 
-[DbHome Summary][40f7e502]
-
-  [40f7e502]: https://docs.us-phoenix-1.oraclecloud.com/api/#/en/database/20160918/DbHomeSummary/ "DbHomeSummary"
-
-Gets a list of database homes in the specified DB System and compartment.
+Gets a list of db_homes.
 
 ## Example Usage
 
 ```
-data "oci_database_db_homes" "t" {
-  compartment_id = "compartment_id"
-  db_system_id = "db_system_id"
-  limit = 1
-  page = "page"
+data "oci_database_db_homes" "testDBHomes" {
+	#Required
+	compartment_id = "${var.compartment_id}"
+	db_system_id = "${var.db_system_id}"
 }
+
 ```
 
-## Argument Reference
+## List Operation
+Gets a list of database homes in the specified DB System and compartment. A database home is a directory where Oracle database software is installed.
 
 The following arguments are supported:
 
-* `compartment_id` - (Required) The compartment OCID.
-* `db_system_id` - (Required) The OCID of the DB System.
-* `limit` - (Required) The maximum number of items to return.
-* `page` - (Optional) The pagination token to continue listing from.
+* `compartment_id` - (Required) The compartment [OCID](https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/identifiers.htm).
+* `db_system_id` - (Required) The [OCID](https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/identifiers.htm) of the DB System.
 
-## Attributes Reference
 
 The following attributes are exported:
 
-* `db_homes` - A list of database homes in the specified DB System and compartment.
+* `db_homes` - The list of db_homes.
+
+## DBHome Reference
+* `compartment_id` - The OCID of the compartment.
+* `db_system_id` - The OCID of the DB System.
+* `db_version` - The Oracle database version.
+* `display_name` - The user-provided name for the database home. It does not need to be unique.
+* `id` - The OCID of the database home.
+* `last_patch_history_entry_id` - The OCID of the last patch history. This is updated as soon as a patch operation is started.
+* `state` - The current state of the database home.
+* `time_created` - The date and time the database home was created.
+

--- a/docs/examples/db_systems/db_home.tf
+++ b/docs/examples/db_systems/db_home.tf
@@ -1,0 +1,52 @@
+variable "tenancy_ocid" {}
+variable "user_ocid" {}
+variable "fingerprint" {}
+variable "private_key_path" {}
+variable "region" {}
+
+variable "compartment_id" {}
+variable "database_admin_password" {}
+variable "database_character_set" {}
+variable "database_db_name" {}
+variable "database_db_workload" {}
+variable "database_ncharacter_set" {}
+variable "database_pdb_name" {}
+variable "db_system_id" {}
+variable "db_version" {}
+variable "display_name" {}
+
+
+provider "oci" {
+    tenancy_ocid = "${var.tenancy_ocid}"
+    user_ocid = "${var.user_ocid}"
+    fingerprint = "${var.fingerprint}"
+    private_key_path = "${var.private_key_path}"
+    region = "${var.region}"
+}
+
+resource "oci_database_db_home" "testDBHome" {
+	#Required
+	database {
+		#Required
+		admin_password = "${var.database_admin_password}"
+		db_name = "${var.database_db_name}"
+
+		#Optional
+		character_set = "${var.database_character_set}"
+		db_workload = "${var.database_db_workload}"
+		ncharacter_set = "${var.database_ncharacter_set}"
+		pdb_name = "${var.database_pdb_name}"
+	}
+	db_system_id = "${var.db_system_id}"
+	db_version = "${var.db_version}"
+
+	#Optional
+	display_name = "${var.display_name}"
+}
+
+
+data "oci_database_db_homes" "testDBHomes" {
+	#Required
+	compartment_id = "${var.compartment_id}"
+	db_system_id = "${var.db_system_id}"
+}

--- a/docs/resources/database/db_home.md
+++ b/docs/resources/database/db_home.md
@@ -1,0 +1,65 @@
+# oci\_database\_db_home
+
+## Example Usage
+
+```
+resource "oci_database_db_home" "testDBHome" {
+	#Required
+	database {
+		#Required
+		admin_password = "${var.database_admin_password}"
+		db_name = "${var.database_db_name}"
+
+		#Optional
+		character_set = "${var.database_character_set}"
+		db_workload = "${var.database_db_workload}"
+		ncharacter_set = "${var.database_ncharacter_set}"
+		pdb_name = "${var.database_pdb_name}"
+	}
+	db_system_id = "${var.db_system_id}"
+	db_version = "${var.db_version}"
+
+	#Optional
+	display_name = "${var.display_name}"
+}
+
+```
+
+## Create Operation
+Creates a new DB Home in the specified DB System based on the request parameters you provide.
+
+
+The following arguments are supported:
+
+* `database` - (Required) 
+	* `admin_password` - (Required) A strong password for SYS, SYSTEM, and PDB Admin. The password must be at least nine characters and contain at least two uppercase, two lowercase, two numbers, and two special characters. The special characters must be _, \#, or -.
+	* `character_set` - (Optional) The character set for the database.  The default is AL32UTF8. Allowed values are:  AL32UTF8, AR8ADOS710, AR8ADOS720, AR8APTEC715, AR8ARABICMACS, AR8ASMO8X, AR8ISO8859P6, AR8MSWIN1256, AR8MUSSAD768, AR8NAFITHA711, AR8NAFITHA721, AR8SAKHR706, AR8SAKHR707, AZ8ISO8859P9E, BG8MSWIN, BG8PC437S, BLT8CP921, BLT8ISO8859P13, BLT8MSWIN1257, BLT8PC775, BN8BSCII, CDN8PC863, CEL8ISO8859P14, CL8ISO8859P5, CL8ISOIR111, CL8KOI8R, CL8KOI8U, CL8MACCYRILLICS, CL8MSWIN1251, EE8ISO8859P2, EE8MACCES, EE8MACCROATIANS, EE8MSWIN1250, EE8PC852, EL8DEC, EL8ISO8859P7, EL8MACGREEKS, EL8MSWIN1253, EL8PC437S, EL8PC851, EL8PC869, ET8MSWIN923, HU8ABMOD, HU8CWI2, IN8ISCII, IS8PC861, IW8ISO8859P8, IW8MACHEBREWS, IW8MSWIN1255, IW8PC1507, JA16EUC, JA16EUCTILDE, JA16SJIS, JA16SJISTILDE, JA16VMS, KO16KSCCS, KO16MSWIN949, LA8ISO6937, LA8PASSPORT, LT8MSWIN921, LT8PC772, LT8PC774, LV8PC1117, LV8PC8LR, LV8RST104090, N8PC865, NE8ISO8859P10, NEE8ISO8859P4, RU8BESTA, RU8PC855, RU8PC866, SE8ISO8859P3, TH8MACTHAIS, TH8TISASCII, TR8DEC, TR8MACTURKISHS, TR8MSWIN1254, TR8PC857, US7ASCII, US8PC437, UTF8, VN8MSWIN1258, VN8VN3, WE8DEC, WE8DG, WE8ISO8859P15, WE8ISO8859P9, WE8MACROMAN8S, WE8MSWIN1252, WE8NCR4970, WE8NEXTSTEP, WE8PC850, WE8PC858, WE8PC860, WE8ROMAN8, ZHS16CGB231280, ZHS16GBK, ZHT16BIG5, ZHT16CCDC, ZHT16DBT, ZHT16HKSCS, ZHT16MSWIN950, ZHT32EUC, ZHT32SOPS, ZHT32TRIS 
+	* `db_name` - (Required) The database name. It must begin with an alphabetic character and can contain a maximum of eight alphanumeric characters. Special characters are not permitted.
+	* `db_workload` - (Optional) Database workload type.
+	* `ncharacter_set` - (Optional) National character set for the database.  The default is AL16UTF16. Allowed values are: AL16UTF16 or UTF8. 
+	* `pdb_name` - (Optional) Pluggable database name. It must begin with an alphabetic character and can contain a maximum of eight alphanumeric characters. Special characters are not permitted. Pluggable database should not be same as database name.
+* `db_system_id` - (Required) The OCID of the DB System.
+* `db_version` - (Required) A valid Oracle database version. To get a list of supported versions, use the [ListDbVersions](https://docs.us-phoenix-1.oraclecloud.com/api/#/en/database/20160918/DbVersion/ListDbVersions) operation.
+* `display_name` - (Optional) The user-provided name of the database home.
+
+
+## Update Operation
+Patches the specified dbHome.
+
+The following arguments support updates:
+* `db_version` - A valid Oracle database version. To get a list of supported versions, use the [ListDbVersions](https://docs.us-phoenix-1.oraclecloud.com/api/#/en/database/20160918/DbVersion/ListDbVersions) operation.
+
+
+** IMPORTANT **
+Any change to a property that does not support update will force the destruction and recreation of the resource with the new property values
+
+## DBHome Reference
+* `compartment_id` - The OCID of the compartment.
+* `db_system_id` - The OCID of the DB System.
+* `db_version` - The Oracle database version.
+* `display_name` - The user-provided name for the database home. It does not need to be unique.
+* `id` - The OCID of the database home.
+* `last_patch_history_entry_id` - The OCID of the last patch history. This is updated as soon as a patch operation is started.
+* `state` - The current state of the database home.
+* `time_created` - The date and time the database home was created.
+

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"github.com/hashicorp/terraform/plugin"
 	"github.com/hashicorp/terraform/terraform"
+
 	"github.com/oracle/terraform-provider-oci/provider"
 )
 

--- a/provider/database_db_home_data_source.go
+++ b/provider/database_db_home_data_source.go
@@ -11,7 +11,7 @@ import (
 
 func DBHomeDatasource() *schema.Resource {
 	return &schema.Resource{
-		Read: readDBHome,
+		Read: readDBHomeDatasource,
 		Schema: map[string]*schema.Schema{
 			"compartment_id": {
 				Type:     schema.TypeString,
@@ -49,7 +49,7 @@ func DBHomeDatasource() *schema.Resource {
 	}
 }
 
-func readDBHome(d *schema.ResourceData, m interface{}) (e error) {
+func readDBHomeDatasource(d *schema.ResourceData, m interface{}) (e error) {
 	client := m.(*OracleClients)
 	sync := &DBHomeDatasourceCrud{}
 	sync.D = d

--- a/provider/database_db_homes_data_source_test.go
+++ b/provider/database_db_homes_data_source_test.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/oracle/bmcs-go-sdk"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type DatasourceDBHomesTestSuite struct {
+	suite.Suite
+	Client       *baremetal.Client
+	Config       string
+	Provider     terraform.ResourceProvider
+	Providers    map[string]terraform.ResourceProvider
+	ResourceName string
+	List         *baremetal.ListDBHomes
+}
+
+func (s *DatasourceDBHomesTestSuite) SetupTest() {
+	s.Client = testAccClient
+	s.Provider = testAccProvider
+	s.Providers = testAccProviders
+	s.Config = `
+resource "oci_database_db_home" "testDBHome" {
+	#Required
+	database {
+		#Required
+		admin_password = "${var.database_admin_password}"
+		db_name = "${var.database_db_name}"
+
+		#Optional
+		character_set = "${var.database_character_set}"
+		db_workload = "${var.database_db_workload}"
+		ncharacter_set = "${var.database_ncharacter_set}"
+		pdb_name = "${var.database_pdb_name}"
+	}
+	db_system_id = "${var.db_system_id}"
+	db_version = "${var.db_version}"
+
+	#Optional
+	display_name = "${var.display_name}"
+}
+
+	`
+	s.Config += testProviderConfig()
+	s.ResourceName = "data.oci_database_db_homes.t"
+}
+
+func (s *DatasourceDBHomesTestSuite) TestReadDBHomes() {
+
+	resource.UnitTest(s.T(), resource.TestCase{
+		PreventPostDestroyRefresh: true,
+		Providers:                 s.Providers,
+		Steps: []resource.TestStep{
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				Config:            s.Config,
+			},
+			{
+				Config: s.Config + `
+data "oci_database_db_homes" "testDBHomes" {
+	#Required
+	compartment_id = "${var.compartment_id}"
+	db_system_id = "${var.db_system_id}"
+}
+
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(s.ResourceName, "db_homes.0.id"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "db_homes.#"),
+				),
+			},
+		},
+	},
+	)
+}
+
+func TestDatasourceDBHomesTestSuite(t *testing.T) {
+	suite.Run(t, new(DatasourceDBHomesTestSuite))
+}

--- a/provider/database_db_homes_resource.go
+++ b/provider/database_db_homes_resource.go
@@ -1,0 +1,243 @@
+// Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+
+package provider
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/oracle/bmcs-go-sdk"
+
+	"github.com/oracle/terraform-provider-oci/crud"
+)
+
+func DBHomeResource() *schema.Resource {
+	return &schema.Resource{
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: crud.DefaultTimeout,
+		Create:   createDBHome,
+		Read:     readDBHome,
+		Update:   updateDBHome,
+		Delete:   deleteDBHome,
+		Schema: map[string]*schema.Schema{
+			//Required
+			"database": {
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						//Required
+						"admin_password": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"db_name": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+
+						//Optional
+						"character_set": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+						"db_workload": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+						"ncharacter_set": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+						"pdb_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+
+						//Computed
+					},
+				},
+			},
+			"db_system_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"db_version": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			//Optional
+			"display_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			//Computed
+			"compartment_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"last_patch_history_entry_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"time_created": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func createDBHome(d *schema.ResourceData, m interface{}) (e error) {
+	sync := &DBHomeResourceCrud{}
+	sync.D = d
+	sync.Client = m.(*OracleClients).client
+	return crud.CreateResource(d, sync)
+}
+
+func readDBHome(d *schema.ResourceData, m interface{}) (e error) {
+	sync := &DBHomeResourceCrud{}
+	sync.D = d
+	sync.Client = m.(*OracleClients).client
+	return crud.ReadResource(sync)
+}
+
+func updateDBHome(d *schema.ResourceData, m interface{}) (e error) {
+	sync := &DBHomeResourceCrud{}
+	sync.D = d
+	sync.Client = m.(*OracleClients).client
+	return crud.UpdateResource(d, sync)
+}
+
+func deleteDBHome(d *schema.ResourceData, m interface{}) (e error) {
+	sync := &DBHomeResourceCrud{}
+	sync.D = d
+	sync.Client = m.(*OracleClients).clientWithoutNotFoundRetries
+	return crud.DeleteResource(d, sync)
+}
+
+type DBHomeResourceCrud struct {
+	crud.BaseCrud
+	Res *baremetal.DBHome
+}
+
+func (s *DBHomeResourceCrud) ID() string {
+	return s.Res.ID
+}
+
+func (s *DBHomeResourceCrud) CreatedPending() []string {
+	return []string{baremetal.ResourceProvisioning}
+}
+
+func (s *DBHomeResourceCrud) CreatedTarget() []string {
+	return []string{baremetal.ResourceAvailable}
+}
+
+func (s *DBHomeResourceCrud) DeletedPending() []string {
+	return []string{baremetal.ResourceTerminating}
+}
+
+func (s *DBHomeResourceCrud) DeletedTarget() []string {
+	return []string{baremetal.ResourceTerminated}
+}
+
+func (s *DBHomeResourceCrud) Create() (e error) {
+	opts := &baremetal.CreateDBHomeOptions{}
+	databaseRaw := s.D.Get("database").([]interface{})
+	database := &baremetal.CreateDatabaseDetails{}
+	if len(databaseRaw) > 0 {
+		databaseMap := databaseRaw[0].(map[string]interface{})
+		adminPassword := databaseMap["admin_password"].(string)
+		database.AdminPassword = adminPassword
+		dbName := databaseMap["db_name"].(string)
+		database.DBName = dbName
+		characterSet, ok := databaseMap["character_set"]
+		if ok && characterSet != nil {
+			database.CharacterSet = characterSet.(string)
+		}
+		dbWorkload, ok := databaseMap["db_workload"]
+		if ok && dbWorkload != nil {
+			database.DBWorkload = dbWorkload.(string)
+		}
+		ncharacterSet, ok := databaseMap["ncharacter_set"]
+		if ok && ncharacterSet != nil {
+			database.NcharacterSet = ncharacterSet.(string)
+		}
+		pdbName, ok := databaseMap["pdb_name"]
+		if ok && pdbName != nil {
+			database.PDBName = pdbName.(string)
+		}
+
+	}
+	dbSystemID := s.D.Get("db_system_id").(string)
+	dbVersion := s.D.Get("db_version").(string)
+	displayName, ok := s.D.GetOk("display_name")
+	if ok && displayName != nil {
+		opts.DisplayName = displayName.(string)
+	}
+
+	s.Res, e = s.Client.CreateDBHome(database, dbSystemID, dbVersion, opts)
+	return
+}
+
+func (s *DBHomeResourceCrud) Get() (e error) {
+	dbHomeID := s.D.Get("id").(string)
+
+	s.Res, e = s.Client.GetDBHome(dbHomeID)
+	return
+}
+
+func (s *DBHomeResourceCrud) Update() (e error) {
+	opts := &baremetal.UpdateDBHomeOptions{}
+	dbHomeID := s.D.Get("id").(string)
+	dbVersion, ok := s.D.GetOk("db_version")
+	if ok && dbVersion != nil {
+		opts.DBVersion = dbVersion.(string)
+	}
+
+	s.Res, e = s.Client.UpdateDBHome(dbHomeID, opts)
+	return
+}
+
+func (s *DBHomeResourceCrud) Delete() (e error) {
+	dbHomeID := s.D.Get("id").(string)
+
+	e = s.Client.DeleteDBHome(dbHomeID, nil)
+	return
+}
+
+func (s *DBHomeResourceCrud) SetData() {
+	s.D.Set("compartment_id", s.Res.CompartmentID)
+	s.D.Set("db_system_id", s.Res.DBSystemID)
+	s.D.Set("db_version", s.Res.DBVersion)
+	s.D.Set("display_name", s.Res.DisplayName)
+	s.D.Set("id", s.Res.ID)
+	s.D.Set("last_patch_history_entry_id", s.Res.LastPatchHistoryEntryID)
+	s.D.Set("state", s.Res.State)
+	s.D.Set("time_created", s.Res.TimeCreated.String())
+}

--- a/provider/database_db_homes_resource_test.go
+++ b/provider/database_db_homes_resource_test.go
@@ -1,0 +1,216 @@
+// Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+
+package provider
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/oracle/bmcs-go-sdk"
+	"github.com/stretchr/testify/suite"
+)
+
+type ResourceDBHomeTestSuite struct {
+	suite.Suite
+	Client       *baremetal.Client
+	Provider     terraform.ResourceProvider
+	Providers    map[string]terraform.ResourceProvider
+	TimeCreated  baremetal.Time
+	Config       string
+	ResourceName string
+	Res          *baremetal.DBHome
+	DeletedRes   *baremetal.DBHome
+}
+
+func (s *ResourceDBHomeTestSuite) SetupTest() {
+	s.Client = testAccClient
+	s.Provider = testAccProvider
+	s.Providers = testAccProviders
+
+	s.TimeCreated = baremetal.Time{Time: time.Now()}
+
+	s.Config = `
+resource "oci_database_db_home" "testDBHome" {
+	#Required
+	database {
+		#Required
+		admin_password = "${var.database_admin_password}"
+		db_name = "${var.database_db_name}"
+	}
+	db_system_id = "${var.db_system_id}"
+	db_version = "${var.db_version}"
+}
+
+	`
+
+	s.Config += testProviderConfig()
+
+	s.ResourceName = "oci_database_db_home.t"
+
+}
+
+func (s *ResourceDBHomeTestSuite) TestCreateResourceDBHome() {
+
+	resource.UnitTest(s.T(), resource.TestCase{
+		Providers: s.Providers,
+		Steps: []resource.TestStep{
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				Config:            s.Config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(s.ResourceName, "display_name", "display_name"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "id"),
+				),
+			},
+		},
+	})
+}
+
+func (s ResourceDBHomeTestSuite) TestUpdateDBHomeDBVersion() {
+	config := `
+resource "oci_database_db_home" "testDBHome" {
+	#Required
+	database {
+		#Required
+		admin_password = "${var.database_admin_password}"
+		db_name = "${var.database_db_name}"
+	}
+	db_system_id = "${var.db_system_id}"
+	db_version = "${var.db_version}"
+}
+`
+
+	config += testProviderConfig()
+
+	resource.UnitTest(s.T(), resource.TestCase{
+		Providers: s.Providers,
+		Steps: []resource.TestStep{
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				Config:            s.Config,
+			},
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(s.ResourceName, "db_version", "newValue"),
+				),
+			},
+		},
+	})
+}
+
+func (s ResourceDBHomeTestSuite) TestUpdateDatabaseForcesNewDBHome() {
+
+	config := `
+resource "oci_database_db_home" "testDBHome" {
+	#Required
+	database {
+		#Required
+		admin_password = "${var.database_admin_password}"
+		db_name = "${var.database_db_name}"
+	}
+	db_system_id = "${var.db_system_id}"
+	db_version = "${var.db_version}"
+}
+`
+
+	config += testProviderConfig()
+
+	resource.UnitTest(s.T(), resource.TestCase{
+		Providers: s.Providers,
+		Steps: []resource.TestStep{
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				Config:            s.Config,
+			},
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(s.ResourceName, "database", "newValue"),
+				),
+			},
+		},
+	})
+}
+
+func (s ResourceDBHomeTestSuite) TestUpdateDBSystemIDForcesNewDBHome() {
+
+	config := `
+resource "oci_database_db_home" "testDBHome" {
+	#Required
+	database {
+		#Required
+		admin_password = "${var.database_admin_password}"
+		db_name = "${var.database_db_name}"
+	}
+	db_system_id = "${var.db_system_id}"
+	db_version = "${var.db_version}"
+}
+`
+
+	config += testProviderConfig()
+
+	resource.UnitTest(s.T(), resource.TestCase{
+		Providers: s.Providers,
+		Steps: []resource.TestStep{
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				Config:            s.Config,
+			},
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(s.ResourceName, "db_system_id", "newValue"),
+				),
+			},
+		},
+	})
+}
+
+func (s ResourceDBHomeTestSuite) TestUpdateDisplayNameForcesNewDBHome() {
+
+	config := `
+resource "oci_database_db_home" "testDBHome" {
+	#Required
+	database {
+		#Required
+		admin_password = "${var.database_admin_password}"
+		db_name = "${var.database_db_name}"
+	}
+	db_system_id = "${var.db_system_id}"
+	db_version = "${var.db_version}"
+
+	#Optional
+	display_name = "${var.display_name}"
+}
+`
+
+	config += testProviderConfig()
+
+	resource.UnitTest(s.T(), resource.TestCase{
+		Providers: s.Providers,
+		Steps: []resource.TestStep{
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				Config:            s.Config,
+			},
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(s.ResourceName, "display_name", "newValue"),
+				),
+			},
+		},
+	})
+}
+
+func TestResourceDBHomeTestSuite(t *testing.T) {
+	suite.Run(t, new(ResourceDBHomeTestSuite))
+}

--- a/provider/database_db_systems_data_source.go
+++ b/provider/database_db_systems_data_source.go
@@ -85,7 +85,7 @@ func (s *DBSystemDatasourceCrud) SetData() {
 				"admin_password": r.DBHome.Database.AdminPassword,
 				"db_name":        r.DBHome.Database.DBName,
 				"character_set":  r.DBHome.Database.CharacterSet,
-				"ncharacter_set": r.DBHome.Database.NCharacterSet,
+				"ncharacter_set": r.DBHome.Database.NcharacterSet,
 				"pdb_name":       r.DBHome.Database.PDBName,
 				"db_workload":    r.DBHome.Database.DBWorkload,
 			}

--- a/vendor/github.com/oracle/bmcs-go-sdk/database_database.go
+++ b/vendor/github.com/oracle/bmcs-go-sdk/database_database.go
@@ -80,15 +80,6 @@ func (c *Client) ListDatabases(compartmentID, dbHomeID string, limit uint64, opt
 	return
 }
 
-type CreateDatabaseDetails struct {
-	AdminPassword string `header:"-" json:"adminPassword" url:"-"`
-	DBName        string `header:"-" json:"dbName" url:"-"`
-	DBWorkload    string `header:"-" json:"dbWorkload,omitempty" url:"-"`
-	CharacterSet  string `header:"-" json:"characterSet,omitempty" url:"-"`
-	NCharacterSet string `header:"-" json:"ncharacterSet,omitempty" url:"-"`
-	PDBName       string `header:"-" json:"pdbName,omitempty" url:"-"`
-}
-
 func NewCreateDatabaseDetails(adminPassword, dbName string, opts *CreateDatabaseOptions) (db CreateDatabaseDetails) {
 	db = CreateDatabaseDetails{
 		AdminPassword: adminPassword,
@@ -102,7 +93,7 @@ func NewCreateDatabaseDetails(adminPassword, dbName string, opts *CreateDatabase
 			db.CharacterSet = opts.CharacterSet
 		}
 		if opts.NCharacterSet != "" {
-			db.NCharacterSet = opts.NCharacterSet
+			db.NcharacterSet = opts.NCharacterSet
 		}
 		if opts.PDBName != "" {
 			db.PDBName = opts.PDBName

--- a/vendor/github.com/oracle/bmcs-go-sdk/request_options.go
+++ b/vendor/github.com/oracle/bmcs-go-sdk/request_options.go
@@ -207,10 +207,6 @@ type LaunchDBSystemOptions struct {
 	NodeCount                  int            `header:"-" json:"nodeCount,omitempty" url:"-"`
 }
 
-type CreateDBHomeOptions struct {
-	DisplayNameOptions
-}
-
 type CreateDatabaseOptions struct {
 	CharacterSet  string
 	NCharacterSet string

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2972,10 +2972,10 @@
 			"revisionTime": "2017-01-25T16:36:56Z"
 		},
 		{
-			"checksumSHA1": "jU2TjFc4VCRbdD93AmkrF3VbOuA=",
+			"checksumSHA1": "8QfmeaXsBbDe4bwm8iyKUwSSc2M=",
 			"path": "github.com/oracle/bmcs-go-sdk",
-			"revision": "694de4d6e89b05a3428bdc549a47d265f6e704cc",
-			"revisionTime": "2017-11-28T18:53:23Z",
+			"revision": "89d938ef918dc1c16969fbf96f9796ef3ac0f734",
+			"revisionTime": "2017-11-15T22:45:47Z",
 			"version": "add-db-license-model",
 			"versionExact": "add-db-license-model"
 		},


### PR DESCRIPTION
Incorporates the generated support for the DBHomes resource.

The first commit is the actual change. The second commit contains the vendor folder changes which are also out for review (separate repo). Once I get the other changes published, I'll update this PR with another commit for the vendor folder _before_ pushing it.

IMPLEMENTS: https://jira.aka.lgl.grungy.us/browse/ORCH-438