### PR TITLE
docs: cidr_block uses snakecase

### DIFF
--- a/website/docs/r/core_vcn.html.markdown
+++ b/website/docs/r/core_vcn.html.markdown
@@ -83,12 +83,12 @@ The following arguments are supported:
 * `byoipv6cidr_details` - (Optional) The list of BYOIPv6 OCIDs and BYOIPv6 CIDR blocks required to create a VCN that uses BYOIPv6 ranges. 
 	* `byoipv6range_id` - (Required) The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the `ByoipRange` resource to which the CIDR block belongs.
 	* `ipv6cidr_block` - (Required) An IPv6 CIDR block required to create a VCN with a BYOIP prefix. It could be the whole CIDR block identified in `byoipv6RangeId`, or a subrange. Example: `2001:0db8:0123::/48` 
-* `cidr_block` - (Optional) **Deprecated.** Do *not* set this value. Use `cidrBlocks` instead. Example: `10.0.0.0/16` 
+* `cidr_block` - (Optional) **Deprecated.** Do *not* set this value. Use `cidr_blocks` instead. Example: `10.0.0.0/16`
 * `cidr_blocks` - (Optional) (Updatable) The list of one or more IPv4 CIDR blocks for the VCN that meet the following criteria:
 	* The CIDR blocks must be valid.
 	* They must not overlap with each other or with the on-premises network CIDR block.
-	* The number of CIDR blocks must not exceed the limit of CIDR blocks allowed per VCN. It is an error to set both cidrBlock and cidrBlocks. Note: cidr_blocks update must be restricted to one operation at a time (either add/remove or modify one single cidr_block) or the operation will be declined. new cidr_block to be added must be placed at the end of the list. Once you migrate to using `cidr_blocks` from `cidr_block`, you will not be able to switch back.
-	**Important:** Do *not* specify a value for `cidrBlock`. Use this parameter instead. 
+	* The number of CIDR blocks must not exceed the limit of CIDR blocks allowed per VCN. It is an error to set both cidr_block and cidr_blocks. Note: cidr_blocks update must be restricted to one operation at a time (either add/remove or modify one single cidr_block) or the operation will be declined. new cidr_block to be added must be placed at the end of the list. Once you migrate to using `cidr_blocks` from `cidr_block`, you will not be able to switch back.
+	**Important:** Do *not* specify a value for `cidr_block`. Use this parameter instead.
 * `compartment_id` - (Required) (Updatable) The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to contain the VCN.
 * `defined_tags` - (Optional) (Updatable) Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).  Example: `{"Operations.CostCenter": "42"}` 
 * `display_name` - (Optional) (Updatable) A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
@@ -105,7 +105,7 @@ The following arguments are supported:
 	* Multiple CIDR blocks must not overlap each other or the on-premises network CIDR block.
 	* The number of CIDR blocks must not exceed the limit of IPv6 CIDR blocks allowed to a vcn.
 
-	**Important:** Do *not* specify a value for `ipv6CidrBlock`. Use this parameter instead. 
+	**Important:** Do *not* specify a value for `ipv6cidr_block`. Use this parameter instead. 
 * `is_ipv6enabled` - (Optional) Whether IPv6 is enabled for the VCN. Default is `false`. If enabled, Oracle will assign the VCN a IPv6 /56 CIDR block. You may skip having Oracle allocate the VCN a IPv6 /56 CIDR block by setting isOracleGuaAllocationEnabled to `false`. For important details about IPv6 addressing in a VCN, see [IPv6 Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).  Example: `true` 
 * `is_oracle_gua_allocation_enabled` - (Optional) Specifies whether to skip Oracle allocated IPv6 GUA. By default, Oracle will allocate one GUA of /56 size for an IPv6 enabled VCN. 
 
@@ -118,7 +118,7 @@ Any change to a property that does not support update will force the destruction
 The following attributes are exported:
 
 * `byoipv6cidr_blocks` - The list of BYOIPv6 CIDR blocks required to create a VCN that uses BYOIPv6 ranges. 
-* `cidr_block` - Deprecated. The first CIDR IP address from cidrBlocks.  Example: `172.16.0.0/16` 
+* `cidr_block` - Deprecated. The first CIDR IP address from cidr_blocks.  Example: `172.16.0.0/16` 
 * `cidr_blocks` - The list of IPv4 CIDR blocks the VCN will use. 
 * `compartment_id` - The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment containing the VCN.
 * `default_dhcp_options_id` - The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) for the VCN's default set of DHCP options. 


### PR DESCRIPTION
References to terraform arguments should use snake case, 