### PR TITLE
Replace hashicorp/oci with oracle/oci in some links

### DIFF
--- a/website/docs/r/container_instances_container_instance.html.markdown
+++ b/website/docs/r/container_instances_container_instance.html.markdown
@@ -279,7 +279,7 @@ The following attributes are exported:
 
 ## Timeouts
 
-The `timeouts` block allows you to specify [timeouts](https://registry.terraform.io/providers/hashicorp/oci/latest/docs/guides/changing_timeouts) for certain operations:
+The `timeouts` block allows you to specify [timeouts](https://registry.terraform.io/providers/oracle/oci/latest/docs/guides/changing_timeouts) for certain operations:
 	* `create` - (Defaults to 20 minutes), when creating the Container Instance
 	* `update` - (Defaults to 20 minutes), when updating the Container Instance
 	* `delete` - (Defaults to 20 minutes), when destroying the Container Instance

--- a/website/docs/r/golden_gate_connection.html.markdown
+++ b/website/docs/r/golden_gate_connection.html.markdown
@@ -185,7 +185,7 @@ The following attributes are exported:
 
 ## Timeouts
 
-The `timeouts` block allows you to specify [timeouts](https://registry.terraform.io/providers/hashicorp/oci/latest/docs/guides/changing_timeouts) for certain operations:
+The `timeouts` block allows you to specify [timeouts](https://registry.terraform.io/providers/oracle/oci/latest/docs/guides/changing_timeouts) for certain operations:
 	* `create` - (Defaults to 20 minutes), when creating the Connection
 	* `update` - (Defaults to 20 minutes), when updating the Connection
 	* `delete` - (Defaults to 20 minutes), when destroying the Connection

--- a/website/docs/r/golden_gate_connection_assignment.html.markdown
+++ b/website/docs/r/golden_gate_connection_assignment.html.markdown
@@ -48,7 +48,7 @@ The following attributes are exported:
 
 ## Timeouts
 
-The `timeouts` block allows you to specify [timeouts](https://registry.terraform.io/providers/hashicorp/oci/latest/docs/guides/changing_timeouts) for certain operations:
+The `timeouts` block allows you to specify [timeouts](https://registry.terraform.io/providers/oracle/oci/latest/docs/guides/changing_timeouts) for certain operations:
 	* `create` - (Defaults to 20 minutes), when creating the Connection Assignment
 	* `update` - (Defaults to 20 minutes), when updating the Connection Assignment
 	* `delete` - (Defaults to 20 minutes), when destroying the Connection Assignment

--- a/website/docs/r/mysql_replica.html.markdown
+++ b/website/docs/r/mysql_replica.html.markdown
@@ -68,7 +68,7 @@ The following attributes are exported:
 
 ## Timeouts
 
-The `timeouts` block allows you to specify [timeouts](https://registry.terraform.io/providers/hashicorp/oci/latest/docs/guides/changing_timeouts) for certain operations:
+The `timeouts` block allows you to specify [timeouts](https://registry.terraform.io/providers/oracle/oci/latest/docs/guides/changing_timeouts) for certain operations:
 	* `create` - (Defaults to 20 minutes), when creating the Replica
 	* `update` - (Defaults to 20 minutes), when updating the Replica
 	* `delete` - (Defaults to 20 minutes), when destroying the Replica

--- a/website/docs/r/queue_queue.html.markdown
+++ b/website/docs/r/queue_queue.html.markdown
@@ -74,7 +74,7 @@ The following attributes are exported:
 
 ## Timeouts
 
-The `timeouts` block allows you to specify [timeouts](https://registry.terraform.io/providers/hashicorp/oci/latest/docs/guides/changing_timeouts) for certain operations:
+The `timeouts` block allows you to specify [timeouts](https://registry.terraform.io/providers/oracle/oci/latest/docs/guides/changing_timeouts) for certain operations:
 	* `create` - (Defaults to 20 minutes), when creating the Queue
 	* `update` - (Defaults to 20 minutes), when updating the Queue
 	* `delete` - (Defaults to 20 minutes), when destroying the Queue


### PR DESCRIPTION
This link is broken:
https://registry.terraform.io/providers/hashicorp/oci/latest/docs/guides/changing_timeouts

This link works:
https://registry.terraform.io/providers/oracle/oci/latest/docs/guides/changing_timeouts

Fixed #1742 