### PR TITLE
Update RHEL solution to use image OCID

### DIFF
--- a/docs/solutions/rhel74_image/configuration.tf
+++ b/docs/solutions/rhel74_image/configuration.tf
@@ -20,7 +20,7 @@ variable "build_env" {
 	type = "map"
 	default = {
 		compartment = "<Compartment display name>"
-		ad = "<the AD you want>"
+		ad = "<The number of the availability domain to use - 1, 2, or 3>"
 		vcn = "<VCN name>"
 		subnet = "<subnet name in compartment in ad in vcn>"
 	}

--- a/docs/solutions/rhel74_image/datasources.tf
+++ b/docs/solutions/rhel74_image/datasources.tf
@@ -35,15 +35,6 @@ data "oci_core_subnets" "subnet" {
 
 }
 
-# Gets the OCID of the image. This technique is for example purposes only. 
-# The results of oci_core_images may change over time for Oracle-provided images, 
-# so the only sure way to get the correct OCID is to supply it directly.
-
-data "oci_core_images" "image" {
-	compartment_id = "${data.oci_identity_compartments.compartment.compartments.0.id}"
-	display_name = "${var.ipxe_instance["image"]}"
-}
-
 data "external" "ipxe_gen" {
 	program = [ "/bin/bash", "./ipxe_gen.sh"]
 	query = {

--- a/docs/solutions/rhel74_image/ipxe.tf
+++ b/docs/solutions/rhel74_image/ipxe.tf
@@ -4,7 +4,7 @@ resource "oci_core_instance" "ipxe_node" {
   availability_domain = "${data.oci_identity_availability_domains.ad.availability_domains.0.name}"
   compartment_id      = "${data.oci_identity_compartments.compartment.compartments.0.id}"
   display_name        = "${var.ipxe_instance["name"]}"
-  image               = "${data.oci_core_images.image.images.0.id}" 
+  image               = "${var.ipxe_instance_image_ocid[var.region]}"
   shape               = "${var.ipxe_instance["shape"]}"
   subnet_id           = "${data.oci_core_subnets.subnet.subnets.0.id}"
   hostname_label      = "${var.ipxe_instance["hostname"]}"

--- a/docs/solutions/rhel74_image/variable.tf
+++ b/docs/solutions/rhel74_image/variable.tf
@@ -22,8 +22,17 @@ variable "ipxe_instance" {
 	default = {
 		name = "ipxe-rhel74"
 		hostname = "ipxe-rhel74"
-		image = "Oracle-Linux-7.4-2017.09.29-0"
 		shape = "VM.Standard1.1"
+	}
+}
+
+variable "ipxe_instance_image_ocid" {
+	type = "map"
+	default = {
+		// Use the image "Oracle-Linux-7.4-2017.09.29-0"
+		us-phoenix-1 = "ocid1.image.oc1.phx.aaaaaaaa3g2xpzlbrrdknqcjtzv2tvxcofjc55vdcmpxdlbohmtt7encpana"
+		us-ashburn-1 = "ocid1.image.oc1.iad.aaaaaaaaawy2hh3nreaesyqcdp4m6csg4lwen6ya2njgiyjeu5sodiahlaxq"
+		eu-frankfurt-1 = "ocid1.image.oc1.eu-frankfurt1.aaaaaaaaydqkfzrcejyllfiwhcfqob2yyvkmytghwki6zcmhyciyruinokva"
 	}
 }
 


### PR DESCRIPTION
The image "Oracle-Linux-7.4-2017.09.29-0" is no longer being returned from the list_images call, so
use the OCID directly (which is the new guidance anyway, we just haven't yet switched all of the
solutions and examples over). Note that we might want to update this to a newer image, such as
"Oracle-Linux-7.4-2017.11.15-0" or "Oracle-Linux-7.4-2017.12.18-0", but that is pending testing using
those versions.