### PR TITLE
Update compute examples

### DIFF
--- a/docs/examples/compute/instance/datasources.tf
+++ b/docs/examples/compute/instance/datasources.tf
@@ -1,6 +1,6 @@
 # Gets a list of Availability Domains
 data "oci_identity_availability_domains" "ADs" {
-  compartment_id = "${var.tenancy_ocid}"
+    compartment_id = "${var.tenancy_ocid}"
 }
 
 # Gets the OCID of the image. This technique is for example purposes only. The results of oci_core_images may
@@ -12,12 +12,12 @@ data "oci_core_images" "OLImageOCID" {
 
 # Gets a list of vNIC attachments on the instance
 data "oci_core_vnic_attachments" "InstanceVnics" {
-compartment_id = "${var.compartment_ocid}" 
-availability_domain = "${lookup(data.oci_identity_availability_domains.ADs.availability_domains[var.AD - 1],"name")}"
-instance_id = "${oci_core_instance.TFInstance.id}"
+    compartment_id = "${var.compartment_ocid}"
+    availability_domain = "${lookup(data.oci_identity_availability_domains.ADs.availability_domains[var.AD - 1],"name")}"
+    instance_id = "${oci_core_instance.TFInstance.id}"
 } 
 
 # Gets the OCID of the first (default) vNIC
 data "oci_core_vnic" "InstanceVnic" {
-vnic_id = "${lookup(data.oci_core_vnic_attachments.InstanceVnics.vnic_attachments[0],"vnic_id")}"
+    vnic_id = "${lookup(data.oci_core_vnic_attachments.InstanceVnics.vnic_attachments[0],"vnic_id")}"
 }

--- a/docs/examples/compute/instance/network.tf
+++ b/docs/examples/compute/instance/network.tf
@@ -13,6 +13,22 @@ resource "oci_core_subnet" "ExampleSubnet" {
   security_list_ids = ["${oci_core_virtual_network.ExampleVCN.default_security_list_id}"]
   compartment_id = "${var.compartment_ocid}"
   vcn_id = "${oci_core_virtual_network.ExampleVCN.id}"
-  route_table_id = "${oci_core_virtual_network.ExampleVCN.default_route_table_id}"
+  route_table_id = "${oci_core_route_table.ExampleRT.id}"
   dhcp_options_id = "${oci_core_virtual_network.ExampleVCN.default_dhcp_options_id}"
+}
+
+resource "oci_core_internet_gateway" "ExampleIG" {
+  compartment_id = "${var.compartment_ocid}"
+  display_name = "TFExampleIG"
+  vcn_id = "${oci_core_virtual_network.ExampleVCN.id}"
+}
+
+resource "oci_core_route_table" "ExampleRT" {
+  compartment_id = "${var.compartment_ocid}"
+  vcn_id = "${oci_core_virtual_network.ExampleVCN.id}"
+  display_name = "TFExampleRouteTable"
+  route_rules {
+    cidr_block = "0.0.0.0/0"
+    network_entity_id = "${oci_core_internet_gateway.ExampleIG.id}"
+  }
 }

--- a/docs/examples/compute/multi_vnic/multi_vnic.tf
+++ b/docs/examples/compute/multi_vnic/multi_vnic.tf
@@ -16,7 +16,7 @@ variable "AD" {
 }
 
 variable "InstanceShape" {
-    default = "VM.Standard1.8"
+    default = "VM.Standard1.1"
 }
 
 variable "InstanceImageDisplayName" {


### PR DESCRIPTION
My previous PR had left out the internet gateway necessary in the
instance example to perform the remote exec. (I initially tried using the 
default route table for this, but experienced some issues with that that
I'll be looking into. So use a new route table for now.)
Also, switching the default shape in multi_vnic to a smaller shape.