### PR TITLE
Corrects missing `is_shareable` attribute in results from data source `oci_core_volume_attachments` #2191

### DIFF
--- a/internal/service/core/core_volume_attachments_data_source.go
+++ b/internal/service/core/core_volume_attachments_data_source.go
@@ -158,6 +158,10 @@ func (s *CoreVolumeAttachmentsDataSourceCrud) SetData() error {
 				result["is_read_only"] = bool(*v.IsReadOnly)
 			}
 
+			if v.IsShareable != nil {
+				result["is_shareable"] = bool(*v.IsShareable)
+			}
+
 			if v.IsVolumeCreatedDuringLaunch != nil {
 				result["is_volume_created_during_launch"] = bool(*v.IsVolumeCreatedDuringLaunch)
 			}
@@ -244,6 +248,10 @@ func (s *CoreVolumeAttachmentsDataSourceCrud) SetData() error {
 				result["is_read_only"] = bool(*v.IsReadOnly)
 			}
 
+			if v.IsShareable != nil {
+				result["is_shareable"] = bool(*v.IsShareable)
+			}
+
 			if v.IsVolumeCreatedDuringLaunch != nil {
 				result["is_volume_created_during_launch"] = bool(*v.IsVolumeCreatedDuringLaunch)
 			}
@@ -296,6 +304,10 @@ func (s *CoreVolumeAttachmentsDataSourceCrud) SetData() error {
 
 			if v.IsReadOnly != nil {
 				result["is_read_only"] = bool(*v.IsReadOnly)
+			}
+
+			if v.IsShareable != nil {
+				result["is_shareable"] = bool(*v.IsShareable)
 			}
 
 			if v.IsVolumeCreatedDuringLaunch != nil {

--- a/website/docs/d/core_volume_attachments.html.markdown
+++ b/website/docs/d/core_volume_attachments.html.markdown
@@ -67,6 +67,7 @@ The following attributes are exported:
 * `is_multipath` - Whether the Iscsi or Paravirtualized attachment is multipath or not, it is not applicable to NVMe attachment.
 * `is_pv_encryption_in_transit_enabled` - Whether in-transit encryption for the data volume's paravirtualized attachment is enabled or not.
 * `is_read_only` - Whether the attachment was created in read-only mode.
+* `is_shareable` - Whether the attachment should be created in shareable mode. If an attachment is created in shareable mode, then other instances can attach the same volume, provided that they also create their attachments in shareable mode. Only certain volume types can be attached in shareable mode. Defaults to false if not specified.
 * `is_volume_created_during_launch` - Flag indicating if this volume was created for the customer as part of a simplified launch. Used to determine whether the volume requires deletion on instance termination. 
 * `iscsi_login_state` - The iscsi login state of the volume attachment. For a Iscsi volume attachment, all iscsi sessions need to be all logged-in or logged-out to be in logged-in or logged-out state.
 * `multipath_devices` - A list of secondary multipath devices


### PR DESCRIPTION
Data source  `oci_core_volume_attachments` is missing `is_shareable` attribute so that it returns `false` for all results. This change adds the missing attribute and updates related documentation to indicate inclusion of the attribute.