### PR TITLE
Bug Fix - Ensure old and new changes are compared for container addon configuration updates

### DIFF
--- a/internal/tfresource/crud_helpers.go
+++ b/internal/tfresource/crud_helpers.go
@@ -590,7 +590,7 @@ func listOfMapEqualIgnoreOrderSuppressDiff(key string, d schemaResourceData) boo
 		}
 		tmp1[i] = string(s1)
 
-		map2 := oldList[i].(map[string]interface{})
+		map2 := newList[i].(map[string]interface{})
 		jsonMap2 := GenericMapToJsonMap(map2)
 		s2, err := json.Marshal(jsonMap2)
 		if err != nil {


### PR DESCRIPTION
When making changes to the `configurations` attribute in the `oci_containerengine_addon` resource, updates are not possible on existing values because the code has a small typo, comparing old with old.

With this fix, i am now able to update values on existing keys (i.e `nodes` for the `ClusterAutoscaler` addon) and plan / apply is now detecting the change:

```hcl
Terraform will perform the following actions:

  # oci_containerengine_addon.demo will be updated in-place
  ~ resource "oci_containerengine_addon" "demo" {
        id = "clusters/ocid1.cluster.oc1.{ocid}/addons/ClusterAutoscaler"
        # (7 unchanged attributes hidden)

      ~ configurations {
          ~ value = "1:3:ocid1.nodepool.{ocid},1:6:ocid1.nodepool.{ocid}" -> "1:6:ocid1.nodepool.{ocid},1:6:ocid1.nodepool.{ocid}"
            # (1 unchanged attribute hidden)
        }
    }
```