### PR TITLE
Fixed target_resource_details of oci_bastion_session having unexpected diff after creation

### DIFF
--- a/internal/service/bastion/bastion_session_resource.go
+++ b/internal/service/bastion/bastion_session_resource.go
@@ -599,9 +599,9 @@ func (s *BastionSessionResourceCrud) mapToCreateSessionTargetResourceDetails(fie
 func TargetResourceDetailsToMap(obj *oci_bastion.TargetResourceDetails) map[string]interface{} {
 	result := map[string]interface{}{}
 	switch v := (*obj).(type) {
-	case oci_bastion.CreateDynamicPortForwardingSessionTargetResourceDetails:
+	case oci_bastion.DynamicPortForwardingSessionTargetResourceDetails:
 		result["session_type"] = "DYNAMIC_PORT_FORWARDING"
-	case oci_bastion.CreateManagedSshSessionTargetResourceDetails:
+	case oci_bastion.ManagedSshSessionTargetResourceDetails:
 		result["session_type"] = "MANAGED_SSH"
 
 		if v.TargetResourceId != nil {
@@ -619,7 +619,7 @@ func TargetResourceDetailsToMap(obj *oci_bastion.TargetResourceDetails) map[stri
 		if v.TargetResourcePrivateIpAddress != nil {
 			result["target_resource_private_ip_address"] = string(*v.TargetResourcePrivateIpAddress)
 		}
-	case oci_bastion.CreatePortForwardingSessionTargetResourceDetails:
+	case oci_bastion.PortForwardingSessionTargetResourceDetails:
 		result["session_type"] = "PORT_FORWARDING"
 
 		if v.TargetResourceFqdn != nil {
@@ -638,7 +638,7 @@ func TargetResourceDetailsToMap(obj *oci_bastion.TargetResourceDetails) map[stri
 			result["target_resource_private_ip_address"] = string(*v.TargetResourcePrivateIpAddress)
 		}
 	default:
-		log.Printf("[WARN] Received 'session_type' of unknown type %v", *obj)
+		log.Printf("[WARN] Received 'session_type' of unknown type %T", *obj)
 		return nil
 	}
 


### PR DESCRIPTION
This PR will fix issue, target_resource_details of oci_bastion_session having unexpected diff after creation.

## The fix
The polymorphic type of `oci_bastion.TargetResourceDetails` which was specified in type assertions was wrong so I fixed to the correct one.

## Step to reproduce this issue
The following terraform resources will cause this issue.

After creating this resources, oci_bastion_session will always run into `forces replacement` because of the unexpected diff of `target_resource_details`.

```terraform
resource "oci_bastion_bastion" "private_bastion" {
  bastion_type                 = "STANDARD"
  compartment_id               = var.compartment_id
  target_subnet_id             = oci_core_subnet.vcn_private_subnet.id
  client_cidr_block_allow_list = ["0.0.0.0/0"]
}

resource "oci_bastion_session" "private_mysql_session" {
  bastion_id = oci_bastion_bastion.private_bastion.id
  key_details {
    public_key_content = "<YOUR_PUBLIC_KEY_HERE>"
  }
  target_resource_details {
    session_type                               = "PORT_FORWARDING"
    target_resource_private_ip_address         = oci_mysql_mysql_db_system.mysql_db_system.ip_address
    target_resource_port                       = 3306
  }

  display_name           = "private_mysql_session"
  key_type               = "PUB"
  session_ttl_in_seconds = "10800"
}
```

The output of terraform plan is following.

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # module.kino.oci_bastion_session.kino_private_mysql_session[0] must be replaced
-/+ resource "oci_bastion_session" "kino_private_mysql_session" {
      ~ bastion_name                 = "bastion20221105195433" -> (known after apply)
      + bastion_public_host_key_info = (known after apply)
      ~ bastion_user_name            = "*************" -> (known after apply)
      ~ id                           = "*************" -> (known after apply)
      + lifecycle_details            = (known after apply)
      ~ ssh_metadata                 = {
          - "command" = "ssh -i <privateKey> -N -L <localPort>:10.0.1.218:3306 -p 22 *************"
        } -> (known after apply)
      ~ state                        = "ACTIVE" -> (known after apply)
      ~ time_created                 = "2022-11-06 10:14:05.865 +0000 UTC" -> (known after apply)
      ~ time_updated                 = "2022-11-06 10:14:12.867 +0000 UTC" -> (known after apply)
        # (4 unchanged attributes hidden)

      + target_resource_details { # forces replacement
          + session_type                               = "PORT_FORWARDING" # forces replacement
          + target_resource_display_name               = (known after apply)
          + target_resource_fqdn                       = (known after apply)
          + target_resource_id                         = (known after apply)
          + target_resource_operating_system_user_name = (known after apply)
          + target_resource_port                       = 3306 # forces replacement
          + target_resource_private_ip_address         = "10.0.1.218" # forces replacement
        }

        # (1 unchanged block hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.
```