### PR TITLE
Add support for arbitrary config file in provider block

### DIFF
--- a/oci/export_compartment_test.go
+++ b/oci/export_compartment_test.go
@@ -1494,20 +1494,20 @@ func TestUnitGetExportConfig(t *testing.T) {
 		t.Skip("This run requires you to set TF_HOME_OVERRIDE")
 	}
 
-	providerConfigTest(t, true, true, authAPIKeySetting, "", getExportConfig)              // ApiKey with required fields + disable auto-retries
-	providerConfigTest(t, false, true, authAPIKeySetting, "", getExportConfig)             // ApiKey without required fields
-	providerConfigTest(t, false, false, authInstancePrincipalSetting, "", getExportConfig) // InstancePrincipal
-	providerConfigTest(t, true, false, "invalid-auth-setting", "", getExportConfig)        // Invalid auth + disable auto-retries
-	configFile, keyFile, err := writeConfigFile()
+	providerConfigTest(t, true, true, authAPIKeySetting, "", "", getExportConfig)              // ApiKey with required fields + disable auto-retries
+	providerConfigTest(t, false, true, authAPIKeySetting, "", "", getExportConfig)             // ApiKey without required fields
+	providerConfigTest(t, false, false, authInstancePrincipalSetting, "", "", getExportConfig) // InstancePrincipal
+	providerConfigTest(t, true, false, "invalid-auth-setting", "", "", getExportConfig)        // Invalid auth + disable auto-retries
+	configFile, keyFile, err := writeConfigFile(defaultConfigDirName, defaultConfigFileName)
 	assert.Nil(t, err)
-	providerConfigTest(t, true, true, authAPIKeySetting, "DEFAULT", getExportConfig)              // ApiKey with required fields + disable auto-retries
-	providerConfigTest(t, false, true, authAPIKeySetting, "DEFAULT", getExportConfig)             // ApiKey without required fields
-	providerConfigTest(t, false, false, authInstancePrincipalSetting, "DEFAULT", getExportConfig) // InstancePrincipal
-	providerConfigTest(t, true, false, "invalid-auth-setting", "DEFAULT", getExportConfig)        // Invalid auth + disable auto-retries
-	providerConfigTest(t, false, false, authAPIKeySetting, "PROFILE1", getExportConfig)           // correct profileName
-	providerConfigTest(t, false, false, authAPIKeySetting, "wrongProfile", getExportConfig)       // Invalid profileName
-	//providerConfigTest(t, false, false, authAPIKeySetting, "PROFILE2", getExportConfig)           // correct profileName with mix and match, disable for TC
-	providerConfigTest(t, false, false, authAPIKeySetting, "PROFILE3", getExportConfig) // correct profileName with mix and match & env
+	providerConfigTest(t, true, true, authAPIKeySetting, "DEFAULT", "", getExportConfig)              // ApiKey with required fields + disable auto-retries
+	providerConfigTest(t, false, true, authAPIKeySetting, "DEFAULT", "", getExportConfig)             // ApiKey without required fields
+	providerConfigTest(t, false, false, authInstancePrincipalSetting, "DEFAULT", "", getExportConfig) // InstancePrincipal
+	providerConfigTest(t, true, false, "invalid-auth-setting", "DEFAULT", "", getExportConfig)        // Invalid auth + disable auto-retries
+	providerConfigTest(t, false, false, authAPIKeySetting, "PROFILE1", "", getExportConfig)           // correct profileName
+	providerConfigTest(t, false, false, authAPIKeySetting, "wrongProfile", "", getExportConfig)       // Invalid profileName
+	//providerConfigTest(t, false, false, authAPIKeySetting, "PROFILE2", "", getExportConfig)           // correct profileName with mix and match, disable for TC
+	providerConfigTest(t, false, false, authAPIKeySetting, "PROFILE3", "", getExportConfig) // correct profileName with mix and match & env
 	defer removeFile(configFile)
 	defer removeFile(keyFile)
 	defer os.RemoveAll(path.Join(getHomeFolder(), defaultConfigDirName))

--- a/oci/provider.go
+++ b/oci/provider.go
@@ -89,6 +89,7 @@ const (
 	ociEnvPrefix             = "OCI_"
 	defaultConfigFileName    = "config"
 	defaultConfigDirName     = ".oci"
+	defaultConfigProfile     = "DEFAULT"
 	colonDelimiter           = ";"
 	equalToOperatorDelimiter = "="
 )
@@ -145,7 +146,7 @@ func init() {
 			"Automatic retries were introduced to solve some eventual consistency problems but it also introduced performance issues on destroy operations.",
 		retryDurationSecondsAttrName: "(Optional) The minimum duration (in seconds) to retry a resource operation in response to an error.\n" +
 			"The actual retry duration may be longer due to jittering of retry operations. This value is ignored if the `disable_auto_retries` field is set to true.",
-		configFileProfileAttrName: "(Optional) The profile name to be used from config file, if not set it will be DEFAULT.",
+		configFileProfileAttrName: fmt.Sprintf("(Optional) The profile name to be used from config file, if not set it will be %s.", defaultConfigProfile),
 	}
 }
 


### PR DESCRIPTION
Allow provider support other configuration files than ~/.oci/config

Added configuration argument `config_file_path`
Logic of method `getSdkConfigProvider` was updated to support combinations of `config_file_profile` and `config_file_path`:
- `configFile` and `profile` are initiliased with default values
- in case corresponding configuration argument is provided, default value is being replaced with the provided one
- if neither of configuration arguments provided, `oci_common.DefaultConfigProvider()` is used to populate `configProviders`
- if any is provided, `oci_common.CustomProfileConfigProvider()` with extracted values is used

Implements the idea #1258