### PR TITLE
Specify KMS key ID for Boot volume in core_instance_configuration

### DIFF
--- a/internal/service/core/core_instance_configuration_resource.go
+++ b/internal/service/core/core_instance_configuration_resource.go
@@ -3516,6 +3516,11 @@ func (s *CoreInstanceConfigurationResourceCrud) mapToInstanceConfigurationInstan
 			tmp := imageId.(string)
 			details.ImageId = &tmp
 		}
+		if kmsKeyId, ok := s.D.GetOkExists(fmt.Sprintf(fieldKeyFormat, "kms_key_id")); ok {
+			tmp := kmsKeyId.(string)
+			details.KmsKeyId = &tmp
+		}
+
 		if instanceSourceImageFilterDetails, ok := s.D.GetOkExists(fmt.Sprintf(fieldKeyFormat, "instance_source_image_filter_details")); ok {
 			if tmpList := instanceSourceImageFilterDetails.([]interface{}); len(tmpList) > 0 {
 				fieldKeyFormatNextLevel := fmt.Sprintf("%s.%d.%%s", fmt.Sprintf(fieldKeyFormat, "instance_source_image_filter_details"), 0)


### PR DESCRIPTION
This PR adds missing kms_key_id for oci_core_instance_configuration in instance_details.launch_details.source_details.

Relates to #1309.

Documentation and terraform schema already state this is supported.