### PR TITLE
Move compute instance's capacity reservation id change to the same request as shape

### DIFF
--- a/internal/service/core/core_instance_resource.go
+++ b/internal/service/core/core_instance_resource.go
@@ -1467,7 +1467,7 @@ func (s *CoreInstanceResourceCrud) Update() error {
 		}
 	}
 
-	// Update shape, shape config, platform config, source details, fault domain and launch options
+	// Update shape, shape config, platform config, source details, fault domain, launch options, and capacity reservation
 	err := s.updateOptionsViaWorkRequest()
 
 	if err != nil {
@@ -1501,10 +1501,6 @@ func (s *CoreInstanceResourceCrud) Update() error {
 		}
 	}
 
-	if capacityReservationId, ok := s.D.GetOkExists("capacity_reservation_id"); ok {
-		tmp := capacityReservationId.(string)
-		request.CapacityReservationId = &tmp
-	}
 	if dedicatedVmHostId, ok := s.D.GetOkExists("dedicated_vm_host_id"); ok {
 		tmp := dedicatedVmHostId.(string)
 		request.DedicatedVmHostId = &tmp
@@ -4073,6 +4069,11 @@ func (s *CoreInstanceResourceCrud) updateOptionsViaWorkRequest() error {
 			}
 			request.ShapeConfig = &tmp
 		}
+	}
+
+	if capacityReservationId, ok := s.D.GetOkExists("capacity_reservation_id"); ok {
+		tmp := capacityReservationId.(string)
+		request.CapacityReservationId = &tmp
 	}
 
 	if platformConfig, ok := s.D.GetOkExists("platform_config"); ok && s.D.HasChange("platform_config") {


### PR DESCRIPTION
Fixes #2313

## Problem
If I have a compute instance and I want to change both its shape and its capacity reservation (to a different capacity reservation that I know has the new shape available), I can do that in the OCI web UI with a single update to the instance.

However, because of how those attributes are split apart in the terraform provider, it ends up being two different update requests. The first update request to change the shape will fail, because the _current_ capacity reservation does not have sufficient capacity for the new shape.
https://github.com/oracle/terraform-provider-oci/blob/97b6ff8db7aaf3b1cb152292f753fb8613ab0d38/internal/service/core/core_instance_resource.go#L1470-L1471

The update to the _new_ capacity reservation id doesn't happen until a later update request.
https://github.com/oracle/terraform-provider-oci/blob/97b6ff8db7aaf3b1cb152292f753fb8613ab0d38/internal/service/core/core_instance_resource.go#L1504-L1507

I believe, that capacity reservation id belongs in the first update (which contains shape, shape config, platform config, source details, fault domain, and launch options), because reserving capacity is _intrinsically_ tied to the shape and shape config of the instance. You are reserving a _specific_ shape. 

## Example
I have a complete working example in https://gist.github.com/b-dean/0cccde387e8dcc57167b08e5e45ef80c, which I referenced from #2313

In this example there's a capacity reservation with E4 instances and one with E5, and the instance will switch between them. Real world examples would likely be more complex, but the principle is still the same: it should be possible to change both shape and capacity reservation at the same time.

```hcl
variable "shape_index" {
  type    = number
  default = 0
}

variable "shapes" {
  type = list(string)

  default = [
    "VM.Standard.E4.Flex",
    "VM.Standard.E5.Flex",
  ]
}

resource "oci_core_compute_capacity_reservation" "example" {
  count = length(var.shapes)

  availability_domain = var.availability_domain
  compartment_id      = var.compartment_id
  display_name        = "example-${count.index}"

  instance_reservation_configs {
    instance_shape = var.shapes[count.index]
    reserved_count = 1
    fault_domain   = var.fault_domain

    instance_shape_config {
      memory_in_gbs = 4
      ocpus         = 1
    }
  }
}

resource "oci_core_instance" "example" {
  availability_domain = var.availability_domain
  compartment_id      = var.compartment_id
  fault_domain   = var.fault_domain
  capacity_reservation_id = oci_core_compute_capacity_reservation.example[var.shape_index].id
  display_name            = "example"
  shape                   = var.shapes[var.shape_index]

  shape_config {
    memory_in_gbs = 4
    ocpus         = 1
  }
}
```

The first terraform apply puts it in the E4 capacity reservation:
```sh
terraform apply -var shape_index=0
```

The second *should* change the shape and move it to the new capacity reservation:
```sh
terraform apply -var shape_index=1
```

but it fails:
```
│ Error: 400-InvalidParameter, Invalid Shape Config: No valid reservation configs in the reservation to move the resize to.
│ Suggestion: Please update the parameter(s) in the Terraform config as per error message Invalid Shape Config: No valid reservation configs in the reservation to move the resize to.
│ Documentation: https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_instance
│ API Reference: https://docs.oracle.com/iaas/api/#/en/iaas/20160918/Instance/UpdateInstance
│ Request Target: PUT https://iaas.us-ashburn-1.oraclecloud.com/20160918/instances/ocid1.instance.oc1.iad.xxxxxxxxxxxxxxxx
│ Provider version: 6.28.0, released on 2025-03-02.
│ Service: Core Instance
│ Operation Name: UpdateInstance
│ OPC request ID: xxxxxxxxxxxxxxxx
│
│
│   with oci_core_instance.example,
│   on main.tf line 46, in resource "oci_core_instance" "example":
│   46: resource "oci_core_instance" "example" {
│
```

Because it's trying to change **only** the shape, and there aren't any of that shape in the old capacity reservation.

When I build a local copy of the provider from this PR it is able to update both shape and capacity reservation at the same time.