### PR TITLE
Fix default DHCP options test resource

### DIFF
--- a/provider/core_dhcp_options_resource_test.go
+++ b/provider/core_dhcp_options_resource_test.go
@@ -139,9 +139,9 @@ func (s *ResourceCoreDHCPOptionsTestSuite) TestAccResourceCoreDHCPOptions_basic(
 			{
 				Config: s.Config + defaultDhcpOpts,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("oci_core_dhcp_options.default", "options.0.type", "DomainNameServer"),
-					resource.TestCheckResourceAttr("oci_core_dhcp_options.default", "options.0.server_type", "CustomDnsServer"),
-					resource.TestCheckResourceAttr("oci_core_dhcp_options.default", "options.1.type", "SearchDomain"),
+					resource.TestCheckResourceAttr("oci_core_default_dhcp_options.default", "options.0.type", "DomainNameServer"),
+					resource.TestCheckResourceAttr("oci_core_default_dhcp_options.default", "options.0.server_type", "CustomDnsServer"),
+					resource.TestCheckResourceAttr("oci_core_default_dhcp_options.default", "options.1.type", "SearchDomain"),
 				),
 			},
 		},


### PR DESCRIPTION
There was a typo in the check for default resources. Fix this.