### PR TITLE
Update instance examples to show interpolation syntax

### DIFF
--- a/docs/examples/compute/instance/README.md
+++ b/docs/examples/compute/instance/README.md
@@ -4,14 +4,18 @@
     #   | |_| |  _ < / ___ | |___| |___| |___
     #    \___/|_| \_/_/   \_\____|_____|_____|
 ***
-## Manage an instance
-This example launches an instance, includes a user-data script in the instance launch, remote executes a command, and outputs the public and private IP address of the instance.
+## Manage instances with multiple attached volumes
+This example launches 3 instances and attaches 2 volumes per instance.
+
+This is done using Terraform's [interpolation syntax](https://www.terraform.io/docs/configuration/interpolation.html) for `count` variables and `math` operations.
+
+The example also includes a user-data script in the instance launch, remote executes a command on each instance to setup the volumes, and outputs the public and private IP address of the instances.
 
 ### Using this example
 * Update env-vars with the required information. Most examples use the same set of environment variables so you only need to do this once.
 * Source env-vars
   * `$ . env-vars`
-* Update `variables.tf` with your instance options.
+* Update `variables.tf` with your instance options. You may also modify the `NumInstances` and `NumVolumesPerInstance` variables to change the number of instances and volumes that are launched.
 
 ### Files in the configuration
 
@@ -20,6 +24,9 @@ Is used to export the environmental variables used in the configuration. These a
 
 Before you plan, apply, or destroy the configuration source the file -  
 `$ . env-vars`
+
+#### `block.tf`
+Defines the volumes that are attached to the compute instances.
 
 #### `compute.tf`
 Defines the compute resource. This demo connects to the running instance 

--- a/docs/examples/compute/instance/block.tf
+++ b/docs/examples/compute/instance/block.tf
@@ -1,14 +1,16 @@
-resource "oci_core_volume" "TFBlock0" {
+resource "oci_core_volume" "TFBlock" {
+  count = "${var.NumInstances * var.NumVolumesPerInstance}"
   availability_domain = "${lookup(data.oci_identity_availability_domains.ADs.availability_domains[var.AD - 1],"name")}"
   compartment_id = "${var.compartment_ocid}"
-  display_name = "TFBlock0"
+  display_name = "TFBlock${count.index}"
   size_in_gbs = "${var.DBSize}"
 }
 
-resource "oci_core_volume_attachment" "TFBlock0Attach" {
+resource "oci_core_volume_attachment" "TFBlockAttach" {
+    count = "${var.NumInstances * var.NumVolumesPerInstance}"
     attachment_type = "iscsi"
     compartment_id = "${var.compartment_ocid}"
-    instance_id = "${oci_core_instance.TFInstance.id}"
-    volume_id = "${oci_core_volume.TFBlock0.id}"
+    instance_id = "${oci_core_instance.TFInstance.*.id[count.index / var.NumVolumesPerInstance]}"
+    volume_id = "${oci_core_volume.TFBlock.*.id[count.index]}"
 }
 

--- a/docs/examples/compute/instance/compute.tf
+++ b/docs/examples/compute/instance/compute.tf
@@ -1,7 +1,8 @@
 resource "oci_core_instance" "TFInstance" {
+  count = "${var.NumInstances}"
   availability_domain = "${lookup(data.oci_identity_availability_domains.ADs.availability_domains[var.AD - 1],"name")}"
   compartment_id = "${var.compartment_ocid}"
-  display_name = "TFInstance"
+  display_name = "TFInstance${count.index}"
   image = "${var.InstanceImageOCID[var.region]}"
   shape = "${var.InstanceShape}"
 
@@ -9,7 +10,7 @@ resource "oci_core_instance" "TFInstance" {
     subnet_id = "${oci_core_subnet.ExampleSubnet.id}"
     display_name = "primaryvnic"
     assign_public_ip = true
-    hostname_label = "tfexampleinstance"
+    hostname_label = "tfexampleinstance${count.index}"
   },
 
   metadata {

--- a/docs/examples/compute/instance/datasources.tf
+++ b/docs/examples/compute/instance/datasources.tf
@@ -2,15 +2,3 @@
 data "oci_identity_availability_domains" "ADs" {
     compartment_id = "${var.tenancy_ocid}"
 }
-
-# Gets a list of vNIC attachments on the instance
-data "oci_core_vnic_attachments" "InstanceVnics" {
-    compartment_id = "${var.compartment_ocid}"
-    availability_domain = "${lookup(data.oci_identity_availability_domains.ADs.availability_domains[var.AD - 1],"name")}"
-    instance_id = "${oci_core_instance.TFInstance.id}"
-} 
-
-# Gets the OCID of the first (default) vNIC
-data "oci_core_vnic" "InstanceVnic" {
-    vnic_id = "${lookup(data.oci_core_vnic_attachments.InstanceVnics.vnic_attachments[0],"vnic_id")}"
-}

--- a/docs/examples/compute/instance/outputs.tf
+++ b/docs/examples/compute/instance/outputs.tf
@@ -1,10 +1,8 @@
 # Output the private and public IPs of the instance
-
-output "InstancePrivateIP" {
-value = ["${data.oci_core_vnic.InstanceVnic.private_ip_address}"]
+output "InstancePrivateIPs" {
+value = ["${oci_core_instance.TFInstance.*.private_ip}"]
 }
 
-output "InstancePublicIP" {
-value = ["${data.oci_core_vnic.InstanceVnic.public_ip_address}"]
+output "InstancePublicIPs" {
+value = ["${oci_core_instance.TFInstance.*.public_ip}"]
 }
-

--- a/docs/examples/compute/instance/remote-exec.tf
+++ b/docs/examples/compute/instance/remote-exec.tf
@@ -1,19 +1,19 @@
 resource "null_resource" "remote-exec" {
-    depends_on = ["oci_core_instance.TFInstance","oci_core_volume_attachment.TFBlock0Attach"]
+    depends_on = ["oci_core_instance.TFInstance","oci_core_volume_attachment.TFBlockAttach"]
+    count = "${var.NumInstances * var.NumVolumesPerInstance}"
     provisioner "remote-exec" {
       connection {
         agent = false
         timeout = "30m"
-        host = "${data.oci_core_vnic.InstanceVnic.public_ip_address}"
+        host = "${oci_core_instance.TFInstance.*.public_ip[count.index % var.NumInstances]}"
         user = "opc"
         private_key = "${var.ssh_private_key}"
     }
       inline = [
         "touch ~/IMadeAFile.Right.Here",
-        "sudo iscsiadm -m node -o new -T ${oci_core_volume_attachment.TFBlock0Attach.iqn} -p ${oci_core_volume_attachment.TFBlock0Attach.ipv4}:${oci_core_volume_attachment.TFBlock0Attach.port}",
-        "sudo iscsiadm -m node -o update -T ${oci_core_volume_attachment.TFBlock0Attach.iqn} -n node.startup -v automatic",
-        "echo sudo iscsiadm -m node -T ${oci_core_volume_attachment.TFBlock0Attach.iqn} -p ${oci_core_volume_attachment.TFBlock0Attach.ipv4}:${oci_core_volume_attachment.TFBlock0Attach.port} -l >> ~/.bashrc"
+        "sudo iscsiadm -m node -o new -T ${oci_core_volume_attachment.TFBlockAttach.*.iqn[count.index]} -p ${oci_core_volume_attachment.TFBlockAttach.*.ipv4[count.index]}:${oci_core_volume_attachment.TFBlockAttach.*.port[count.index]}",
+        "sudo iscsiadm -m node -o update -T ${oci_core_volume_attachment.TFBlockAttach.*.iqn[count.index]} -n node.startup -v automatic",
+        "echo sudo iscsiadm -m node -T ${oci_core_volume_attachment.TFBlockAttach.*.iqn[count.index]} -p ${oci_core_volume_attachment.TFBlockAttach.*.ipv4[count.index]}:${oci_core_volume_attachment.TFBlockAttach.*.port[count.index]} -l >> ~/.bashrc"
       ]
     }
 }
-

--- a/docs/examples/compute/instance/variables.tf
+++ b/docs/examples/compute/instance/variables.tf
@@ -8,6 +8,18 @@ variable "compartment_ocid" {}
 variable "ssh_public_key" {}
 variable "ssh_private_key" {}
 
+# Defines the number of instances to deploy
+variable "NumInstances" {
+    default = "3"
+}
+
+# Defines the number of volumes to create and attach to each instance
+# NOTE: Changing this value after applying it could result in re-attaching existing volumes to different instances.
+# This is a result of using 'count' variables to specify the volume and instance IDs for the volume attachment resource.
+variable "NumVolumesPerInstance" {
+    default = "2"
+}
+
 # Choose an Availability Domain
 variable "AD" {
     default = "1"


### PR DESCRIPTION
This shows usage of count variable and math operations to set-up
instances that can be attached to multiple block storage volumes.