### PR TITLE
Fix image datasource test to be more permissive

### DIFF
--- a/provider/core_images_data_source_test.go
+++ b/provider/core_images_data_source_test.go
@@ -9,16 +9,21 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/oracle/bmcs-go-sdk"
 
+	"fmt"
 	"github.com/stretchr/testify/suite"
+	"regexp"
 )
 
 type DatasourceCoreImageTestSuite struct {
 	suite.Suite
-	Client       *baremetal.Client
-	Config       string
-	Provider     terraform.ResourceProvider
-	Providers    map[string]terraform.ResourceProvider
-	ResourceName string
+	Client                 *baremetal.Client
+	Config                 string
+	Provider               terraform.ResourceProvider
+	Providers              map[string]terraform.ResourceProvider
+	ResourceName           string
+	FilterExpression       string
+	OperatingSystem        string
+	OperatingSystemVersion string
 }
 
 func (s *DatasourceCoreImageTestSuite) SetupTest() {
@@ -27,6 +32,10 @@ func (s *DatasourceCoreImageTestSuite) SetupTest() {
 	s.Providers = testAccProviders
 	s.Config = testProviderConfig()
 	s.ResourceName = "data.oci_core_images.t"
+	// This test will need to be updated when this image is removed from ListImages.
+	s.FilterExpression = ".*2017.12.18-0"
+	s.OperatingSystem = "Oracle Linux"
+	s.OperatingSystemVersion = "7.4"
 }
 
 func (s *DatasourceCoreImageTestSuite) TestAccImage_basic() {
@@ -37,27 +46,26 @@ func (s *DatasourceCoreImageTestSuite) TestAccImage_basic() {
 			{
 				ImportState:       true,
 				ImportStateVerify: true,
-				Config: s.Config + `
+				Config: s.Config + fmt.Sprintf(`
 				data "oci_core_images" "t" {
 					compartment_id = "${var.compartment_id}"
-					operating_system = "Oracle Linux"
-					operating_system_version = "7.4"
+					operating_system = "%s"
+					operating_system_version = "%s"
 				
 					filter {
 						name = "display_name"
-						// This test will need to be updated when this image is removed from ListImages.
-						values = [".*2017.12.18-0"]
+						values = ["%s"]
 						regex = true
 					}
-				}`,
+				}`, s.OperatingSystem, s.OperatingSystemVersion, s.FilterExpression),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(s.ResourceName, "images.#", "1"),
+					resource.TestMatchResourceAttr(s.ResourceName, "images.#", regexp.MustCompile("[1-9][0-9]*")),
 					resource.TestCheckResourceAttrSet(s.ResourceName, "images.0.id"),
 					resource.TestCheckResourceAttr(s.ResourceName, "images.0.create_image_allowed", "true"),
-					resource.TestCheckResourceAttr(s.ResourceName, "images.0.display_name", "Oracle-Linux-7.4-2017.12.18-0"),
+					resource.TestMatchResourceAttr(s.ResourceName, "images.0.display_name", regexp.MustCompile(s.FilterExpression)),
 					resource.TestCheckResourceAttr(s.ResourceName, "images.0.state", "AVAILABLE"),
-					resource.TestCheckResourceAttr(s.ResourceName, "images.0.operating_system", "Oracle Linux"),
-					resource.TestCheckResourceAttr(s.ResourceName, "images.0.operating_system_version", "7.4"),
+					resource.TestCheckResourceAttr(s.ResourceName, "images.0.operating_system", s.OperatingSystem),
+					resource.TestCheckResourceAttr(s.ResourceName, "images.0.operating_system_version", s.OperatingSystemVersion),
 					resource.TestCheckResourceAttrSet(s.ResourceName, "images.0.time_created"),
 				),
 			},


### PR DESCRIPTION
ListImages may return multiple images for a given build date.
Make the test more robust by allowing it.