### PR TITLE
Set "manage_default_resource_id" during import of default resources

### DIFF
--- a/crud/helpers.go
+++ b/crud/helpers.go
@@ -338,3 +338,8 @@ func FilterMissingResourceError(sync ResourceVoider, err *error) {
 func EqualIgnoreCaseSuppressDiff(key string, old string, new string, d *schema.ResourceData) bool {
 	return strings.EqualFold(old, new)
 }
+
+func ImportDefaultResource(d *schema.ResourceData, value interface{}) ([]*schema.ResourceData, error) {
+	err := d.Set("manage_default_resource_id", d.Id())
+	return []*schema.ResourceData{d}, err
+}

--- a/provider/core_dhcp_options_resource.go
+++ b/provider/core_dhcp_options_resource.go
@@ -12,7 +12,7 @@ import (
 func DefaultDHCPOptionsResource() *schema.Resource {
 	return &schema.Resource{
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: crud.ImportDefaultResource,
 		},
 		Timeouts: crud.DefaultTimeout,
 		Create:   createDHCPOptions,

--- a/provider/core_route_table_resource.go
+++ b/provider/core_route_table_resource.go
@@ -15,7 +15,7 @@ import (
 func DefaultRouteTableResource() *schema.Resource {
 	return &schema.Resource{
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: crud.ImportDefaultResource,
 		},
 		Timeouts: crud.DefaultTimeout,
 		Create:   createRouteTable,

--- a/provider/core_security_list_resource.go
+++ b/provider/core_security_list_resource.go
@@ -66,7 +66,7 @@ var icmpSchema = &schema.Schema{
 func DefaultSecurityListResource() *schema.Resource {
 	return &schema.Resource{
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: crud.ImportDefaultResource,
 		},
 		Timeouts: crud.DefaultTimeout,
 		Create:   createSecurityList,


### PR DESCRIPTION
This fixes an issue where importing a default resource will leave
the manage_default_resource_id empty in the state file. Any change
in the TF config would force an unwanted delete/recreate.

Fix this by setting the manage_default_resource_id on import.

This should address issue with default resource imports described in #379 