### PR TITLE
Add source port range to security list rules (another rebase)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Unreleased
+
+### Added
+- Support for security list rule source port ranges (#340). This can be specified in "tcp_options" and "udp_options" using "source_port_range".
+
 ## 2.0.4 - 2017-11-2
 
 ### Added

--- a/docs/datasources/core/security_lists.md
+++ b/docs/datasources/core/security_lists.md
@@ -11,8 +11,6 @@ Gets a list of security lists. Each security list is a set of virtual firewall r
 ```
     data "oci_core_security_lists" "t" {
       compartment_id = "compartment_id"
-      limit = 1
-      page = "page"
       vcn_id = "vcn_id"
     }
 ```

--- a/docs/examples/networking/security_list/security_list.tf
+++ b/docs/examples/networking/security_list/security_list.tf
@@ -45,6 +45,7 @@ resource "oci_core_security_list" "ExampleSecurityList" {
     stateless = true
 
     udp_options {
+      // These values correspond to the destination port range.
       "min" = 319
       "max" = 320
     }

--- a/docs/examples/networking/security_list/security_list.tf
+++ b/docs/examples/networking/security_list/security_list.tf
@@ -9,9 +9,6 @@ variable "private_key_path" {}
 variable "compartment_ocid" {}
 variable "region" {}
 
-variable "vcn_ocid" {}
-
-
 provider "oci" {
   tenancy_ocid = "${var.tenancy_ocid}"
   user_ocid = "${var.user_ocid}"
@@ -20,13 +17,20 @@ provider "oci" {
   region = "${var.region}"
 }
 
+resource "oci_core_virtual_network" "ExampleVCN" {
+  cidr_block = "10.0.0.0/16"
+  dns_label = "examplevcn"
+  compartment_id = "${var.compartment_ocid}"
+  display_name = "ExampleVCN"
+}
+
 # Protocols are specified as protocol numbers.
 # http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
 
-resource "oci_core_security_list" "security_list1" {
+resource "oci_core_security_list" "ExampleSecurityList" {
   compartment_id = "${var.compartment_ocid}"
-  vcn_id = "${var.vcn_ocid}"
-  display_name = "security_list1"
+  vcn_id = "${oci_core_virtual_network.ExampleVCN.id}"
+  display_name = "ExampleSecurityList"
 
   // allow outbound tcp traffic on all ports
   egress_security_rules {
@@ -46,13 +50,18 @@ resource "oci_core_security_list" "security_list1" {
     }
   }
 
-  // allow inbound ssh traffic
+  // allow inbound ssh traffic from a specific port
   ingress_security_rules {
     protocol = "6" // tcp
     source = "0.0.0.0/0"
     stateless = false
 
     tcp_options {
+      source_port_range {
+        "min" = 100
+        "max" = 100
+      }
+      // These values correspond to the destination port range.
       "min" = 22
       "max" = 22
     }

--- a/docs/resources/core/security_list.md
+++ b/docs/resources/core/security_list.md
@@ -38,8 +38,13 @@ resource "oci_core_security_list" "t" {
         stateless = true
 
         tcp_options {
-            "min" = 80
-            "max" = 82
+            source_port_range {
+                "min" = 100
+                "max" = 100
+             }
+             // These values correspond to the destination port range.
+             "min" = 22
+             "max" = 22
         }
     }
 
@@ -49,6 +54,8 @@ resource "oci_core_security_list" "t" {
         stateless = true
 
         udp_options {
+            // These values correspond to the destination port range.
+            // source_port_range may also be specified.
             "min" = 319
             "max" = 320
         }

--- a/docs/resources/core/security_list.md
+++ b/docs/resources/core/security_list.md
@@ -41,10 +41,10 @@ resource "oci_core_security_list" "t" {
             source_port_range {
                 "min" = 100
                 "max" = 100
-             }
-             // These values correspond to the destination port range.
-             "min" = 22
-             "max" = 22
+            }
+            // These values correspond to the destination port range.
+            "min" = 22
+            "max" = 22
         }
     }
 

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"github.com/hashicorp/terraform/plugin"
 	"github.com/hashicorp/terraform/terraform"
+
 	"github.com/oracle/terraform-provider-oci/provider"
 )
 

--- a/provider/core_security_list_resource.go
+++ b/provider/core_security_list_resource.go
@@ -5,6 +5,7 @@ package provider
 import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/oracle/bmcs-go-sdk"
+
 	"github.com/oracle/terraform-provider-oci/crud"
 )
 
@@ -469,12 +470,13 @@ func buildPortRange(conf []interface{}) (portRange *baremetal.PortRange) {
 	if len(conf) > 0 && conf[0] != nil {
 		mapConf := conf[0].(map[string]interface{})
 
-		// The ok value will always be true, so we need to check against the default value instead.
 		max := mapConf["max"].(int)
 		min := mapConf["min"].(int)
 
 		// Max and Min default to 0, and that is not a valid port number, so we can assume that if
 		// the value is 0 then the user has not set the port number.
+		// Also, note that if either max or min is set, then the service will return an error if both are not
+		// set. However, we want to create the PortRange if either is set and let the service return the error.
 		if max != 0 || min != 0 {
 			portRange = &baremetal.PortRange{
 				Max: uint64(max),
@@ -495,31 +497,7 @@ func (s *SecurityListResourceCrud) buildSourceAndDestinationPortRanges(conf []in
 	return
 }
 
-func buildConfICMPOptions(opts *baremetal.ICMPOptions) (list []interface{}) {
-	confOpts := map[string]interface{}{
-		"code": int(opts.Code),
-		"type": int(opts.Type),
-	}
-	return []interface{}{confOpts}
-}
-
-func buildConfTransportOptions(destinationPortRange *baremetal.PortRange, sourcePortRange *baremetal.PortRange) (list []interface{}) {
-	confOpts := map[string]interface{}{}
-	if destinationPortRange != nil {
-		confOpts["max"] = int(destinationPortRange.Max)
-		confOpts["min"] = int(destinationPortRange.Min)
-	}
-
-	if sourcePortRange != nil {
-		confOpts["source_port_range"] = []interface{}{map[string]interface{}{
-			"max": int(sourcePortRange.Max),
-			"min": int(sourcePortRange.Min),
-		}}
-	}
-
-	return []interface{}{confOpts}
-}
-
+// Used to build rule lists for SetData.
 func buildConfRuleLists(res *baremetal.SecurityList) (confEgressRules, confIngressRules []map[string]interface{}) {
 	for _, egressRule := range res.EgressSecurityRules {
 		confEgressRule := map[string]interface{}{}
@@ -552,6 +530,7 @@ func buildConfRuleLists(res *baremetal.SecurityList) (confEgressRules, confIngre
 	return
 }
 
+// Used to build rules for SetData.
 func buildConfRule(
 	confRule map[string]interface{},
 	protocol string,
@@ -574,4 +553,31 @@ func buildConfRule(
 		confRule["stateless"] = *stateless
 	}
 	return confRule
+}
+
+// Used to build ICMP options for SetData.
+func buildConfICMPOptions(opts *baremetal.ICMPOptions) (list []interface{}) {
+	confOpts := map[string]interface{}{
+		"code": int(opts.Code),
+		"type": int(opts.Type),
+	}
+	return []interface{}{confOpts}
+}
+
+// Used to build TCP/UDP port ranges for SetData.
+func buildConfTransportOptions(destinationPortRange *baremetal.PortRange, sourcePortRange *baremetal.PortRange) (list []interface{}) {
+	confOpts := map[string]interface{}{}
+	if destinationPortRange != nil {
+		confOpts["max"] = int(destinationPortRange.Max)
+		confOpts["min"] = int(destinationPortRange.Min)
+	}
+
+	if sourcePortRange != nil {
+		confOpts["source_port_range"] = []interface{}{map[string]interface{}{
+			"max": int(sourcePortRange.Max),
+			"min": int(sourcePortRange.Min),
+		}}
+	}
+
+	return []interface{}{confOpts}
 }

--- a/provider/core_security_list_resource.go
+++ b/provider/core_security_list_resource.go
@@ -5,7 +5,6 @@ package provider
 import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/oracle/bmcs-go-sdk"
-
 	"github.com/oracle/terraform-provider-oci/crud"
 )
 
@@ -15,13 +14,31 @@ var transportSchema = &schema.Schema{
 	MaxItems: 1,
 	Elem: &schema.Resource{
 		Schema: map[string]*schema.Schema{
+			"source_port_range": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				MinItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"max": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"min": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+					},
+				},
+			},
 			"max": {
 				Type:     schema.TypeInt,
-				Required: true,
+				Optional: true,
 			},
 			"min": {
 				Type:     schema.TypeInt,
-				Required: true,
+				Optional: true,
 			},
 		},
 	},
@@ -153,7 +170,7 @@ func SecurityListResource() *schema.Resource {
 			},
 			"egress_security_rules": {
 				Type:     schema.TypeList,
-				Required: true,
+				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"destination": {
@@ -181,7 +198,7 @@ func SecurityListResource() *schema.Resource {
 			},
 			"ingress_security_rules": {
 				Type:     schema.TypeList,
-				Required: true,
+				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"icmp_options": icmpSchema,
@@ -336,48 +353,20 @@ func (s *SecurityListResourceCrud) Update() (e error) {
 	}
 
 	s.Res, e = s.Client.UpdateSecurityList(s.D.Id(), opts)
+
 	return
 }
 
 func (s *SecurityListResourceCrud) SetData() {
 	s.D.Set("compartment_id", s.Res.CompartmentID)
 	s.D.Set("display_name", s.Res.DisplayName)
-
-	confEgressRules := []map[string]interface{}{}
-	for _, egressRule := range s.Res.EgressSecurityRules {
-		confEgressRule := map[string]interface{}{}
-		confEgressRule["destination"] = egressRule.Destination
-		confEgressRule = buildConfRule(
-			confEgressRule,
-			egressRule.Protocol,
-			egressRule.ICMPOptions,
-			egressRule.TCPOptions,
-			egressRule.UDPOptions,
-			&egressRule.IsStateless,
-		)
-		confEgressRules = append(confEgressRules, confEgressRule)
-	}
-	s.D.Set("egress_security_rules", confEgressRules)
-
-	confIngressRules := []map[string]interface{}{}
-	for _, ingressRule := range s.Res.IngressSecurityRules {
-		confIngressRule := map[string]interface{}{}
-		confIngressRule["source"] = ingressRule.Source
-		confIngressRule = buildConfRule(
-			confIngressRule,
-			ingressRule.Protocol,
-			ingressRule.ICMPOptions,
-			ingressRule.TCPOptions,
-			ingressRule.UDPOptions,
-			&ingressRule.IsStateless,
-		)
-		confIngressRules = append(confIngressRules, confIngressRule)
-	}
-	s.D.Set("ingress_security_rules", confIngressRules)
-
 	s.D.Set("state", s.Res.State)
 	s.D.Set("time_created", s.Res.TimeCreated.String())
 	s.D.Set("vcn_id", s.Res.VcnID)
+
+	confEgressRules, confIngressRules := buildConfRuleLists(s.Res)
+	s.D.Set("egress_security_rules", confEgressRules)
+	s.D.Set("ingress_security_rules", confIngressRules)
 }
 
 func (s *SecurityListResourceCrud) reset() (e error) {
@@ -453,30 +442,56 @@ func (s *SecurityListResourceCrud) buildICMPOptions(conf map[string]interface{})
 }
 
 func (s *SecurityListResourceCrud) buildTCPOptions(conf map[string]interface{}) (opts *baremetal.TCPOptions) {
-	l := conf["tcp_options"].([]interface{})
-	if len(l) > 0 {
-		confOpts := l[0].(map[string]interface{})
+	options := conf["tcp_options"].([]interface{})
+	if len(options) > 0 {
+		sourcePortRange, destinationPortRange := s.buildSourceAndDestinationPortRanges(options)
 		opts = &baremetal.TCPOptions{
-			baremetal.PortRange{
-				Max: uint64(confOpts["max"].(int)),
-				Min: uint64(confOpts["min"].(int)),
-			},
+			destinationPortRange,
+			sourcePortRange,
 		}
 	}
 	return
 }
 
 func (s *SecurityListResourceCrud) buildUDPOptions(conf map[string]interface{}) (opts *baremetal.UDPOptions) {
-	l := conf["udp_options"].([]interface{})
-	if len(l) > 0 {
-		confOpts := l[0].(map[string]interface{})
+	options := conf["udp_options"].([]interface{})
+	if len(options) > 0 {
+		sourcePortRange, destinationPortRange := s.buildSourceAndDestinationPortRanges(options)
 		opts = &baremetal.UDPOptions{
-			baremetal.PortRange{
-				Max: uint64(confOpts["max"].(int)),
-				Min: uint64(confOpts["min"].(int)),
-			},
+			destinationPortRange,
+			sourcePortRange,
 		}
 	}
+	return
+}
+
+func buildPortRange(conf []interface{}) (portRange *baremetal.PortRange) {
+	if len(conf) > 0 && conf[0] != nil {
+		mapConf := conf[0].(map[string]interface{})
+
+		// The ok value will always be true, so we need to check against the default value instead.
+		max := mapConf["max"].(int)
+		min := mapConf["min"].(int)
+
+		// Max and Min default to 0, and that is not a valid port number, so we can assume that if
+		// the value is 0 then the user has not set the port number.
+		if max != 0 || min != 0 {
+			portRange = &baremetal.PortRange{
+				Max: uint64(max),
+				Min: uint64(min),
+			}
+		}
+	}
+	return
+}
+
+func (s *SecurityListResourceCrud) buildSourceAndDestinationPortRanges(conf []interface{}) (sourcePortRange, destinationPortRange *baremetal.PortRange) {
+	if len(conf) > 0 && conf[0] != nil {
+		mapConf := conf[0].(map[string]interface{})
+		sourcePortRange = buildPortRange(mapConf["source_port_range"].([]interface{}))
+		destinationPortRange = buildPortRange(conf)
+	}
+
 	return
 }
 
@@ -488,12 +503,53 @@ func buildConfICMPOptions(opts *baremetal.ICMPOptions) (list []interface{}) {
 	return []interface{}{confOpts}
 }
 
-func buildConfTransportOptions(portRange baremetal.PortRange) (list []interface{}) {
-	confOpts := map[string]interface{}{
-		"max": int(portRange.Max),
-		"min": int(portRange.Min),
+func buildConfTransportOptions(destinationPortRange *baremetal.PortRange, sourcePortRange *baremetal.PortRange) (list []interface{}) {
+	confOpts := map[string]interface{}{}
+	if destinationPortRange != nil {
+		confOpts["max"] = int(destinationPortRange.Max)
+		confOpts["min"] = int(destinationPortRange.Min)
 	}
+
+	if sourcePortRange != nil {
+		confOpts["source_port_range"] = []interface{}{map[string]interface{}{
+			"max": int(sourcePortRange.Max),
+			"min": int(sourcePortRange.Min),
+		}}
+	}
+
 	return []interface{}{confOpts}
+}
+
+func buildConfRuleLists(res *baremetal.SecurityList) (confEgressRules, confIngressRules []map[string]interface{}) {
+	for _, egressRule := range res.EgressSecurityRules {
+		confEgressRule := map[string]interface{}{}
+		confEgressRule["destination"] = egressRule.Destination
+		confEgressRule = buildConfRule(
+			confEgressRule,
+			egressRule.Protocol,
+			egressRule.ICMPOptions,
+			egressRule.TCPOptions,
+			egressRule.UDPOptions,
+			&egressRule.IsStateless,
+		)
+		confEgressRules = append(confEgressRules, confEgressRule)
+	}
+
+	for _, ingressRule := range res.IngressSecurityRules {
+		confIngressRule := map[string]interface{}{}
+		confIngressRule["source"] = ingressRule.Source
+		confIngressRule = buildConfRule(
+			confIngressRule,
+			ingressRule.Protocol,
+			ingressRule.ICMPOptions,
+			ingressRule.TCPOptions,
+			ingressRule.UDPOptions,
+			&ingressRule.IsStateless,
+		)
+		confIngressRules = append(confIngressRules, confIngressRule)
+	}
+
+	return
 }
 
 func buildConfRule(
@@ -509,10 +565,10 @@ func buildConfRule(
 		confRule["icmp_options"] = buildConfICMPOptions(icmpOpts)
 	}
 	if tcpOpts != nil {
-		confRule["tcp_options"] = buildConfTransportOptions(tcpOpts.DestinationPortRange)
+		confRule["tcp_options"] = buildConfTransportOptions(tcpOpts.DestinationPortRange, tcpOpts.SourcePortRange)
 	}
 	if udpOpts != nil {
-		confRule["udp_options"] = buildConfTransportOptions(udpOpts.DestinationPortRange)
+		confRule["udp_options"] = buildConfTransportOptions(udpOpts.DestinationPortRange, udpOpts.SourcePortRange)
 	}
 	if stateless != nil {
 		confRule["stateless"] = *stateless

--- a/provider/core_security_list_resource.go
+++ b/provider/core_security_list_resource.go
@@ -447,8 +447,8 @@ func (s *SecurityListResourceCrud) buildTCPOptions(conf map[string]interface{}) 
 	if len(options) > 0 {
 		sourcePortRange, destinationPortRange := s.buildSourceAndDestinationPortRanges(options)
 		opts = &baremetal.TCPOptions{
-			destinationPortRange,
-			sourcePortRange,
+			DestinationPortRange: destinationPortRange,
+			SourcePortRange:      sourcePortRange,
 		}
 	}
 	return
@@ -459,8 +459,8 @@ func (s *SecurityListResourceCrud) buildUDPOptions(conf map[string]interface{}) 
 	if len(options) > 0 {
 		sourcePortRange, destinationPortRange := s.buildSourceAndDestinationPortRanges(options)
 		opts = &baremetal.UDPOptions{
-			destinationPortRange,
-			sourcePortRange,
+			DestinationPortRange: destinationPortRange,
+			SourcePortRange:      sourcePortRange,
 		}
 	}
 	return
@@ -500,30 +500,26 @@ func (s *SecurityListResourceCrud) buildSourceAndDestinationPortRanges(conf []in
 // Used to build rule lists for SetData.
 func buildConfRuleLists(res *baremetal.SecurityList) (confEgressRules, confIngressRules []map[string]interface{}) {
 	for _, egressRule := range res.EgressSecurityRules {
-		confEgressRule := map[string]interface{}{}
-		confEgressRule["destination"] = egressRule.Destination
-		confEgressRule = buildConfRule(
-			confEgressRule,
+		confEgressRule := buildConfRule(
 			egressRule.Protocol,
 			egressRule.ICMPOptions,
 			egressRule.TCPOptions,
 			egressRule.UDPOptions,
 			&egressRule.IsStateless,
 		)
+		confEgressRule["destination"] = egressRule.Destination
 		confEgressRules = append(confEgressRules, confEgressRule)
 	}
 
 	for _, ingressRule := range res.IngressSecurityRules {
-		confIngressRule := map[string]interface{}{}
-		confIngressRule["source"] = ingressRule.Source
-		confIngressRule = buildConfRule(
-			confIngressRule,
+		confIngressRule := buildConfRule(
 			ingressRule.Protocol,
 			ingressRule.ICMPOptions,
 			ingressRule.TCPOptions,
 			ingressRule.UDPOptions,
 			&ingressRule.IsStateless,
 		)
+		confIngressRule["source"] = ingressRule.Source
 		confIngressRules = append(confIngressRules, confIngressRule)
 	}
 
@@ -532,13 +528,13 @@ func buildConfRuleLists(res *baremetal.SecurityList) (confEgressRules, confIngre
 
 // Used to build rules for SetData.
 func buildConfRule(
-	confRule map[string]interface{},
 	protocol string,
 	icmpOpts *baremetal.ICMPOptions,
 	tcpOpts *baremetal.TCPOptions,
 	udpOpts *baremetal.UDPOptions,
 	stateless *bool,
-) map[string]interface{} {
+) (confRule map[string]interface{}) {
+	confRule = map[string]interface{}{}
 	confRule["protocol"] = protocol
 	if icmpOpts != nil {
 		confRule["icmp_options"] = buildConfICMPOptions(icmpOpts)

--- a/provider/core_security_list_resource_test.go
+++ b/provider/core_security_list_resource_test.go
@@ -13,52 +13,13 @@ import (
 
 type ResourceCoreSecurityListTestSuite struct {
 	suite.Suite
-	Client         *baremetal.Client
-	Provider       terraform.ResourceProvider
-	Providers      map[string]terraform.ResourceProvider
-	Config         string
-	ResourceName   string
-	DataSourceName string
+	Client              *baremetal.Client
+	Provider            terraform.ResourceProvider
+	Providers           map[string]terraform.ResourceProvider
+	Config              string
+	ResourceName        string
+	DataSourceName      string
 	DefaultResourceName string
-	FullConfig     string
-}
-
-var defaultSecurityList = `
-resource "oci_core_default_security_list" "default" {
-	manage_default_resource_id = "${oci_core_virtual_network.t.default_security_list_id}"
-	display_name = "default-tf-security_list"
-	egress_security_rules = [{
-		destination = "0.0.0.0/0"
-		protocol = "6"
-	}]
-	ingress_security_rules = [{
-		protocol = "1"
-		source = "0.0.0.0/0"
-		icmp_options {
-			"type" = 3
-			"code" = 4
-		}
-	},
-	{
-		protocol = "6"
-		source = "0.0.0.0/0"
-		tcp_options {
-			"min" = 80
-			"max" = 80
-		}
-	},
-	{
-		protocol = "17"
-		source = "10.0.0.0/16"
-		udp_options {
-			"min" = 319
-			"max" = 320
-		}
-	}]
-}`
-
-func extraWait(ew crud.ExtraWaitPostCreateDelete) {
-	return
 }
 
 func (s *ResourceCoreSecurityListTestSuite) SetupTest() {
@@ -70,104 +31,107 @@ func (s *ResourceCoreSecurityListTestSuite) SetupTest() {
 			cidr_block = "10.0.0.0/16"
 			compartment_id = "${var.compartment_id}"
 			display_name = "-tf-vcn"
-		}
-	    data "oci_core_security_lists" "t" {
-			compartment_id = "${var.compartment_id}"
-			vcn_id = "${oci_core_virtual_network.t.id}"
-			filter {
-				name = "display_name"
-				values = ["${oci_core_security_list.t.display_name}"]
-			}
 		}`
 	s.ResourceName = "oci_core_security_list.t"
 	s.DefaultResourceName = "oci_core_default_security_list.default"
 	s.DataSourceName = "data.oci_core_security_lists.t"
-
-	s.FullConfig = `
-		resource "oci_core_security_list" "t" {
-			compartment_id = "${var.compartment_id}"
-			display_name = "-tf-security_list"
-			vcn_id = "${oci_core_virtual_network.t.id}"
-			egress_security_rules = {
-				destination = "0.0.0.0/1"
-				protocol = "6"
-			}
-			egress_security_rules = {
-				destination = "0.0.0.0/2"
-				protocol = "1"
-				stateless = true
-				icmp_options {
-					"type" = 3
-					"code" = 4
-				}
-			}
-			egress_security_rules = {
-				destination = "0.0.0.0/3"
-				protocol = "6"
-				stateless = false
-				tcp_options {
-					"min" = 10
-					"max" = 11
-					source_port_range {
-						"min" = 20
-						"max" = 21
-					}
-				}
-			}
-			egress_security_rules = {
-				destination = "0.0.0.0/4"
-				protocol = "17"
-				udp_options {
-					"min" = 30
-					"max" = 31
-					source_port_range {
-						"min" = 40
-						"max" = 41
-					}
-				}
-			}
-			ingress_security_rules = [{
-				protocol = "1"
-				source = "0.0.0.0/5"
-			},
-			{
-				protocol = "1"
-				source = "0.0.0.0/6"
-				icmp_options {
-					"type" = 3
-					"code" = 4
-				}
-			},
-			{
-				protocol = "6"
-				stateless = true
-				source = "0.0.0.0/7"
-				tcp_options {
-					"min" = 50
-					"max" = 51
-					source_port_range {
-						"min" = 60
-						"max" = 61
-					}
-				}
-			},
-			{
-				protocol = "17"
-				stateless = false
-				source = "10.0.0.0/8"
-				udp_options {
-					"min" = 70
-					"max" = 71
-					source_port_range {
-						"min" = 80
-						"max" = 81
-					}
-				}
-			}]
-		}
-	`
 }
 
+var dataSource = `
+	data "oci_core_security_lists" "t" {
+		compartment_id = "${var.compartment_id}"
+		vcn_id = "${oci_core_virtual_network.t.id}"
+		filter {
+			name = "display_name"
+			values = ["${oci_core_security_list.t.display_name}"]
+		}
+	}`
+
+var fullConfig = `
+	resource "oci_core_security_list" "t" {
+		compartment_id = "${var.compartment_id}"
+		display_name = "-tf-security_list"
+		vcn_id = "${oci_core_virtual_network.t.id}"
+		egress_security_rules = {
+			destination = "0.0.0.0/1"
+			protocol = "6"
+		}
+		egress_security_rules = {
+			destination = "0.0.0.0/2"
+			protocol = "1"
+			stateless = true
+			icmp_options {
+				"type" = 3
+				"code" = 4
+			}
+		}
+		egress_security_rules = {
+			destination = "0.0.0.0/3"
+			protocol = "6"
+			stateless = false
+			tcp_options {
+				"min" = 10
+				"max" = 11
+				source_port_range {
+					"min" = 20
+					"max" = 21
+				}
+			}
+		}
+		egress_security_rules = {
+			destination = "0.0.0.0/4"
+			protocol = "17"
+			udp_options {
+				"min" = 30
+				"max" = 31
+				source_port_range {
+					"min" = 40
+					"max" = 41
+				}
+			}
+		}
+		ingress_security_rules = [{
+			protocol = "1"
+			source = "0.0.0.0/5"
+		},
+		{
+			protocol = "1"
+			source = "0.0.0.0/6"
+			icmp_options {
+				"type" = 3
+				"code" = 4
+			}
+		},
+		{
+			protocol = "6"
+			stateless = true
+			source = "0.0.0.0/7"
+			tcp_options {
+				"min" = 50
+				"max" = 51
+				source_port_range {
+					"min" = 60
+					"max" = 61
+				}
+			}
+		},
+		{
+			protocol = "17"
+			stateless = false
+			source = "10.0.0.0/8"
+			udp_options {
+				"min" = 70
+				"max" = 71
+				source_port_range {
+					"min" = 80
+					"max" = 81
+				}
+			}
+		}]
+	}
+`
+
+// Verifies the contents of fullConfig, with parameters that allows this to be checked via eithier a resource or a data source.
 func (s *ResourceCoreSecurityListTestSuite) BuildTestsForFullConfig(resourceName, prefix string) []resource.TestCheckFunc {
 	return []resource.TestCheckFunc{
 		resource.TestCheckResourceAttr(resourceName, prefix+"display_name", "-tf-security_list"),
@@ -252,13 +216,13 @@ func (s *ResourceCoreSecurityListTestSuite) TestAccResourceCoreSecurityList_basi
 			{
 				ImportState:       true,
 				ImportStateVerify: true,
-				Config:            s.Config + s.FullConfig,
+				Config:            s.Config + dataSource + fullConfig,
 				Check: resource.ComposeTestCheckFunc(append(s.BuildTestsForFullConfig(s.ResourceName, ""),
 					s.BuildTestsForFullConfig(s.DataSourceName, "security_lists.0.")...)...),
 			},
 			// Plan with the same config should do nothing
 			{
-				Config:             s.Config + s.FullConfig,
+				Config:             s.Config + dataSource + fullConfig,
 				ExpectNonEmptyPlan: false,
 				PlanOnly:           true,
 			},
@@ -275,7 +239,8 @@ func (s *ResourceCoreSecurityListTestSuite) TestAccResourceCoreSecurityList_basi
 							destination = "0.0.0.0/1"
 							protocol = "6"
 						}
-					}` + defaultSecurityList,
+					}
+				`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.#", "1"),
 					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.0.destination", "0.0.0.0/1"),
@@ -285,13 +250,6 @@ func (s *ResourceCoreSecurityListTestSuite) TestAccResourceCoreSecurityList_basi
 					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.0.udp_options.#", "0"),
 					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.0.icmp_options.#", "0"),
 					resource.TestCheckResourceAttr(s.ResourceName, "ingress_security_rules.#", "0"),
-					resource.TestCheckResourceAttr(s.DefaultResourceName, "display_name", "default-tf-security_list"),
-					resource.TestCheckResourceAttr(s.DefaultResourceName, "egress_security_rules.#", "1"),
-					resource.TestCheckResourceAttr(s.DefaultResourceName, "egress_security_rules.0.stateless", "false"),
-					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.#", "3"),
-					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.0.icmp_options.0.type", "3"),
-					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.1.tcp_options.0.max", "80"),
-					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.2.udp_options.0.max", "320"),
 				),
 			},
 			// Update to zero rules
@@ -340,77 +298,8 @@ func (s *ResourceCoreSecurityListTestSuite) TestAccResourceCoreSecurityList_basi
 							}
 						}
 					}
-
-					resource "oci_core_default_security_list" "default" {
-						manage_default_resource_id = "${oci_core_virtual_network.t.default_security_list_id}"
-						display_name = "default-tf-security_list-updated"
-						egress_security_rules = [{
-							destination = "0.0.0.0/0"
-							protocol = "17"
-							stateless = true
-						}]
-						ingress_security_rules = [{
-							protocol = "1"
-							source = "0.0.0.0/0"
-							stateless = true
-							icmp_options {
-								"type" = 5
-								"code" = 0
-							}
-						},
-						{
-							protocol = "6"
-							source = "0.0.0.0/0"
-							stateless = true
-							tcp_options {
-								"min" = 80
-								"max" = 82
-							}
-						},
-						{
-							protocol = "17"
-							source = "10.0.0.0/16"
-							stateless = true
-						}]
-					}
 				`,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(s.ResourceName, "display_name", "-tf-security_list-updated"),
-					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.0.protocol", "17"),
-					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.0.stateless", "true"),
-					resource.TestCheckResourceAttr(s.ResourceName, "ingress_security_rules.0.stateless", "true"),
-					resource.TestCheckResourceAttr(s.ResourceName, "ingress_security_rules.0.icmp_options.0.type", "5"),
-					resource.TestCheckResourceAttr(s.ResourceName, "ingress_security_rules.1.tcp_options.0.max", "82"),
-					resource.TestCheckResourceAttr(s.ResourceName, "ingress_security_rules.1.stateless", "true"),
-					resource.TestCheckResourceAttr(s.ResourceName, "ingress_security_rules.2.stateless", "true"),
-					resource.TestCheckNoResourceAttr(s.ResourceName, "ingress_security_rules.2.udp_options"),
-					resource.TestCheckResourceAttr(s.DefaultResourceName, "display_name", "default-tf-security_list-updated"),
-					resource.TestCheckResourceAttr(s.DefaultResourceName, "egress_security_rules.0.protocol", "17"),
-					resource.TestCheckResourceAttr(s.DefaultResourceName, "egress_security_rules.0.stateless", "true"),
-					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.0.stateless", "true"),
-					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.0.icmp_options.0.type", "5"),
-					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.1.tcp_options.0.max", "82"),
-					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.1.stateless", "true"),
-					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.2.stateless", "true"),
-					resource.TestCheckNoResourceAttr(s.DefaultResourceName, "ingress_security_rules.2.udp_options"),
-				),
-			},
-			// Verify removing the default resource
-			{
-				Config: s.Config,
-				Check:  nil,
-			},
-			// verify adding the default resource again
-			{
-				Config: s.Config + defaultSecurityList,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(s.DefaultResourceName, "display_name", "default-tf-security_list"),
-					resource.TestCheckResourceAttr(s.DefaultResourceName, "egress_security_rules.#", "1"),
-					resource.TestCheckResourceAttr(s.DefaultResourceName, "egress_security_rules.0.stateless", "false"),
-					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.#", "3"),
-					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.0.icmp_options.0.type", "3"),
-					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.1.tcp_options.0.max", "80"),
-					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.2.udp_options.0.max", "320"),
 					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.#", "2"),
 					resource.TestCheckResourceAttr(s.ResourceName, "ingress_security_rules.#", "0"),
 					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.0.destination", "0.0.0.0/3"),
@@ -470,15 +359,162 @@ func (s *ResourceCoreSecurityListTestSuite) TestAccResourceCoreSecurityList_empt
 			{
 				ImportState:       true,
 				ImportStateVerify: true,
-				Config:            s.Config + s.FullConfig,
+				Config:            s.Config + dataSource + fullConfig,
 				Check:             resource.ComposeTestCheckFunc(s.BuildTestsForFullConfig(s.ResourceName, "")...),
 			},
 			// Apply the same config and check the data source, since the data source will not have updated on the previous apply.
 			{
 				ImportState:       true,
 				ImportStateVerify: true,
-				Config:            s.Config + s.FullConfig,
+				Config:            s.Config + dataSource + fullConfig,
 				Check:             resource.ComposeTestCheckFunc(s.BuildTestsForFullConfig(s.DataSourceName, "security_lists.0.")...),
+			},
+		},
+	})
+}
+
+func (s *ResourceCoreSecurityListTestSuite) TestAccResourceCoreSecurityList_defaultSecurityList() {
+	defaultSecurityList := `
+		resource "oci_core_default_security_list" "default" {
+			manage_default_resource_id = "${oci_core_virtual_network.t.default_security_list_id}"
+			display_name = "default-tf-security_list"
+			egress_security_rules = [{
+				destination = "0.0.0.0/0"
+				protocol = "6"
+			}]
+			ingress_security_rules = [{
+				protocol = "1"
+				source = "0.0.0.0/0"
+				icmp_options {
+					"type" = 3
+					"code" = 4
+				}
+			},
+			{
+				protocol = "6"
+				source = "0.0.0.0/0"
+				tcp_options {
+					"min" = 80
+					"max" = 80
+				}
+			},
+			{
+				protocol = "17"
+				source = "10.0.0.0/16"
+				udp_options {
+					"min" = 319
+					"max" = 320
+				}
+			}]
+		}`
+	resource.Test(s.T(), resource.TestCase{
+		Providers: s.Providers,
+		Steps: []resource.TestStep{
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				Config:            s.Config + defaultSecurityList,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "display_name", "default-tf-security_list"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "egress_security_rules.#", "1"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "egress_security_rules.0.stateless", "false"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.#", "3"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.0.icmp_options.0.type", "3"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.1.tcp_options.0.max", "80"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.2.udp_options.0.max", "320"),
+				),
+			},
+			// Update
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				Config: s.Config + `
+					resource "oci_core_default_security_list" "default" {
+						manage_default_resource_id = "${oci_core_virtual_network.t.default_security_list_id}"
+						display_name = "default-tf-security_list-updated"
+						egress_security_rules = [{
+							destination = "0.0.0.0/0"
+							protocol = "17"
+							stateless = true
+						}]
+						ingress_security_rules = [{
+							protocol = "1"
+							source = "0.0.0.0/0"
+							stateless = true
+							icmp_options {
+								"type" = 5
+								"code" = 0
+							}
+						},
+						{
+							protocol = "6"
+							source = "0.0.0.0/0"
+							stateless = true
+							tcp_options {
+								source_port_range {
+									"min" = 99
+									"max" = 100
+								}
+							}
+						},
+						{
+							protocol = "17"
+							source = "10.0.0.0/16"
+							stateless = true
+						}]
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "display_name", "default-tf-security_list-updated"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "egress_security_rules.0.protocol", "17"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "egress_security_rules.0.stateless", "true"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.0.stateless", "true"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.0.icmp_options.0.type", "5"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.1.tcp_options.0.source_port_range.0.max", "100"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.1.stateless", "true"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.2.stateless", "true"),
+					resource.TestCheckNoResourceAttr(s.DefaultResourceName, "ingress_security_rules.2.udp_options"),
+				),
+			},
+			// Verify removing the default resource
+			{
+				Config: s.Config,
+				Check:  nil,
+			},
+			// verify adding the default resource again
+			{
+				Config: s.Config + defaultSecurityList,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "display_name", "default-tf-security_list"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "egress_security_rules.#", "1"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "egress_security_rules.0.stateless", "false"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.#", "3"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.0.icmp_options.0.type", "3"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.1.tcp_options.0.max", "80"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.2.udp_options.0.max", "320"),
+				),
+			},
+			// Verify lists can be cleared out. Also try adding an additional security list.
+			{
+				Config: s.Config + `
+					resource "oci_core_default_security_list" "default" {
+						manage_default_resource_id = "${oci_core_virtual_network.t.default_security_list_id}"
+						display_name = "default-tf-security_list-updated"
+						egress_security_rules = []
+						ingress_security_rules = []
+					}
+					resource "oci_core_security_list" "t" {
+						compartment_id = "${var.compartment_id}"
+						display_name = "-tf-security_list"
+						vcn_id = "${oci_core_virtual_network.t.id}"
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.#", "0"),
+					resource.TestCheckResourceAttr(s.ResourceName, "ingress_security_rules.#", "0"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "egress_security_rules.#", "0"),
+					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.#", "0"),
+				),
 			},
 		},
 	})

--- a/provider/core_security_list_resource_test.go
+++ b/provider/core_security_list_resource_test.go
@@ -9,18 +9,18 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/oracle/bmcs-go-sdk"
 	"github.com/stretchr/testify/suite"
-
-	"github.com/oracle/terraform-provider-oci/crud"
 )
 
 type ResourceCoreSecurityListTestSuite struct {
 	suite.Suite
-	Client              *baremetal.Client
-	Provider            terraform.ResourceProvider
-	Providers           map[string]terraform.ResourceProvider
-	Config              string
-	ResourceName        string
+	Client         *baremetal.Client
+	Provider       terraform.ResourceProvider
+	Providers      map[string]terraform.ResourceProvider
+	Config         string
+	ResourceName   string
+	DataSourceName string
 	DefaultResourceName string
+	FullConfig     string
 }
 
 var defaultSecurityList = `
@@ -70,17 +70,199 @@ func (s *ResourceCoreSecurityListTestSuite) SetupTest() {
 			cidr_block = "10.0.0.0/16"
 			compartment_id = "${var.compartment_id}"
 			display_name = "-tf-vcn"
+		}
+	    data "oci_core_security_lists" "t" {
+			compartment_id = "${var.compartment_id}"
+			vcn_id = "${oci_core_virtual_network.t.id}"
+			filter {
+				name = "display_name"
+				values = ["${oci_core_security_list.t.display_name}"]
+			}
 		}`
 	s.ResourceName = "oci_core_security_list.t"
 	s.DefaultResourceName = "oci_core_default_security_list.default"
+	s.DataSourceName = "data.oci_core_security_lists.t"
+
+	s.FullConfig = `
+		resource "oci_core_security_list" "t" {
+			compartment_id = "${var.compartment_id}"
+			display_name = "-tf-security_list"
+			vcn_id = "${oci_core_virtual_network.t.id}"
+			egress_security_rules = {
+				destination = "0.0.0.0/1"
+				protocol = "6"
+			}
+			egress_security_rules = {
+				destination = "0.0.0.0/2"
+				protocol = "1"
+				stateless = true
+				icmp_options {
+					"type" = 3
+					"code" = 4
+				}
+			}
+			egress_security_rules = {
+				destination = "0.0.0.0/3"
+				protocol = "6"
+				stateless = false
+				tcp_options {
+					"min" = 10
+					"max" = 11
+					source_port_range {
+						"min" = 20
+						"max" = 21
+					}
+				}
+			}
+			egress_security_rules = {
+				destination = "0.0.0.0/4"
+				protocol = "17"
+				udp_options {
+					"min" = 30
+					"max" = 31
+					source_port_range {
+						"min" = 40
+						"max" = 41
+					}
+				}
+			}
+			ingress_security_rules = [{
+				protocol = "1"
+				source = "0.0.0.0/5"
+			},
+			{
+				protocol = "1"
+				source = "0.0.0.0/6"
+				icmp_options {
+					"type" = 3
+					"code" = 4
+				}
+			},
+			{
+				protocol = "6"
+				stateless = true
+				source = "0.0.0.0/7"
+				tcp_options {
+					"min" = 50
+					"max" = 51
+					source_port_range {
+						"min" = 60
+						"max" = 61
+					}
+				}
+			},
+			{
+				protocol = "17"
+				stateless = false
+				source = "10.0.0.0/8"
+				udp_options {
+					"min" = 70
+					"max" = 71
+					source_port_range {
+						"min" = 80
+						"max" = 81
+					}
+				}
+			}]
+		}
+	`
+}
+
+func (s *ResourceCoreSecurityListTestSuite) BuildTestsForFullConfig(resourceName, prefix string) []resource.TestCheckFunc {
+	return []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(resourceName, prefix+"display_name", "-tf-security_list"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"egress_security_rules.#", "4"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"egress_security_rules.0.destination", "0.0.0.0/1"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"egress_security_rules.0.protocol", "6"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"egress_security_rules.0.stateless", "false"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"egress_security_rules.0.tcp_options.#", "0"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"egress_security_rules.0.udp_options.#", "0"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"egress_security_rules.0.icmp_options.#", "0"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"egress_security_rules.1.destination", "0.0.0.0/2"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"egress_security_rules.1.protocol", "1"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"egress_security_rules.1.stateless", "true"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"egress_security_rules.1.tcp_options.#", "0"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"egress_security_rules.1.udp_options.#", "0"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"egress_security_rules.1.icmp_options.#", "1"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"egress_security_rules.1.icmp_options.0.type", "3"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"egress_security_rules.1.icmp_options.0.code", "4"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"egress_security_rules.2.destination", "0.0.0.0/3"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"egress_security_rules.2.protocol", "6"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"egress_security_rules.2.stateless", "false"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"egress_security_rules.2.tcp_options.#", "1"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"egress_security_rules.2.tcp_options.0.min", "10"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"egress_security_rules.2.tcp_options.0.max", "11"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"egress_security_rules.2.tcp_options.0.source_port_range.0.min", "20"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"egress_security_rules.2.tcp_options.0.source_port_range.0.max", "21"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"egress_security_rules.2.udp_options.#", "0"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"egress_security_rules.2.icmp_options.#", "0"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"egress_security_rules.3.destination", "0.0.0.0/4"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"egress_security_rules.3.protocol", "17"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"egress_security_rules.3.stateless", "false"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"egress_security_rules.3.tcp_options.#", "0"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"egress_security_rules.3.udp_options.#", "1"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"egress_security_rules.3.udp_options.0.min", "30"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"egress_security_rules.3.udp_options.0.max", "31"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"egress_security_rules.3.udp_options.0.source_port_range.0.min", "40"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"egress_security_rules.3.udp_options.0.source_port_range.0.max", "41"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"egress_security_rules.3.icmp_options.#", "0"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"ingress_security_rules.#", "4"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"ingress_security_rules.0.source", "0.0.0.0/5"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"ingress_security_rules.0.protocol", "1"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"ingress_security_rules.0.stateless", "false"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"ingress_security_rules.0.tcp_options.#", "0"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"ingress_security_rules.0.udp_options.#", "0"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"ingress_security_rules.0.icmp_options.#", "0"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"ingress_security_rules.1.source", "0.0.0.0/6"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"ingress_security_rules.1.protocol", "1"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"ingress_security_rules.1.stateless", "false"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"ingress_security_rules.1.tcp_options.#", "0"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"ingress_security_rules.1.udp_options.#", "0"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"ingress_security_rules.1.icmp_options.#", "1"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"ingress_security_rules.1.icmp_options.0.type", "3"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"ingress_security_rules.1.icmp_options.0.code", "4"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"ingress_security_rules.2.source", "0.0.0.0/7"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"ingress_security_rules.2.protocol", "6"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"ingress_security_rules.2.stateless", "true"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"ingress_security_rules.2.tcp_options.#", "1"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"ingress_security_rules.2.tcp_options.0.min", "50"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"ingress_security_rules.2.tcp_options.0.max", "51"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"ingress_security_rules.2.tcp_options.0.source_port_range.0.min", "60"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"ingress_security_rules.2.tcp_options.0.source_port_range.0.max", "61"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"ingress_security_rules.2.udp_options.#", "0"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"ingress_security_rules.2.icmp_options.#", "0"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"ingress_security_rules.3.source", "10.0.0.0/8"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"ingress_security_rules.3.protocol", "17"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"ingress_security_rules.3.stateless", "false"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"ingress_security_rules.3.tcp_options.#", "0"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"ingress_security_rules.3.udp_options.#", "1"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"ingress_security_rules.3.udp_options.0.min", "70"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"ingress_security_rules.3.udp_options.0.max", "71"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"ingress_security_rules.3.udp_options.0.source_port_range.0.min", "80"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"ingress_security_rules.3.udp_options.0.source_port_range.0.max", "81"),
+		resource.TestCheckResourceAttr(resourceName, prefix+"ingress_security_rules.3.icmp_options.#", "0"),
+	}
 }
 
 func (s *ResourceCoreSecurityListTestSuite) TestAccResourceCoreSecurityList_basic() {
-
 	resource.Test(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
-			// verify create
+			// verify create with all options
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				Config:            s.Config + s.FullConfig,
+				Check: resource.ComposeTestCheckFunc(append(s.BuildTestsForFullConfig(s.ResourceName, ""),
+					s.BuildTestsForFullConfig(s.DataSourceName, "security_lists.0.")...)...),
+			},
+			// Plan with the same config should do nothing
+			{
+				Config:             s.Config + s.FullConfig,
+				ExpectNonEmptyPlan: false,
+				PlanOnly:           true,
+			},
+			// Update to a single rule
 			{
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -89,43 +271,20 @@ func (s *ResourceCoreSecurityListTestSuite) TestAccResourceCoreSecurityList_basi
 						compartment_id = "${var.compartment_id}"
 						display_name = "-tf-security_list"
 						vcn_id = "${oci_core_virtual_network.t.id}"
-						egress_security_rules = [{
-							destination = "0.0.0.0/0"
+						egress_security_rules = {
+							destination = "0.0.0.0/1"
 							protocol = "6"
-						}]
-						ingress_security_rules = [{
-							protocol = "1"
-							source = "0.0.0.0/0"
-							icmp_options {
-								"type" = 3
-								"code" = 4
-							}
-						},
-						{
-							protocol = "6"
-							source = "0.0.0.0/0"
-							tcp_options {
-								"min" = 80
-								"max" = 80
-							}
-						},
-						{
-							protocol = "17"
-							source = "10.0.0.0/16"
-							udp_options {
-								"min" = 319
-								"max" = 320
-							}
-						}]
+						}
 					}` + defaultSecurityList,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(s.ResourceName, "display_name", "-tf-security_list"),
 					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.#", "1"),
+					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.0.destination", "0.0.0.0/1"),
+					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.0.protocol", "6"),
 					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.0.stateless", "false"),
-					resource.TestCheckResourceAttr(s.ResourceName, "ingress_security_rules.#", "3"),
-					resource.TestCheckResourceAttr(s.ResourceName, "ingress_security_rules.0.icmp_options.0.type", "3"),
-					resource.TestCheckResourceAttr(s.ResourceName, "ingress_security_rules.1.tcp_options.0.max", "80"),
-					resource.TestCheckResourceAttr(s.ResourceName, "ingress_security_rules.2.udp_options.0.max", "320"),
+					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.0.tcp_options.#", "0"),
+					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.0.udp_options.#", "0"),
+					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.0.icmp_options.#", "0"),
+					resource.TestCheckResourceAttr(s.ResourceName, "ingress_security_rules.#", "0"),
 					resource.TestCheckResourceAttr(s.DefaultResourceName, "display_name", "default-tf-security_list"),
 					resource.TestCheckResourceAttr(s.DefaultResourceName, "egress_security_rules.#", "1"),
 					resource.TestCheckResourceAttr(s.DefaultResourceName, "egress_security_rules.0.stateless", "false"),
@@ -135,41 +294,51 @@ func (s *ResourceCoreSecurityListTestSuite) TestAccResourceCoreSecurityList_basi
 					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.2.udp_options.0.max", "320"),
 				),
 			},
-			// verify update
+			// Update to zero rules
 			{
+				ImportState:       true,
+				ImportStateVerify: true,
 				Config: s.Config + `
 					resource "oci_core_security_list" "t" {
 						compartment_id = "${var.compartment_id}"
-						display_name = "-tf-security_list-updated"
+						display_name = "-tf-security_list"
 						vcn_id = "${oci_core_virtual_network.t.id}"
-						egress_security_rules = [{
-							destination = "0.0.0.0/0"
-							protocol = "17"
-							stateless = true
-						}]
-						ingress_security_rules = [{
-							protocol = "1"
-							source = "0.0.0.0/0"
-							stateless = true
-							icmp_options {
-								"type" = 5
-								"code" = 0
-							}
-						},
-						{
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.#", "0"),
+					resource.TestCheckResourceAttr(s.ResourceName, "ingress_security_rules.#", "0"),
+				),
+			},
+			// Update to rules that use only source and only destination port ranges
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				Config: s.Config + `
+					resource "oci_core_security_list" "t" {
+						compartment_id = "${var.compartment_id}"
+						display_name = "-tf-security_list"
+						vcn_id = "${oci_core_virtual_network.t.id}"
+						egress_security_rules = {
+							destination = "0.0.0.0/3"
 							protocol = "6"
-							source = "0.0.0.0/0"
-							stateless = true
+							stateless = false
 							tcp_options {
-								"min" = 80
-								"max" = 82
+								source_port_range {
+									"min" = 20
+									"max" = 21
+								}
 							}
-						},
-						{
+						}
+						# Check the maximum range
+						egress_security_rules = {
+							destination = "0.0.0.0/4"
 							protocol = "17"
-							source = "10.0.0.0/16"
-							stateless = true
-						}]
+							udp_options {
+								"min" = 1
+								"max" = 65535
+							}
+						}
 					}
 
 					resource "oci_core_default_security_list" "default" {
@@ -242,23 +411,45 @@ func (s *ResourceCoreSecurityListTestSuite) TestAccResourceCoreSecurityList_basi
 					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.0.icmp_options.0.type", "3"),
 					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.1.tcp_options.0.max", "80"),
 					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.2.udp_options.0.max", "320"),
+					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.#", "2"),
+					resource.TestCheckResourceAttr(s.ResourceName, "ingress_security_rules.#", "0"),
+					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.0.destination", "0.0.0.0/3"),
+					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.0.protocol", "6"),
+					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.0.stateless", "false"),
+					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.0.tcp_options.#", "1"),
+					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.0.tcp_options.0.min", "0"),
+					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.0.tcp_options.0.max", "0"),
+					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.0.tcp_options.0.source_port_range.0.min", "20"),
+					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.0.tcp_options.0.source_port_range.0.max", "21"),
+					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.0.udp_options.#", "0"),
+					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.0.icmp_options.#", "0"),
+					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.1.destination", "0.0.0.0/4"),
+					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.1.protocol", "17"),
+					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.1.stateless", "false"),
+					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.1.tcp_options.#", "0"),
+					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.1.udp_options.#", "1"),
+					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.1.udp_options.0.min", "1"),
+					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.1.udp_options.0.max", "65535"),
+					resource.TestCheckResourceAttr(s.ResourceName, "egress_security_rules.1.udp_options.0.source_port_range.#", "0"),
 				),
 			},
-			// todo: consistent 500 error from server without this step
+		},
+	})
+}
+
+func (s *ResourceCoreSecurityListTestSuite) TestAccResourceCoreSecurityList_emptyList() {
+	resource.Test(s.T(), resource.TestCase{
+		Providers: s.Providers,
+		Steps: []resource.TestStep{
 			{
+				// Create a security list with no rules (which is different from the earlier test of updating to no rules)
 				ImportState:       true,
 				ImportStateVerify: true,
-				Config:            s.Config,
-			},
-			// verify lists can be cleared out
-			{
 				Config: s.Config + `
 					resource "oci_core_security_list" "t" {
 						compartment_id = "${var.compartment_id}"
-						display_name = "-tf-security_list-updated"
+						display_name = "-tf-security_list"
 						vcn_id = "${oci_core_virtual_network.t.id}"
-						egress_security_rules = []
-						ingress_security_rules = []
 					}
 
 					resource "oci_core_default_security_list" "default" {
@@ -274,6 +465,20 @@ func (s *ResourceCoreSecurityListTestSuite) TestAccResourceCoreSecurityList_basi
 					resource.TestCheckResourceAttr(s.DefaultResourceName, "egress_security_rules.#", "0"),
 					resource.TestCheckResourceAttr(s.DefaultResourceName, "ingress_security_rules.#", "0"),
 				),
+			},
+			// update with all options
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				Config:            s.Config + s.FullConfig,
+				Check:             resource.ComposeTestCheckFunc(s.BuildTestsForFullConfig(s.ResourceName, "")...),
+			},
+			// Apply the same config and check the data source, since the data source will not have updated on the previous apply.
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				Config:            s.Config + s.FullConfig,
+				Check:             resource.ComposeTestCheckFunc(s.BuildTestsForFullConfig(s.DataSourceName, "security_lists.0.")...),
 			},
 		},
 	})

--- a/provider/core_security_lists_data_source.go
+++ b/provider/core_security_lists_data_source.go
@@ -99,36 +99,8 @@ func (s *SecurityListDatasourceCrud) SetData() {
 			"vcn_id":         v.VcnID,
 		}
 
-		confEgressRules := []map[string]interface{}{}
-		for _, egressRule := range v.EgressSecurityRules {
-			confEgressRule := map[string]interface{}{}
-			confEgressRule["destination"] = egressRule.Destination
-			confEgressRule = buildConfRule(
-				confEgressRule,
-				egressRule.Protocol,
-				egressRule.ICMPOptions,
-				egressRule.TCPOptions,
-				egressRule.UDPOptions,
-				&egressRule.IsStateless,
-			)
-			confEgressRules = append(confEgressRules, confEgressRule)
-		}
+		confEgressRules, confIngressRules := buildConfRuleLists(&v)
 		res["egress_security_rules"] = confEgressRules
-
-		confIngressRules := []map[string]interface{}{}
-		for _, ingressRule := range v.IngressSecurityRules {
-			confIngressRule := map[string]interface{}{}
-			confIngressRule["source"] = ingressRule.Source
-			confIngressRule = buildConfRule(
-				confIngressRule,
-				ingressRule.Protocol,
-				ingressRule.ICMPOptions,
-				ingressRule.TCPOptions,
-				ingressRule.UDPOptions,
-				nil,
-			)
-			confIngressRules = append(confIngressRules, confIngressRule)
-		}
 		res["ingress_security_rules"] = confIngressRules
 
 		resources = append(resources, res)

--- a/vendor/github.com/oracle/bmcs-go-sdk/core_security_list.go
+++ b/vendor/github.com/oracle/bmcs-go-sdk/core_security_list.go
@@ -16,14 +16,16 @@ type PortRange struct {
 //
 // See https://docs.us-phoenix-1.oraclecloud.com/api/#/en/iaas/20160918/UdpOptions/
 type UDPOptions struct {
-	DestinationPortRange PortRange `header:"-" json:"destinationPortRange" url:"-"`
+	DestinationPortRange *PortRange `header:"-" json:"destinationPortRange" url:"-"`
+	SourcePortRange      *PortRange `header:"-" json:"sourcePortRange" url:"-"`
 }
 
 // TCPOptions specifies ports for a TCP rule
 //
 // See https://docs.us-phoenix-1.oraclecloud.com/api/#/en/iaas/20160918/TcpOptions/
 type TCPOptions struct {
-	DestinationPortRange PortRange `header:"-" json:"destinationPortRange" url:"-"`
+	DestinationPortRange *PortRange `header:"-" json:"destinationPortRange" url:"-"`
+	SourcePortRange      *PortRange `header:"-" json:"sourcePortRange" url:"-"`
 }
 
 // ICMPOptions specifies a particular ICMP type and code

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2972,10 +2972,10 @@
 			"revisionTime": "2017-01-25T16:36:56Z"
 		},
 		{
-			"checksumSHA1": "jU2TjFc4VCRbdD93AmkrF3VbOuA=",
+			"checksumSHA1": "EY2CFkCSq6E581t2Pc2t17KWiV0=",
 			"path": "github.com/oracle/bmcs-go-sdk",
-			"revision": "694de4d6e89b05a3428bdc549a47d265f6e704cc",
-			"revisionTime": "2017-11-28T18:53:23Z",
+			"revision": "e95f390096f7ad4988c4a4d1b97a0dcd424ee91d",
+			"revisionTime": "2017-11-06T17:38:49Z",
 			"version": "add-db-license-model",
 			"versionExact": "add-db-license-model"
 		},


### PR DESCRIPTION
This is a rebase of #375 to incorporate the default resource changes. (I accidentally did this in a way that changed the previous commits, so putting up a new review.) The security list resource tests needed some refactoring - I've split the default resource tests out from the other tests. Otherwise only minorchanges. Also responded to comments from @kohashim. Original PR info:

Currently, TCP and UDP options can be specified with a single set of
max/min values, which correspond to the destination port range. This change
adds the ability to specify the source port range as well, issue #338.

Ideally, we should deprecate the existing max/min params and add a new
destination_port_range option next to the new source_port_range. Unfortunately,
a number of issue with nested schemas in Terraform are preventing support of both
of these params simultaneously. Instead, max/min params will remain, and source_port_range
will exist beside it.

This change also enables security lists with no rules.

Some updates are made to the docs, but the docs for the security list resource and data source
could really use a bigger update that is not included in this change.