### PR TITLE
Fix Load Balancer resources to use proper states and IDs

### DIFF
--- a/provider/load_balancer_backendset_resource.go
+++ b/provider/load_balancer_backendset_resource.go
@@ -97,7 +97,6 @@ func (s *LoadBalancerBackendSetResourceCrud) ID() string {
 
 func (s *LoadBalancerBackendSetResourceCrud) CreatedPending() []string {
 	return []string{
-		baremetal.ResourceWaitingForWorkRequest,
 		baremetal.WorkRequestInProgress,
 		baremetal.WorkRequestAccepted,
 	}
@@ -105,15 +104,13 @@ func (s *LoadBalancerBackendSetResourceCrud) CreatedPending() []string {
 
 func (s *LoadBalancerBackendSetResourceCrud) CreatedTarget() []string {
 	return []string{
-		baremetal.ResourceSucceededWorkRequest,
 		baremetal.WorkRequestSucceeded,
-		baremetal.ResourceFailed,
+		baremetal.WorkRequestFailed,
 	}
 }
 
 func (s *LoadBalancerBackendSetResourceCrud) DeletedPending() []string {
 	return []string{
-		baremetal.ResourceWaitingForWorkRequest,
 		baremetal.WorkRequestInProgress,
 		baremetal.WorkRequestAccepted,
 	}
@@ -121,7 +118,7 @@ func (s *LoadBalancerBackendSetResourceCrud) DeletedPending() []string {
 
 func (s *LoadBalancerBackendSetResourceCrud) DeletedTarget() []string {
 	return []string{
-		baremetal.ResourceSucceededWorkRequest,
+		baremetal.WorkRequestFailed,
 		baremetal.WorkRequestSucceeded,
 	}
 }
@@ -140,6 +137,7 @@ func (s *LoadBalancerBackendSetResourceCrud) Create() (e error) {
 	if e != nil {
 		return
 	}
+	s.D.SetId(workReqID)
 	s.WorkRequest, e = s.Client.GetWorkRequest(workReqID, nil)
 	return
 }

--- a/provider/load_balancer_certificate_resource.go
+++ b/provider/load_balancer_certificate_resource.go
@@ -97,7 +97,6 @@ func (s *LoadBalancerCertificateResourceCrud) ID() string {
 
 func (s *LoadBalancerCertificateResourceCrud) CreatedPending() []string {
 	return []string{
-		baremetal.ResourceWaitingForWorkRequest,
 		baremetal.WorkRequestInProgress,
 		baremetal.WorkRequestAccepted,
 	}
@@ -105,15 +104,13 @@ func (s *LoadBalancerCertificateResourceCrud) CreatedPending() []string {
 
 func (s *LoadBalancerCertificateResourceCrud) CreatedTarget() []string {
 	return []string{
-		baremetal.ResourceSucceededWorkRequest,
 		baremetal.WorkRequestSucceeded,
-		baremetal.ResourceFailed,
+		baremetal.WorkRequestFailed,
 	}
 }
 
 func (s *LoadBalancerCertificateResourceCrud) DeletedPending() []string {
 	return []string{
-		baremetal.ResourceWaitingForWorkRequest,
 		baremetal.WorkRequestInProgress,
 		baremetal.WorkRequestAccepted,
 	}
@@ -121,8 +118,8 @@ func (s *LoadBalancerCertificateResourceCrud) DeletedPending() []string {
 
 func (s *LoadBalancerCertificateResourceCrud) DeletedTarget() []string {
 	return []string{
-		baremetal.ResourceSucceededWorkRequest,
 		baremetal.WorkRequestSucceeded,
+		baremetal.WorkRequestFailed,
 	}
 }
 
@@ -142,6 +139,7 @@ func (s *LoadBalancerCertificateResourceCrud) Create() (e error) {
 	if e != nil {
 		return
 	}
+	s.D.SetId(workReqID)
 	s.WorkRequest, e = s.Client.GetWorkRequest(workReqID, nil)
 	return
 }

--- a/provider/load_balancer_listener_resource.go
+++ b/provider/load_balancer_listener_resource.go
@@ -99,7 +99,6 @@ func (s *LoadBalancerListenerResourceCrud) ID() string {
 
 func (s *LoadBalancerListenerResourceCrud) CreatedPending() []string {
 	return []string{
-		baremetal.ResourceWaitingForWorkRequest,
 		baremetal.WorkRequestInProgress,
 		baremetal.WorkRequestAccepted,
 	}
@@ -107,15 +106,13 @@ func (s *LoadBalancerListenerResourceCrud) CreatedPending() []string {
 
 func (s *LoadBalancerListenerResourceCrud) CreatedTarget() []string {
 	return []string{
-		baremetal.ResourceSucceededWorkRequest,
 		baremetal.WorkRequestSucceeded,
-		baremetal.ResourceFailed,
+		baremetal.WorkRequestFailed,
 	}
 }
 
 func (s *LoadBalancerListenerResourceCrud) DeletedPending() []string {
 	return []string{
-		baremetal.ResourceWaitingForWorkRequest,
 		baremetal.WorkRequestInProgress,
 		baremetal.WorkRequestAccepted,
 	}
@@ -123,7 +120,7 @@ func (s *LoadBalancerListenerResourceCrud) DeletedPending() []string {
 
 func (s *LoadBalancerListenerResourceCrud) DeletedTarget() []string {
 	return []string{
-		baremetal.ResourceSucceededWorkRequest,
+		baremetal.WorkRequestFailed,
 		baremetal.WorkRequestSucceeded,
 	}
 }
@@ -156,6 +153,7 @@ func (s *LoadBalancerListenerResourceCrud) Create() (e error) {
 	if e != nil {
 		return
 	}
+	s.D.SetId(workReqID)
 	s.WorkRequest, e = s.Client.GetWorkRequest(workReqID, nil)
 	return
 }


### PR DESCRIPTION
Make sure that work requests are waiting on the correct states and
remove unnecessary states. Also make sure backend resources use
the BuildId (IP address + port) for its SDK calls.

This partially fixes a bug found in #414 where Backend set doesn't wait for the Failed state during deletion. This doesn't address retry logic that should kick in if the service returns intermittent failures for the work requests.