### PR TITLE
Improve user_data metadata example

### DIFF
--- a/website/docs/d/core_instance_configuration.html.markdown
+++ b/website/docs/d/core_instance_configuration.html.markdown
@@ -187,7 +187,7 @@ The following attributes are exported:
 
 			**Metadata Example**
 
-			"metadata" : { "quake_bot_level" : "Severe", "ssh_authorized_keys" : "ssh-rsa <your_public_SSH_key>== rsa-key-20160227", "user_data" : "<your_public_SSH_key>==" } **Getting Metadata on the Instance**
+			"metadata" : { "quake_bot_level" : "Severe", "ssh_authorized_keys" : "ssh-rsa <your_public_SSH_key>== rsa-key-20160227", "user_data" : "<your_base64_encoded_user_data>==" } **Getting Metadata on the Instance**
 
 			To get information about your instance, connect to the instance using SSH and issue any of the following GET requests:
 

--- a/website/docs/d/core_instance_configurations.html.markdown
+++ b/website/docs/d/core_instance_configurations.html.markdown
@@ -194,7 +194,7 @@ The following attributes are exported:
 
 			**Metadata Example**
 
-			"metadata" : { "quake_bot_level" : "Severe", "ssh_authorized_keys" : "ssh-rsa <your_public_SSH_key>== rsa-key-20160227", "user_data" : "<your_public_SSH_key>==" } **Getting Metadata on the Instance**
+			"metadata" : { "quake_bot_level" : "Severe", "ssh_authorized_keys" : "ssh-rsa <your_public_SSH_key>== rsa-key-20160227", "user_data" : "<your_base64_encoded_user_data>==" } **Getting Metadata on the Instance**
 
 			To get information about your instance, connect to the instance using SSH and issue any of the following GET requests:
 

--- a/website/docs/r/core_instance.html.markdown
+++ b/website/docs/r/core_instance.html.markdown
@@ -311,7 +311,7 @@ The following arguments are supported:
 	**Metadata Example**
 
 	```
-	"metadata" : { "quake_bot_level" : "Severe", "ssh_authorized_keys" : "ssh-rsa <your_public_SSH_key>== rsa-key-20160227", "user_data" : "<your_public_SSH_key>==" }
+	"metadata" : { "quake_bot_level" : "Severe", "ssh_authorized_keys" : "ssh-rsa <your_public_SSH_key>== rsa-key-20160227", "user_data" : "<your_base64_encoded_user_data>==" }
 	```
 
 	**Getting Metadata on the Instance**

--- a/website/docs/r/core_instance_configuration.html.markdown
+++ b/website/docs/r/core_instance_configuration.html.markdown
@@ -348,7 +348,7 @@ The following arguments are supported:
 
 			**Metadata Example**
 
-			"metadata" : { "quake_bot_level" : "Severe", "ssh_authorized_keys" : "ssh-rsa <your_public_SSH_key>== rsa-key-20160227", "user_data" : "<your_public_SSH_key>==" } **Getting Metadata on the Instance**
+			"metadata" : { "quake_bot_level" : "Severe", "ssh_authorized_keys" : "ssh-rsa <your_public_SSH_key>== rsa-key-20160227", "user_data" : "<your_base64_encoded_user_data>==" } **Getting Metadata on the Instance**
 
 			To get information about your instance, connect to the instance using SSH and issue any of the following GET requests:
 
@@ -582,7 +582,7 @@ The following attributes are exported:
 
 			**Metadata Example**
 
-			"metadata" : { "quake_bot_level" : "Severe", "ssh_authorized_keys" : "ssh-rsa <your_public_SSH_key>== rsa-key-20160227", "user_data" : "<your_public_SSH_key>==" } **Getting Metadata on the Instance**
+			"metadata" : { "quake_bot_level" : "Severe", "ssh_authorized_keys" : "ssh-rsa <your_public_SSH_key>== rsa-key-20160227", "user_data" : "<your_base64_encoded_user_data>==" } **Getting Metadata on the Instance**
 
 			To get information about your instance, connect to the instance using SSH and issue any of the following GET requests:
 


### PR DESCRIPTION
Replace`<your_public_SSH_key>` with `<your_base64_encoded_user_data>` in `metadata.user_data` example.