### PR TITLE
Updated with fixes and image OCID updates

### DIFF
--- a/docs/solutions/rhel74_image/README.md
+++ b/docs/solutions/rhel74_image/README.md
@@ -1,7 +1,45 @@
 This example provides a method to generate a RHEL 7.4 image for use by both VM and BM shapes.
+
+UPDATED 23 May 2018!  Please read below!
+
+What is fixed/changed in this release:
+
+- Fixed issue with OCI-CLI and pip that was preventing the process from working.  The original 
+  process attempted to install OCI-CLI as a global resource in the global python repo...this broke
+  after some changes in pip.  So now we install pip locally to each user.
+- Changed our blank image OCID to use a new global value.  This makes the process *more* portable across
+  regions (but not completely...see next bullet).
+- Updated the ipxe server image list to include the LHR region.  LHR is now fully supported on this process.
+- *** IMPORTANT CHANGE *** Updated process to use Instance Principal authorization method for OCI-CLI.  This
+  removes the requirement to upload the user private key into the ipxe server.  *HOWEVER*, it does REQUIRE 
+  the creation of a Dynamic Group for the Compartment this is being executed in.  This is included in the
+  prerequisites section below.  The new process WILL NOT WORK without an Instance Principal (also known
+  as a Dynamic Group).
+  
 There are several prerequisites for using this process:
 
-1. You MUST have a valid RedHat account with subscriptions available.  The TF template needs a 
+1. *** UPDATE *** You MUST setup a Dynamic Group for the Compartment in which you are going to run this process.  The
+   Dynamic Group allows the ipxe instance itself to authenticate to OCI so that no user configuration is 
+   needed to create the image.  
+   
+   Information on how to create a Dynamic Group can be found here:
+   https://docs.us-phoenix-1.oraclecloud.com/Content/Identity/Tasks/managingdynamicgroups.htm?Highlight=Dynamic%20Group
+   
+   In short, from the console:
+   - Get the Compartment OCID for the Compartment you will be using.
+   - In Identity, select Dynamic Groups
+   - Click on the Create Dynamic Group box
+   - Specify a name for the group
+   - Click on the link labeled "Launch Rule Builder"
+   - Select 'in Compartment ID' as the Resource Attribute
+   - Enter the Compartment OCID in the Value box
+   - Click on the Add Rule button
+   - Click on the Create Dynamic Group button.
+   
+   The compartment is now enabled for Instance Principals.  If you do not want this after the image is
+   created, simply delete the Dynamic Group AFTER the image is created.  Deletion of the DG will not
+   affect the usability of the image.
+2. You MUST have a valid RedHat account with subscriptions available.  The TF template needs a 
    RH Username and Password to allow you to temporarily subscribe the instance that is building the image 
    and get access to the various RH repos.
 2. The template expects pre-configured VCNs and Subnets.  
@@ -21,6 +59,9 @@ There are several prerequisites for using this process:
 6. The subnet to be used must have the following configuration:
 	- Port 80 TCP must be allowed on the subnet
 	- All ICMP traffic must be allowed on the subnet (ICMP All)
+7. *** UPDATE *** Ensure that either uuencode/uudecode is available in your shell or that the sharutils package has been
+   installed on the OS where this terraform template will be executed.  Uuencode is used to dynamically load
+   the configuration files needed for the RHEL build process.
 
 NOTE: A template env-vars file is provided as part of this example.  Simply complete the items inside the template and source the result into your shell by using:
 
@@ -43,7 +84,4 @@ boot the instance used to load RHEL, causes RHEL to load, builds the image, dest
 NOTE: The source configuration files for the iPXE server are included here.  It is *STRONGLY* recommended that they not be 
       altered.
       
-      
-ALSO NOTE: *THE PRIVATE KEY USED TO ACCESS OCI WILL TEMPORARILY BE TRANSFERRED TO THE IPXE INSTANCE.  ONCE THE IPXE INSTANCE IS DESTROYED, THE COPY OF THE PRIVATE KEY IS DESTROYED ALONG WITH IT.*
-
 Enjoy.

--- a/docs/solutions/rhel74_image/datasources.tf
+++ b/docs/solutions/rhel74_image/datasources.tf
@@ -38,17 +38,11 @@ data "oci_core_subnets" "subnet" {
 data "external" "ipxe_gen" {
 	program = [ "/bin/bash", "./ipxe_gen.sh"]
 	query = {
-		tenancy_ocid         = "${var.tenancy_ocid}"
-  		user_ocid            = "${var.user_ocid}"
- 		private_key_path     = "${var.private_key_path}"
-		private_key_password = "${var.private_key_password}"
-		fingerprint		 = "${var.fingerprint}"
-		region               = "${var.region}"
 		ssh_public_key		 = "${var.ssh_public_key}"
 		os_short_name		 = "rhel74"
 		rhel_user			 = "${var.rhel_account["user_name"]}"
 		rhel_pw			 = "${var.rhel_account["password"]}"
-		zeros_ocid		 = "${var.region_all_zeros_ocid[var.region]}"
+		zeros_ocid		 = "${var.region_all_zeros_ocid["all"]}"
 		iso_url			 = "${var.iso_url}"
 	}
 }

--- a/docs/solutions/rhel74_image/ipxe.sh.template
+++ b/docs/solutions/rhel74_image/ipxe.sh.template
@@ -1,11 +1,6 @@
 
 # DO NOT CHANGE - PRE-GENERATED VALUES #
 SSH_PUBLIC_KEY=<PUBLIC_KEY>
-TENANCY=<TENANCY>
-USER=<USER>
-FINGERPRINT=<FINGERPRINT>
-REGION=<REGION>
-PR_KEY_PW=<PASSPHRASE>
 OS="<OS_NAME>"
 RU="<RHEL_UNAME>"
 RP="<RHEL_PASS>"
@@ -25,6 +20,12 @@ SHAPE="BM.Standard1.36"
 
 yum -y -q update
 yum -y -q install sharutils httpd rsync lzma gcc libffi-devel python-devel openssl-devel unzip gcc rsyslog jq python-firewall
+easy_install pip
+pip install pip --upgrade
+pip install --user oci-cli
+
+export PATH=${PATH}:/root/.local/bin
+SUBNET_ID=`oci --auth=instance_principal network vnic get --vnic-id=${VNIC_ID} | jq '.data ["subnet-id"]' | sed 's/\"//g'`
 
 sed -i.bak 's/<\/zone>/  <service name=\"http\"\/>/' /etc/firewalld/zones/public.xml
 echo "</zone>" >> /etc/firewalld/zones/public.xml
@@ -37,47 +38,19 @@ systemctl start httpd
 mkdir -p /var/www/{isos,html}
 mkdir -p /var/www/html/{ipxe,oci,<OS_NAME>}
 mkdir /mnt/iso
-mkdir -p /home/opc/.oci
-
-chmod 755 /home/opc/.oci
 chmod 777 /var/www/isos
 
-easy_install pip
-pip install pip --upgrade
-pip install oci-cli
+cd /var/www/isos
+curl -s -o ${ISO_NAME} ${ISO_URL}
+mount -o ro ./${ISO_NAME} /mnt/iso
+cd /mnt/iso
+find . -print | cpio -pmvdu /var/www/html/${OS}
+cd ~
+umount /mnt/iso
 
 sed '/imtcp/s/#//g' -i.bak /etc/rsyslog.conf
 sed '/InputTCPServerRun/s/#//g' -i.bak /etc/rsyslog.conf
 systemctl restart rsyslog.service
-
-cd /home/opc/.oci
-if [ -z "${PR_KEY_PW}" ]
-then
-	cat > config <<-EOF
-[DEFAULT]
-user=${USER}
-fingerprint=${FINGERPRINT}
-key_file=/home/opc/.oci/oci_api_key.pem
-tenancy=${TENANCY}
-region=${REGION}
-EOF
-else
-	cat > config <<-EOF
-[DEFAULT]
-user=${USER}
-fingerprint=${FINGERPRINT}
-key_file=/home/opc/.oci/oci_api_key.pem
-tenancy=${TENANCY}
-region=${REGION}
-pass_phrase=${PR_KEY_PW}
-EOF
-fi
-
-chmod 600 ./config
-privkey
-
-chown -R opc:opc /home/opc/.oci
-chmod 700 /home/opc/.oci
 
 cd /var/www/html/ipxe
 ks
@@ -104,78 +77,67 @@ cd /var/www/html/oci
 cloud
 firewallcfg
 
-cat > /home/opc/sacrifice-launch.sh <<-EOF
-#!/bin/bash
-function inst_status { 
-	oci compute instance get --instance-id=\$1 | jq -r '.data["lifecycle-state"]'
-}
-function img_status {
-	oci compute image get --image-id=\$1 | jq -r '.data["lifecycle-state"]'
-}
-sac_inst_ocid=\`oci compute instance launch --availability-domain=${AD} \
+sac_inst_ocid=`oci --auth=instance_principal compute instance launch \
+--availability-domain=${AD} \
 --compartment-id=${COMPARTMENT} --image-id=${SAC_OCID} \
---display-name="sacrifice" --ipxe-script-file="/var/www/html/ipxe/ipxeboot" \
---shape=${SHAPE} --subnet-id=<SUBNET_OCID> \
---metadata='{"ssh_authorized_keys": "${SSH_PUBLIC_KEY}" }' | jq -r '.data["id"]'\`
+--display-name="sacrifice" \
+--ipxe-script-file="/var/www/html/ipxe/ipxeboot" \
+--shape=${SHAPE} \
+--subnet-id=${SUBNET_ID} \
+--metadata='{"ssh_authorized_keys": "'"${SSH_PUBLIC_KEY}"'" }' | jq -r '.data["id"]'`
 sleep 120
-sac_vnic_attach=\`oci compute vnic-attachment list --instance-id=\${sac_inst_ocid} \
---compartment-id=${COMPARTMENT} | jq -r '.data[0]["vnic-id"]'\`
-sac_ip=\`oci network vnic get --vnic-id=\${sac_vnic_attach} | jq -r '.data["private-ip"]'\`
+
+sac_vnic_attach=`oci --auth=instance_principal compute vnic-attachment list \
+--instance-id=${sac_inst_ocid} \
+--compartment-id=${COMPARTMENT} | jq -r '.data[0]["vnic-id"]'`
+
+sac_ip=`oci --auth=instance_principal network vnic get --vnic-id=\${sac_vnic_attach} | jq -r '.data["private-ip"]'`
+
 build_ping=1
 state=""
-while [ \${build_ping} == 1 ]
+while [ ${build_ping} == 1 ]
 do
 	sleep 120
-	ping -q -c 1 \${sac_ip}
-	build_ping=\$?
-	state=\`inst_status \${sac_inst_ocid}\`
-	if [ "\${state}" == "TERMINATED" ]
+	ping -q -c 1 ${sac_ip}
+	build_ping=$?
+	state=`inst_status ${sac_inst_ocid}`
+	if [ "${state}" == "TERMINATED" ]
 	then
 		break
 	fi
 done
 
-if [ "\${state}" != "TERMINATED" ]
+if [ "${state}" != "TERMINATED" ]
 then
 	ping_result=0
-	while [ \${ping_result} == 0 ]
+	while [ ${ping_result} == 0 ]
 	do
 		sleep 20
-		ping -q -c 1 \${sac_ip}
-		ping_result=\$?
-		state=\`inst_status \${sac_inst_ocid}\`
-		if [ "\${state}" == "TERMINATED" ]
+		ping -q -c 1 ${sac_ip}
+		ping_result=$?
+		state=`inst_status ${sac_inst_ocid}`
+		if [ "${state}" == "TERMINATED" ]
 		then
 			break
 		fi
 	done
-	if [ "\${state}" != "TERMINATED" ]
+	if [ "${state}" != "TERMINATED" ]
 	then
-		image_ocid=\`oci compute image create --compartment-id=${COMPARTMENT} \
-		--instance-id=\${sac_inst_ocid} --display-name="RHEL_74" | jq -r '.data["id"]'\`
-		image_status=\`img_status \${image_ocid}\`
-		while [ "\${image_status}" != "AVAILABLE" ]
+		image_ocid=`oci --auth=instance_principal compute image create \
+		--compartment-id=${COMPARTMENT} \
+		--instance-id=${sac_inst_ocid} \
+		--display-name="RHEL_74" | jq -r '.data["id"]'`
+
+		image_status=`img_status ${image_ocid}`
+		while [ "${image_status}" != "AVAILABLE" ]
 		do
 			sleep 120
-			image_status=\`img_status \${image_ocid}\`
+			image_status=`img_status ${image_ocid}`
 		done
-		oci compute instance terminate --instance-id=\${sac_inst_ocid} --force
+		oci --auth=instance_principal compute instance terminate --instance-id=${sac_inst_ocid} --force
 	fi
 fi
-oci compute instance terminate --instance-id=${MY_OCID} --force
-EOF
+oci --auth=instance_principal compute instance terminate --instance-id=${MY_OCID} --force
 
-SUBNET_ID=`sudo -u opc oci network vnic get --vnic-id=${VNIC_ID} | jq '.data ["subnet-id"]' | sed 's/\"//g'`
-sed -i.bak 's/<SUBNET_OCID>/'"${SUBNET_ID}"'/g' /home/opc/sacrifice-launch.sh
-chown opc:opc /home/opc/sacrifice*
-chmod 755 /home/opc/sacrifice*
-cd /var/www/isos
-curl -s -o ${ISO_NAME} ${ISO_URL}
-mount -o ro ./${ISO_NAME} /mnt/iso
-cd /mnt/iso
-find . -print | cpio -pmvdu /var/www/html/${OS}
-cd ~
-umount /mnt/iso
-sudo -u opc nohup /home/opc/sacrifice-launch.sh &
 
 

--- a/docs/solutions/rhel74_image/variable.tf
+++ b/docs/solutions/rhel74_image/variable.tf
@@ -22,26 +22,26 @@ variable "ipxe_instance" {
 	default = {
 		name = "ipxe-rhel74"
 		hostname = "ipxe-rhel74"
-		os = "Oracle Linux"
-		os-version = "7.4"
 		shape = "VM.Standard1.1"
 	}
 }
 
+# NOTE: If a different all zeros is required for a specific region, specify it here, then change
+# the datasource.tf to match (specify var.region between the [] vs. "all")
 variable "region_all_zeros_ocid" {
 	type = "map"
 	default = {
-		us-phoenix-1 = "ocid1.image.oc1.phx.aaaaaaaay27pdopotkapf2ahjlsn2wxndui5hn5w37hd2wss4ses4ol5xs6a"
-		us-ashburn-1 = "ocid1.image.oc1.iad.aaaaaaaaqftkoa5web2r7w4ls3wekgqmqy5f7untloetfiozyqbv2ql6qidq"
-		eu-frankfurt-1 = "ocid1.image.oc1.eu-frankfurt-1.aaaaaaaah4rggbyglst25peqd7vnyjzl6n5lwogiyllb6jaircakom46nswq"
+		all = "ocid1.image.oc1..aaaaaaaadevqufnklkexuu6z62f7riocqigz6zng5mxhuhghy3e6zurwct2a"
 	}
 }
 
+# These will need to be periodically updated with the latest OL 7 images.
 variable "ipxe_image_ocid" {
 	type = "map"
 	default = {
-		us-phoenix-1 = "ocid1.image.oc1.phx.aaaaaaaaxklzl52nmabfp3466ilzfpo7lv737k44kih4jpo7nsmxjehwrdsq"
-		us-ashburn-1 = "ocid1.image.oc1.iad.aaaaaaaahglw45opiuf6zrbhyuywh7lv5nxsxqbm4yznjwkac6zkapg6zi4a"
-		eu-frankfurt-1 = "ocid1.image.oc1.eu-frankfurt-1.aaaaaaaagixzcssj76xeehppbnobvhais57zrvxe32bncaalty4wrhpossfa"
+		us-phoenix-1 = "ocid1.image.oc1.phx.aaaaaaaaozjbzisykoybkppaiwviyfzusjzokq7jzwxi7nvwdiopk7ligoia"
+		us-ashburn-1 = "ocid1.image.oc1.iad.aaaaaaaa6ybn2lkqp2ejhijhehf5i65spqh3igt53iyvncyjmo7uhm5235ca"
+		eu-frankfurt-1 = "ocid1.image.oc1.eu-frankfurt-1.aaaaaaaazregkysspxnktw35k4r5vzwurxk6myu44umqthjeakbkvxvxdlkq"
+		uk-london-1 = "ocid1.image.oc1.uk-london-1.aaaaaaaayodsld656eh5stds5mo4hrmwuhk2ugin4eyfpgoiiskqfxll6a4a"
 	}
 }


### PR DESCRIPTION
What is fixed/changed in this release:

- Fixed issue with OCI-CLI and pip that was preventing the process from working.  The original 
  process attempted to install OCI-CLI as a global resource in the global python repo...this broke
  after some changes in pip.  So now we install pip locally to each user.
- Changed our blank image OCID to use a new global value.  This makes the process *more* portable across
  regions (but not completely...see next bullet).
- Updated the ipxe server image list to include the LHR region.  LHR is now fully supported on this process.
- *** IMPORTANT CHANGE *** Updated process to use Instance Principal authorization method for OCI-CLI.  This
  removes the requirement to upload the user private key into the ipxe server.  *HOWEVER*, it does REQUIRE 
  the creation of a Dynamic Group for the Compartment this is being executed in.  This is included in the
  prerequisites section below.  The new process WILL NOT WORK without an Instance Principal (also known
  as a Dynamic Group).