### PR TITLE
Handling a null response for certain values from PCA

### DIFF
--- a/internal/service/core/core_instance_resource.go
+++ b/internal/service/core/core_instance_resource.go
@@ -1621,6 +1621,9 @@ func (s *CoreInstanceResourceCrud) SetData() error {
 
 	if s.Res.ExtendedMetadata != nil {
 		s.D.Set("extended_metadata", tfresource.GenericMapToJsonMap(s.Res.ExtendedMetadata))
+	} else {
+		extended_metadata := map[string]interface{}{}
+		s.D.Set("extended_metadata", extended_metadata)
 	}
 
 	if s.Res.FaultDomain != nil {
@@ -1728,6 +1731,9 @@ func (s *CoreInstanceResourceCrud) SetData() error {
 
 	if s.Res.SystemTags != nil {
 		s.D.Set("system_tags", tfresource.SystemTagsToMap(s.Res.SystemTags))
+	} else {
+		system_tags := map[string]interface{}{}
+		s.D.Set("system_tags", system_tags)
 	}
 
 	if s.Res.TimeCreated != nil {

--- a/internal/service/core/core_volume_resource.go
+++ b/internal/service/core/core_volume_resource.go
@@ -688,6 +688,9 @@ func (s *CoreVolumeResourceCrud) SetData() error {
 
 	if s.Res.SystemTags != nil {
 		s.D.Set("system_tags", tfresource.SystemTagsToMap(s.Res.SystemTags))
+	} else {
+		system_tags := map[string]interface{}{}
+		s.D.Set("system_tags", system_tags)
 	}
 
 	if s.Res.TimeCreated != nil {


### PR DESCRIPTION
Oracle Private Cloud Appliances are designed to be API compatible with Oracle Cloud. However the Appliances have no concept of system_tags and return a null value to the Golang SDK functions. This results in Terraform plans that constantly report a (known after apply change) for `system_tags`.

There is similar behavior for the `extended_metadata` 

By adding logic to appropriately convert null values in API responses to empty maps `{}` the terraform-provider-oci provider will become much more usable for customers using it to manage Private Cloud Appliances.