### PR TITLE
Fix oci_marketplace_listing_package_agreement data source name

### DIFF
--- a/website/docs/d/marketplace_listing_package_agreement.html.markdown
+++ b/website/docs/d/marketplace_listing_package_agreement.html.markdown
@@ -7,7 +7,7 @@ description: |-
   Provides details about a specific Listing Package Agreement in Oracle Cloud Infrastructure Marketplace service
 ---
 
-# Data Source: oci_marketplace_listing_package_agreement_management
+# Data Source: oci_marketplace_listing_package_agreement
 This data source provides details about a specific Listing Package Agreement resource in Oracle Cloud Infrastructure Marketplace service.
 
 It can be used to retrieve the time-based signature of terms of use agreement for a package that can be used to


### PR DESCRIPTION
This change fixes an inaccuracy in the documentation where the `oci_marketplace_listing_package_agreement` data source is misnamed `oci_marketplace_listing_package_agreement_management`.