### PR TITLE
Remove extra space in Shielded Instances

### DIFF
--- a/website/docs/r/core_instance.html.markdown
+++ b/website/docs/r/core_instance.html.markdown
@@ -428,7 +428,7 @@ The following arguments are supported:
 
 	Each shape only supports certain configurable values. If the values that you provide are not valid for the specified `shape`, an error is returned.
 
-	For more information about shielded instances, see [Shielded Instances](https://docs.cloud.oracle. com/iaas/Content/Compute/References/shielded-instances.htm).
+	For more information about shielded instances, see [Shielded Instances](https://docs.cloud.oracle.com/iaas/Content/Compute/References/shielded-instances.htm).
 
 	For more information about BIOS settings for bare metal instances, see [BIOS Settings for Bare Metal Instances](https://docs.cloud.oracle.com/iaas/Content/Compute/References/bios-settings.htm). 
 	* `are_virtual_instructions_enabled` - (Applicable when type=AMD_MILAN_BM | AMD_MILAN_BM_GPU | AMD_ROME_BM | AMD_ROME_BM_GPU | GENERIC_BM) Whether virtualization instructions are available. For example, Secure Virtual Machine for AMD shapes or VT-x for Intel shapes. 


### PR DESCRIPTION
In the documentation about Shielded Instances we have a broken link caused by an extra space and this PR remove it