### PR TITLE
Fixing the always_free example to work with flexible load balancing

### DIFF
--- a/examples/always_free/main.tf
+++ b/examples/always_free/main.tf
@@ -196,7 +196,11 @@ resource "oci_load_balancer" "free_load_balancer" {
   #Required
   compartment_id = var.compartment_ocid
   display_name   = "alwaysFreeLoadBalancer"
-  shape          = "10Mbps-Micro"
+  shape = "flexible"
+  shape_details {
+      maximum_bandwidth_in_mbps = 10
+      minimum_bandwidth_in_mbps = 10
+  }
 
   subnet_ids = [
     oci_core_subnet.test_subnet.id,


### PR DESCRIPTION
[This post](https://blogs.oracle.com/cloud-infrastructure/announcing-oracle-cloud-infrastructure-flexible-load-balancing) changed how free-tier load balancers are provisioned.

This commit updates the example Terraform code for free-tier resources to use the new provisioning model; without this fix attempting to deploy this Terraform file to a free-tier OCI account will fail due to service limit imposed on free-tier accounts wrt old-style "10Mbps-Micro" load balancers.