### PR TITLE
Deactivate app before deletion in identity_domains

### DIFF
--- a/internal/service/identity_domains/identity_domains_app_resource.go
+++ b/internal/service/identity_domains/identity_domains_app_resource.go
@@ -22,15 +22,17 @@ import (
 )
 
 func IdentityDomainsAppResource() *schema.Resource {
+	log.Printf("[DEBUG] Identity Domains App resource initialized with ignore_defined_tags CustomizeDiff: field=%q", identityDomainsOciTagsField)
 	return &schema.Resource{
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
-		Timeouts: tfresource.DefaultTimeout,
-		Create:   createIdentityDomainsApp,
-		Read:     readIdentityDomainsApp,
-		Update:   updateIdentityDomainsApp,
-		Delete:   deleteIdentityDomainsApp,
+		Timeouts:      tfresource.DefaultTimeout,
+		Create:        createIdentityDomainsApp,
+		Read:          readIdentityDomainsApp,
+		Update:        updateIdentityDomainsApp,
+		Delete:        deleteIdentityDomainsApp,
+		CustomizeDiff: identityDomainsIgnoreDefinedTagsCustomizeDiff("oci_identity_domains_app", identityDomainsOciTagsField),
 		Schema: map[string]*schema.Schema{
 			// Required
 			"based_on_template": {
@@ -987,10 +989,11 @@ func IdentityDomainsAppResource() *schema.Resource {
 
 						// Optional
 						"defined_tags": {
-							Type:             schema.TypeList,
+							Type:             schema.TypeSet,
 							Optional:         true,
 							Computed:         true,
 							DiffSuppressFunc: tfresource.DefinedTagsDiffSuppressFunction,
+							Set:              definedTagsHashCodeForSets,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									// Required
@@ -1014,9 +1017,10 @@ func IdentityDomainsAppResource() *schema.Resource {
 							},
 						},
 						"freeform_tags": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Optional: true,
 							Computed: true,
+							Set:      freeformTagsHashCodeForSets,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									// Required
@@ -5010,7 +5014,7 @@ func (s *IdentityDomainsAppResourceCrud) SetData() error {
 	s.D.Set("trust_scope", s.Res.TrustScope)
 
 	if s.Res.UrnIetfParamsScimSchemasOracleIdcsExtensionOciTags != nil {
-		s.D.Set("urnietfparamsscimschemasoracleidcsextension_oci_tags", []interface{}{ExtensionOCITagsToMap(s.Res.UrnIetfParamsScimSchemasOracleIdcsExtensionOciTags)})
+		s.D.Set("urnietfparamsscimschemasoracleidcsextension_oci_tags", []interface{}{ExtensionOCITagsToMap(s.Res.UrnIetfParamsScimSchemasOracleIdcsExtensionOciTags, false)})
 	} else {
 		s.D.Set("urnietfparamsscimschemasoracleidcsextension_oci_tags", nil)
 	}
@@ -5637,7 +5641,7 @@ func AppToMap(obj oci_identity_domains.App, datasource bool) map[string]interfac
 	result["trust_scope"] = string(obj.TrustScope)
 
 	if obj.UrnIetfParamsScimSchemasOracleIdcsExtensionOciTags != nil {
-		result["urnietfparamsscimschemasoracleidcsextension_oci_tags"] = []interface{}{ExtensionOCITagsToMap(obj.UrnIetfParamsScimSchemasOracleIdcsExtensionOciTags)}
+		result["urnietfparamsscimschemasoracleidcsextension_oci_tags"] = []interface{}{ExtensionOCITagsToMap(obj.UrnIetfParamsScimSchemasOracleIdcsExtensionOciTags, datasource)}
 	}
 
 	if obj.UrnIetfParamsScimSchemasOracleIdcsExtensionDbcsApp != nil {
@@ -8839,10 +8843,11 @@ func (s *IdentityDomainsAppResourceCrud) mapToExtensionOCITags(fieldKeyFormat st
 	result := oci_identity_domains.ExtensionOciTags{}
 
 	if definedTags, ok := s.D.GetOkExists(fmt.Sprintf(fieldKeyFormat, "defined_tags")); ok {
-		interfaces := definedTags.([]interface{})
+		set := definedTags.(*schema.Set)
+		interfaces := set.List()
 		tmp := make([]oci_identity_domains.DefinedTags, len(interfaces))
 		for i := range interfaces {
-			stateDataIndex := i
+			stateDataIndex := definedTagsHashCodeForSets(interfaces[i])
 			fieldKeyFormatNextLevel := fmt.Sprintf("%s.%d.%%s", fmt.Sprintf(fieldKeyFormat, "defined_tags"), stateDataIndex)
 			converted, err := s.mapTodefinedTags(fieldKeyFormatNextLevel)
 			if err != nil {
@@ -8856,10 +8861,11 @@ func (s *IdentityDomainsAppResourceCrud) mapToExtensionOCITags(fieldKeyFormat st
 	}
 
 	if freeformTags, ok := s.D.GetOkExists(fmt.Sprintf(fieldKeyFormat, "freeform_tags")); ok {
-		interfaces := freeformTags.([]interface{})
+		set := freeformTags.(*schema.Set)
+		interfaces := set.List()
 		tmp := make([]oci_identity_domains.FreeformTags, len(interfaces))
 		for i := range interfaces {
-			stateDataIndex := i
+			stateDataIndex := freeformTagsHashCodeForSets(interfaces[i])
 			fieldKeyFormatNextLevel := fmt.Sprintf("%s.%d.%%s", fmt.Sprintf(fieldKeyFormat, "freeform_tags"), stateDataIndex)
 			converted, err := s.mapTofreeformTags(fieldKeyFormatNextLevel)
 			if err != nil {

--- a/internal/service/identity_domains/identity_domains_dynamic_resource_group_resource.go
+++ b/internal/service/identity_domains/identity_domains_dynamic_resource_group_resource.go
@@ -20,15 +20,17 @@ import (
 )
 
 func IdentityDomainsDynamicResourceGroupResource() *schema.Resource {
+	log.Printf("[DEBUG] Identity Domains DynamicResourceGroup resource initialized with ignore_defined_tags CustomizeDiff: field=%q", identityDomainsOciTagsField)
 	return &schema.Resource{
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
-		Timeouts: tfresource.DefaultTimeout,
-		Create:   createIdentityDomainsDynamicResourceGroup,
-		Read:     readIdentityDomainsDynamicResourceGroup,
-		Update:   updateIdentityDomainsDynamicResourceGroup,
-		Delete:   deleteIdentityDomainsDynamicResourceGroup,
+		Timeouts:      tfresource.DefaultTimeout,
+		Create:        createIdentityDomainsDynamicResourceGroup,
+		Read:          readIdentityDomainsDynamicResourceGroup,
+		Update:        updateIdentityDomainsDynamicResourceGroup,
+		Delete:        deleteIdentityDomainsDynamicResourceGroup,
+		CustomizeDiff: identityDomainsIgnoreDefinedTagsCustomizeDiff("oci_identity_domains_dynamic_resource_group", identityDomainsOciTagsField),
 		Schema: map[string]*schema.Schema{
 			// Required
 			"display_name": {
@@ -116,10 +118,11 @@ func IdentityDomainsDynamicResourceGroupResource() *schema.Resource {
 
 						// Optional
 						"defined_tags": {
-							Type:             schema.TypeList,
+							Type:             schema.TypeSet,
 							Optional:         true,
 							Computed:         true,
 							DiffSuppressFunc: tfresource.DefinedTagsDiffSuppressFunction,
+							Set:              definedTagsHashCodeForSets,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									// Required
@@ -143,9 +146,10 @@ func IdentityDomainsDynamicResourceGroupResource() *schema.Resource {
 							},
 						},
 						"freeform_tags": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Optional: true,
 							Computed: true,
+							Set:      freeformTagsHashCodeForSets,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									// Required
@@ -853,7 +857,7 @@ func (s *IdentityDomainsDynamicResourceGroupResourceCrud) SetData() error {
 	}
 
 	if s.Res.UrnIetfParamsScimSchemasOracleIdcsExtensionOciTags != nil {
-		s.D.Set("urnietfparamsscimschemasoracleidcsextension_oci_tags", []interface{}{ExtensionOCITagsToMap(s.Res.UrnIetfParamsScimSchemasOracleIdcsExtensionOciTags)})
+		s.D.Set("urnietfparamsscimschemasoracleidcsextension_oci_tags", []interface{}{ExtensionOCITagsToMap(s.Res.UrnIetfParamsScimSchemasOracleIdcsExtensionOciTags, false)})
 	} else {
 		s.D.Set("urnietfparamsscimschemasoracleidcsextension_oci_tags", nil)
 	}
@@ -882,7 +886,7 @@ func parseDynamicResourceGroupCompositeId(compositeId string) (dynamicResourceGr
 	return
 }
 
-func DynamicResourceGroupToMap(obj oci_identity_domains.DynamicResourceGroup) map[string]interface{} {
+func DynamicResourceGroupToMap(obj oci_identity_domains.DynamicResourceGroup, datasource bool) map[string]interface{} {
 	result := map[string]interface{}{}
 
 	if obj.CompartmentOcid != nil {
@@ -960,7 +964,7 @@ func DynamicResourceGroupToMap(obj oci_identity_domains.DynamicResourceGroup) ma
 	}
 
 	if obj.UrnIetfParamsScimSchemasOracleIdcsExtensionOciTags != nil {
-		result["urnietfparamsscimschemasoracleidcsextension_oci_tags"] = []interface{}{ExtensionOCITagsToMap(obj.UrnIetfParamsScimSchemasOracleIdcsExtensionOciTags)}
+		result["urnietfparamsscimschemasoracleidcsextension_oci_tags"] = []interface{}{ExtensionOCITagsToMap(obj.UrnIetfParamsScimSchemasOracleIdcsExtensionOciTags, datasource)}
 	}
 
 	return result
@@ -1024,10 +1028,11 @@ func (s *IdentityDomainsDynamicResourceGroupResourceCrud) mapToExtensionOCITags(
 	result := oci_identity_domains.ExtensionOciTags{}
 
 	if definedTags, ok := s.D.GetOkExists(fmt.Sprintf(fieldKeyFormat, "defined_tags")); ok {
-		interfaces := definedTags.([]interface{})
+		set := definedTags.(*schema.Set)
+		interfaces := set.List()
 		tmp := make([]oci_identity_domains.DefinedTags, len(interfaces))
 		for i := range interfaces {
-			stateDataIndex := i
+			stateDataIndex := definedTagsHashCodeForSets(interfaces[i])
 			fieldKeyFormatNextLevel := fmt.Sprintf("%s.%d.%%s", fmt.Sprintf(fieldKeyFormat, "defined_tags"), stateDataIndex)
 			converted, err := s.mapTodefinedTags(fieldKeyFormatNextLevel)
 			if err != nil {
@@ -1041,10 +1046,11 @@ func (s *IdentityDomainsDynamicResourceGroupResourceCrud) mapToExtensionOCITags(
 	}
 
 	if freeformTags, ok := s.D.GetOkExists(fmt.Sprintf(fieldKeyFormat, "freeform_tags")); ok {
-		interfaces := freeformTags.([]interface{})
+		set := freeformTags.(*schema.Set)
+		interfaces := set.List()
 		tmp := make([]oci_identity_domains.FreeformTags, len(interfaces))
 		for i := range interfaces {
-			stateDataIndex := i
+			stateDataIndex := freeformTagsHashCodeForSets(interfaces[i])
 			fieldKeyFormatNextLevel := fmt.Sprintf("%s.%d.%%s", fmt.Sprintf(fieldKeyFormat, "freeform_tags"), stateDataIndex)
 			converted, err := s.mapTofreeformTags(fieldKeyFormatNextLevel)
 			if err != nil {

--- a/internal/service/identity_domains/identity_domains_group_resource.go
+++ b/internal/service/identity_domains/identity_domains_group_resource.go
@@ -23,15 +23,17 @@ import (
 )
 
 func IdentityDomainsGroupResource() *schema.Resource {
+	log.Printf("[DEBUG] Identity Domains Group resource initialized with ignore_defined_tags CustomizeDiff: field=%q", identityDomainsOciTagsField)
 	return &schema.Resource{
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
-		Timeouts: tfresource.DefaultTimeout,
-		Create:   createIdentityDomainsGroup,
-		Read:     readIdentityDomainsGroup,
-		Update:   updateIdentityDomainsGroup,
-		Delete:   deleteIdentityDomainsGroup,
+		Timeouts:      tfresource.DefaultTimeout,
+		Create:        createIdentityDomainsGroup,
+		Read:          readIdentityDomainsGroup,
+		Update:        updateIdentityDomainsGroup,
+		Delete:        deleteIdentityDomainsGroup,
+		CustomizeDiff: identityDomainsIgnoreDefinedTagsCustomizeDiff("oci_identity_domains_group", identityDomainsOciTagsField),
 		Schema: map[string]*schema.Schema{
 			// Required
 			"display_name": {
@@ -79,7 +81,6 @@ func IdentityDomainsGroupResource() *schema.Resource {
 			"members": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				Computed: true,
 				Set:      membersHashCodeForSets,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -172,10 +173,11 @@ func IdentityDomainsGroupResource() *schema.Resource {
 
 						// Optional
 						"defined_tags": {
-							Type:             schema.TypeList,
+							Type:             schema.TypeSet,
 							Optional:         true,
 							Computed:         true,
 							DiffSuppressFunc: tfresource.DefinedTagsDiffSuppressFunction,
+							Set:              definedTagsHashCodeForSets,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									// Required
@@ -199,9 +201,10 @@ func IdentityDomainsGroupResource() *schema.Resource {
 							},
 						},
 						"freeform_tags": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Optional: true,
 							Computed: true,
+							Set:      freeformTagsHashCodeForSets,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									// Required
@@ -1286,7 +1289,7 @@ func (s *IdentityDomainsGroupResourceCrud) SetData() error {
 	}
 
 	if s.Res.UrnIetfParamsScimSchemasOracleIdcsExtensionOciTags != nil {
-		s.D.Set("urnietfparamsscimschemasoracleidcsextension_oci_tags", []interface{}{ExtensionOCITagsToMap(s.Res.UrnIetfParamsScimSchemasOracleIdcsExtensionOciTags)})
+		s.D.Set("urnietfparamsscimschemasoracleidcsextension_oci_tags", []interface{}{ExtensionOCITagsToMap(s.Res.UrnIetfParamsScimSchemasOracleIdcsExtensionOciTags, false)})
 	} else {
 		s.D.Set("urnietfparamsscimschemasoracleidcsextension_oci_tags", nil)
 	}
@@ -1530,10 +1533,11 @@ func (s *IdentityDomainsGroupResourceCrud) mapToExtensionOCITags(fieldKeyFormat 
 	result := oci_identity_domains.ExtensionOciTags{}
 
 	if definedTags, ok := s.D.GetOkExists(fmt.Sprintf(fieldKeyFormat, "defined_tags")); ok {
-		interfaces := definedTags.([]interface{})
+		set := definedTags.(*schema.Set)
+		interfaces := set.List()
 		tmp := make([]oci_identity_domains.DefinedTags, len(interfaces))
 		for i := range interfaces {
-			stateDataIndex := i
+			stateDataIndex := definedTagsHashCodeForSets(interfaces[i])
 			fieldKeyFormatNextLevel := fmt.Sprintf("%s.%d.%%s", fmt.Sprintf(fieldKeyFormat, "defined_tags"), stateDataIndex)
 			converted, err := s.mapTodefinedTags(fieldKeyFormatNextLevel)
 			if err != nil {
@@ -1547,10 +1551,11 @@ func (s *IdentityDomainsGroupResourceCrud) mapToExtensionOCITags(fieldKeyFormat 
 	}
 
 	if freeformTags, ok := s.D.GetOkExists(fmt.Sprintf(fieldKeyFormat, "freeform_tags")); ok {
-		interfaces := freeformTags.([]interface{})
+		set := freeformTags.(*schema.Set)
+		interfaces := set.List()
 		tmp := make([]oci_identity_domains.FreeformTags, len(interfaces))
 		for i := range interfaces {
-			stateDataIndex := i
+			stateDataIndex := freeformTagsHashCodeForSets(interfaces[i])
 			fieldKeyFormatNextLevel := fmt.Sprintf("%s.%d.%%s", fmt.Sprintf(fieldKeyFormat, "freeform_tags"), stateDataIndex)
 			converted, err := s.mapTofreeformTags(fieldKeyFormatNextLevel)
 			if err != nil {
@@ -1612,7 +1617,7 @@ func ExtensionRequestableGroupToMap(obj *oci_identity_domains.ExtensionRequestab
 	return result
 }
 
-func GroupToMap(obj oci_identity_domains.Group) map[string]interface{} {
+func GroupToMap(obj oci_identity_domains.Group, datasource bool) map[string]interface{} {
 	result := map[string]interface{}{}
 
 	if obj.CompartmentOcid != nil {
@@ -1684,7 +1689,7 @@ func GroupToMap(obj oci_identity_domains.Group) map[string]interface{} {
 	}
 
 	if obj.UrnIetfParamsScimSchemasOracleIdcsExtensionOciTags != nil {
-		result["urnietfparamsscimschemasoracleidcsextension_oci_tags"] = []interface{}{ExtensionOCITagsToMap(obj.UrnIetfParamsScimSchemasOracleIdcsExtensionOciTags)}
+		result["urnietfparamsscimschemasoracleidcsextension_oci_tags"] = []interface{}{ExtensionOCITagsToMap(obj.UrnIetfParamsScimSchemasOracleIdcsExtensionOciTags, datasource)}
 	}
 
 	if obj.UrnIetfParamsScimSchemasOracleIdcsExtensionDbcsGroup != nil {

--- a/internal/service/identity_domains/identity_domains_tags_helper.go
+++ b/internal/service/identity_domains/identity_domains_tags_helper.go
@@ -1,0 +1,355 @@
+// Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package identity_domains
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/oracle/terraform-provider-oci/internal/tfresource"
+)
+
+const identityDomainsOciTagsField = "urnietfparamsscimschemasoracleidcsextension_oci_tags"
+
+func suppressIgnoredStructuredDefinedTagsForOciTags(field string) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		log.Printf("[DEBUG] Identity Domains ignore_defined_tags suppressor invoked: field=%q ignored_tags=%v", field, tfresource.DefinedTagsToSuppress)
+		if len(tfresource.DefinedTagsToSuppress) == 0 {
+			log.Printf("[DEBUG] Identity Domains ignore_defined_tags suppressor skipping: field=%q ignored_tags is empty", field)
+			return nil
+		}
+
+		configuredTagsByBlock := configuredStructuredDefinedTagsFromRawConfig(d, field)
+		oldRaw, newRaw := d.GetChange(field)
+		log.Printf(
+			"[DEBUG] Identity Domains ignore_defined_tags suppressor inputs: field=%q old=%s new=%s configured=%s",
+			field,
+			debugSummaryForStructuredDefinedTagsRaw(oldRaw),
+			debugSummaryForStructuredDefinedTagsRaw(newRaw),
+			debugSummaryForConfiguredStructuredDefinedTags(configuredTagsByBlock),
+		)
+		merged, changed := mergeIgnoredStructuredDefinedTags(oldRaw, newRaw, configuredTagsByBlock)
+		log.Printf(
+			"[DEBUG] Identity Domains ignore_defined_tags suppressor merge result: field=%q changed=%t merged=%s",
+			field,
+			changed,
+			debugSummaryForStructuredDefinedTagsRaw(merged),
+		)
+		if !changed {
+			log.Printf("[DEBUG] Identity Domains ignore_defined_tags suppressor no-op: field=%q", field)
+			return nil
+		}
+
+		if err := d.SetNew(field, merged); err != nil {
+			log.Printf("[DEBUG] Identity Domains ignore_defined_tags suppressor SetNew failed: field=%q err=%v", field, err)
+			return err
+		}
+
+		log.Printf("[DEBUG] Identity Domains ignore_defined_tags suppressor SetNew applied: field=%q", field)
+		return nil
+	}
+}
+
+func identityDomainsIgnoreDefinedTagsCustomizeDiff(resourceName string, field string) schema.CustomizeDiffFunc {
+	suppressor := suppressIgnoredStructuredDefinedTagsForOciTags(field)
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		log.Printf(
+			"[DEBUG] Identity Domains resource CustomizeDiff invoked: resource=%q field=%q id=%q has_change=%t ignored_tags=%v",
+			resourceName,
+			field,
+			d.Id(),
+			d.HasChange(field),
+			tfresource.DefinedTagsToSuppress,
+		)
+		return suppressor(ctx, d, meta)
+	}
+}
+
+func mergeIgnoredStructuredDefinedTags(oldRaw interface{}, newRaw interface{}, configuredTagsByBlock [][]map[string]interface{}) ([]interface{}, bool) {
+	oldBlocks := normalizeOciTagsBlocks(oldRaw)
+	if len(oldBlocks) == 0 {
+		return toInterfaceSlice(normalizeOciTagsBlocks(newRaw)), false
+	}
+
+	newBlocks := normalizeOciTagsBlocks(newRaw)
+	if len(newBlocks) == 0 {
+		newBlocks = []map[string]interface{}{{}}
+	}
+
+	changed := false
+	for i, oldBlock := range oldBlocks {
+		var configuredTags []map[string]interface{}
+		if len(configuredTagsByBlock) > i {
+			configuredTags = cloneTags(configuredTagsByBlock[i])
+		}
+
+		if len(newBlocks) <= i {
+			newBlocks = append(newBlocks, map[string]interface{}{})
+			changed = true
+		}
+
+		oldTags := normalizeStructuredDefinedTags(oldBlock["defined_tags"])
+		if len(oldTags) == 0 {
+			if len(configuredTags) > 0 {
+				newBlocks[i]["defined_tags"] = schema.NewSet(definedTagsHashCodeForSets, toInterfaceSlice(configuredTags))
+			}
+			continue
+		}
+
+		newTags := configuredTags
+		existing := map[string]bool{}
+		for _, tag := range newTags {
+			if tagName := structuredDefinedTagName(tag); tagName != "" {
+				existing[strings.ToLower(tagName)] = true
+			}
+		}
+
+		for _, tag := range oldTags {
+			tagName := structuredDefinedTagName(tag)
+			if tagName == "" || !isIgnoredDefinedTag(tagName) || existing[strings.ToLower(tagName)] {
+				continue
+			}
+
+			newTags = append(newTags, cloneMap(tag))
+			existing[strings.ToLower(tagName)] = true
+			changed = true
+		}
+
+		if len(newTags) > 0 {
+			newBlocks[i]["defined_tags"] = schema.NewSet(definedTagsHashCodeForSets, toInterfaceSlice(newTags))
+		} else if _, ok := newBlocks[i]["defined_tags"]; ok {
+			newBlocks[i]["defined_tags"] = schema.NewSet(definedTagsHashCodeForSets, []interface{}{})
+		}
+	}
+
+	return toInterfaceSlice(newBlocks), changed
+}
+
+func configuredStructuredDefinedTagsFromRawConfig(d *schema.ResourceDiff, field string) [][]map[string]interface{} {
+	rawConfig := d.GetRawConfig()
+	if rawConfig.IsNull() || !rawConfig.IsKnown() || !rawConfig.Type().IsObjectType() {
+		return nil
+	}
+
+	fieldValue, ok := rawConfig.AsValueMap()[field]
+	if !ok || fieldValue.IsNull() || !fieldValue.IsKnown() {
+		return nil
+	}
+
+	return structuredDefinedTagsFromCtyBlocks(fieldValue)
+}
+
+func structuredDefinedTagsFromCtyBlocks(blocksValue cty.Value) [][]map[string]interface{} {
+	if blocksValue.IsNull() || !blocksValue.IsKnown() || !canIterateCtyCollection(blocksValue) {
+		return nil
+	}
+
+	result := make([][]map[string]interface{}, 0, blocksValue.LengthInt())
+	blocksValue.ForEachElement(func(_ cty.Value, blockValue cty.Value) bool {
+		if blockValue.IsNull() || !blockValue.IsKnown() || !blockValue.Type().IsObjectType() {
+			result = append(result, nil)
+			return false
+		}
+
+		blockAttrs := blockValue.AsValueMap()
+		definedTagsValue, ok := blockAttrs["defined_tags"]
+		if !ok {
+			result = append(result, nil)
+			return false
+		}
+
+		result = append(result, structuredDefinedTagsFromCtyValue(definedTagsValue))
+		return false
+	})
+
+	return result
+}
+
+func structuredDefinedTagsFromCtyValue(value cty.Value) []map[string]interface{} {
+	if value.IsNull() || !value.IsKnown() || !canIterateCtyCollection(value) {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, value.LengthInt())
+	value.ForEachElement(func(_ cty.Value, tagValue cty.Value) bool {
+		if tagValue.IsNull() || !tagValue.IsKnown() || !tagValue.Type().IsObjectType() {
+			return false
+		}
+
+		tagAttrs := tagValue.AsValueMap()
+		tag := map[string]interface{}{}
+
+		if namespace, ok := tagAttrs["namespace"]; ok && namespace.IsKnown() && !namespace.IsNull() {
+			tag["namespace"] = namespace.AsString()
+		}
+		if key, ok := tagAttrs["key"]; ok && key.IsKnown() && !key.IsNull() {
+			tag["key"] = key.AsString()
+		}
+		if val, ok := tagAttrs["value"]; ok && val.IsKnown() && !val.IsNull() {
+			tag["value"] = val.AsString()
+		}
+
+		if structuredDefinedTagName(tag) != "" {
+			result = append(result, tag)
+		}
+		return false
+	})
+
+	return result
+}
+
+func canIterateCtyCollection(value cty.Value) bool {
+	return value.Type().IsTupleType() || value.Type().IsListType() || value.Type().IsSetType()
+}
+
+func normalizeOciTagsBlocks(raw interface{}) []map[string]interface{} {
+	items, ok := raw.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		if itemMap, ok := item.(map[string]interface{}); ok {
+			result = append(result, cloneMap(itemMap))
+		}
+	}
+
+	return result
+}
+
+func normalizeStructuredDefinedTags(raw interface{}) []map[string]interface{} {
+	var items []interface{}
+	switch v := raw.(type) {
+	case nil:
+		return nil
+	case []interface{}:
+		items = v
+	case *schema.Set:
+		items = v.List()
+	default:
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		if itemMap, ok := item.(map[string]interface{}); ok {
+			result = append(result, cloneMap(itemMap))
+		}
+	}
+
+	return result
+}
+
+func structuredDefinedTagName(tag map[string]interface{}) string {
+	namespace, _ := tag["namespace"].(string)
+	key, _ := tag["key"].(string)
+	if namespace == "" || key == "" {
+		return ""
+	}
+
+	return namespace + "." + key
+}
+
+func isIgnoredDefinedTag(tagName string) bool {
+	for _, ignoredTag := range tfresource.DefinedTagsToSuppress {
+		if strings.EqualFold(tagName, ignoredTag) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func cloneMap(src map[string]interface{}) map[string]interface{} {
+	if src == nil {
+		return nil
+	}
+
+	dst := make(map[string]interface{}, len(src))
+	for key, value := range src {
+		dst[key] = value
+	}
+
+	return dst
+}
+
+func cloneTags(src []map[string]interface{}) []map[string]interface{} {
+	if src == nil {
+		return nil
+	}
+
+	dst := make([]map[string]interface{}, 0, len(src))
+	for _, item := range src {
+		dst = append(dst, cloneMap(item))
+	}
+
+	return dst
+}
+
+func toInterfaceSlice[T any](items []T) []interface{} {
+	result := make([]interface{}, 0, len(items))
+	for _, item := range items {
+		result = append(result, item)
+	}
+
+	return result
+}
+
+func debugSummaryForStructuredDefinedTagsRaw(raw interface{}) string {
+	if raw == nil {
+		return "<nil>"
+	}
+
+	blocks := normalizeOciTagsBlocks(raw)
+	if len(blocks) == 0 {
+		if rawBlocks, ok := raw.([]interface{}); ok {
+			return fmt.Sprintf("blocks=%d", len(rawBlocks))
+		}
+		return fmt.Sprintf("type=%T", raw)
+	}
+
+	summaries := make([]string, 0, len(blocks))
+	for i, block := range blocks {
+		summaries = append(summaries, fmt.Sprintf("block[%d]=%v", i, structuredDefinedTagDetails(normalizeStructuredDefinedTags(block["defined_tags"]))))
+	}
+
+	return strings.Join(summaries, "; ")
+}
+
+func debugSummaryForConfiguredStructuredDefinedTags(blocks [][]map[string]interface{}) string {
+	if len(blocks) == 0 {
+		return "blocks=0"
+	}
+
+	summaries := make([]string, 0, len(blocks))
+	for i, block := range blocks {
+		summaries = append(summaries, fmt.Sprintf("block[%d]=%v", i, structuredDefinedTagDetails(block)))
+	}
+
+	return strings.Join(summaries, "; ")
+}
+
+func structuredDefinedTagDetails(tags []map[string]interface{}) []string {
+	if len(tags) == 0 {
+		return []string{}
+	}
+
+	details := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		if name := structuredDefinedTagName(tag); name != "" {
+			value, _ := tag["value"].(string)
+			details = append(details, fmt.Sprintf("%s=%q", name, value))
+		}
+	}
+
+	sort.Strings(details)
+	return details
+}

--- a/internal/service/identity_domains/identity_domains_tags_helper_test.go
+++ b/internal/service/identity_domains/identity_domains_tags_helper_test.go
@@ -1,0 +1,158 @@
+// Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package identity_domains
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/oracle/terraform-provider-oci/internal/tfresource"
+)
+
+func TestUnitMergeIgnoredStructuredDefinedTags(t *testing.T) {
+	oldSuppressed := tfresource.DefinedTagsToSuppress
+	defer func() {
+		tfresource.DefinedTagsToSuppress = oldSuppressed
+	}()
+
+	tfresource.DefinedTagsToSuppress = []string{"Oracle-Tags.CreatedBy", "Oracle-Tags.CreatedOn"}
+
+	oldRaw := []interface{}{
+		map[string]interface{}{
+			"defined_tags": schema.NewSet(definedTagsHashCodeForSets, []interface{}{
+				map[string]interface{}{"namespace": "Oracle-Tags", "key": "CreatedBy", "value": "service"},
+				map[string]interface{}{"namespace": "Oracle-Tags", "key": "CreatedOn", "value": "2026-03-16T20:45:36.983Z"},
+				map[string]interface{}{"namespace": "MyNamespace", "key": "Managed", "value": "custom"},
+			}),
+		},
+	}
+
+	newRaw := []interface{}{
+		map[string]interface{}{
+			"defined_tags": schema.NewSet(definedTagsHashCodeForSets, []interface{}{
+				map[string]interface{}{"namespace": "MyNamespace", "key": "Managed", "value": "custom"},
+			}),
+		},
+	}
+
+	configuredTagsByBlock := [][]map[string]interface{}{
+		{
+			{"namespace": "MyNamespace", "key": "Managed", "value": "custom"},
+		},
+	}
+
+	merged, changed := mergeIgnoredStructuredDefinedTags(oldRaw, newRaw, configuredTagsByBlock)
+	if !changed {
+		t.Fatalf("expected mergeIgnoredStructuredDefinedTags to report a change")
+	}
+
+	mergedBlocks := normalizeOciTagsBlocks(merged)
+	if len(mergedBlocks) != 1 {
+		t.Fatalf("expected exactly one OCI tags block, got %d", len(mergedBlocks))
+	}
+
+	mergedTags := normalizeStructuredDefinedTags(mergedBlocks[0]["defined_tags"])
+	if len(mergedTags) != 3 {
+		t.Fatalf("expected three defined tags after merge, got %d", len(mergedTags))
+	}
+
+	names := map[string]bool{}
+	for _, tag := range mergedTags {
+		names[structuredDefinedTagName(tag)] = true
+	}
+
+	for _, expected := range []string{"Oracle-Tags.CreatedBy", "Oracle-Tags.CreatedOn", "MyNamespace.Managed"} {
+		if !names[expected] {
+			t.Fatalf("expected merged defined tags to include %s", expected)
+		}
+	}
+}
+
+func TestUnitMergeIgnoredStructuredDefinedTagsNoIgnoredTagsConfigured(t *testing.T) {
+	oldSuppressed := tfresource.DefinedTagsToSuppress
+	defer func() {
+		tfresource.DefinedTagsToSuppress = oldSuppressed
+	}()
+
+	tfresource.DefinedTagsToSuppress = nil
+
+	oldRaw := []interface{}{
+		map[string]interface{}{
+			"defined_tags": schema.NewSet(definedTagsHashCodeForSets, []interface{}{
+				map[string]interface{}{"namespace": "Oracle-Tags", "key": "CreatedBy", "value": "service"},
+			}),
+		},
+	}
+
+	newRaw := []interface{}{
+		map[string]interface{}{
+			"defined_tags": schema.NewSet(definedTagsHashCodeForSets, []interface{}{}),
+		},
+	}
+
+	merged, changed := mergeIgnoredStructuredDefinedTags(oldRaw, newRaw, nil)
+	if changed {
+		t.Fatalf("expected no merge when ignore_defined_tags is empty, got %#v", merged)
+	}
+}
+
+func TestUnitMergeIgnoredStructuredDefinedTagsKeepsIgnoredButRemovesCustomTags(t *testing.T) {
+	oldSuppressed := tfresource.DefinedTagsToSuppress
+	defer func() {
+		tfresource.DefinedTagsToSuppress = oldSuppressed
+	}()
+
+	tfresource.DefinedTagsToSuppress = []string{"Oracle-Tags.CreatedBy", "Oracle-Tags.CreatedOn"}
+
+	oldRaw := []interface{}{
+		map[string]interface{}{
+			"defined_tags": schema.NewSet(definedTagsHashCodeForSets, []interface{}{
+				map[string]interface{}{"namespace": "Oracle-Tags", "key": "CreatedBy", "value": "service"},
+				map[string]interface{}{"namespace": "Oracle-Tags", "key": "CreatedOn", "value": "2026-03-16T20:45:36.983Z"},
+				map[string]interface{}{"namespace": "testns", "key": "TestTag", "value": "TestValue"},
+			}),
+		},
+	}
+
+	newRaw := []interface{}{
+		map[string]interface{}{
+			"defined_tags": schema.NewSet(definedTagsHashCodeForSets, []interface{}{
+				map[string]interface{}{"namespace": "Oracle-Tags", "key": "CreatedBy", "value": "service"},
+				map[string]interface{}{"namespace": "Oracle-Tags", "key": "CreatedOn", "value": "2026-03-16T20:45:36.983Z"},
+				map[string]interface{}{"namespace": "testns", "key": "TestTag", "value": "TestValue"},
+			}),
+		},
+	}
+
+	merged, changed := mergeIgnoredStructuredDefinedTags(oldRaw, newRaw, [][]map[string]interface{}{{}})
+	if !changed {
+		t.Fatalf("expected mergeIgnoredStructuredDefinedTags to report a change")
+	}
+
+	mergedBlocks := normalizeOciTagsBlocks(merged)
+	if len(mergedBlocks) != 1 {
+		t.Fatalf("expected exactly one OCI tags block, got %d", len(mergedBlocks))
+	}
+
+	mergedTags := normalizeStructuredDefinedTags(mergedBlocks[0]["defined_tags"])
+	if len(mergedTags) != 2 {
+		t.Fatalf("expected only ignored defined tags after merge, got %d", len(mergedTags))
+	}
+
+	names := map[string]bool{}
+	for _, tag := range mergedTags {
+		names[structuredDefinedTagName(tag)] = true
+	}
+
+	for _, expected := range []string{"Oracle-Tags.CreatedBy", "Oracle-Tags.CreatedOn"} {
+		if !names[expected] {
+			t.Fatalf("expected merged defined tags to include %s", expected)
+		}
+	}
+
+	if names["testns.TestTag"] {
+		t.Fatalf("expected merged defined tags to remove testns.TestTag")
+	}
+}

--- a/internal/service/identity_domains/identity_domains_user_resource.go
+++ b/internal/service/identity_domains/identity_domains_user_resource.go
@@ -23,15 +23,17 @@ import (
 )
 
 func IdentityDomainsUserResource() *schema.Resource {
+	log.Printf("[DEBUG] Identity Domains User resource initialized with ignore_defined_tags CustomizeDiff: field=%q", identityDomainsOciTagsField)
 	return &schema.Resource{
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
-		Timeouts: tfresource.DefaultTimeout,
-		Create:   createIdentityDomainsUser,
-		Read:     readIdentityDomainsUser,
-		Update:   updateIdentityDomainsUser,
-		Delete:   deleteIdentityDomainsUser,
+		Timeouts:      tfresource.DefaultTimeout,
+		Create:        createIdentityDomainsUser,
+		Read:          readIdentityDomainsUser,
+		Update:        updateIdentityDomainsUser,
+		Delete:        deleteIdentityDomainsUser,
+		CustomizeDiff: identityDomainsIgnoreDefinedTagsCustomizeDiff("oci_identity_domains_user", identityDomainsOciTagsField),
 		Schema: map[string]*schema.Schema{
 			// Required
 			"idcs_endpoint": {
@@ -544,10 +546,11 @@ func IdentityDomainsUserResource() *schema.Resource {
 
 						// Optional
 						"defined_tags": {
-							Type:             schema.TypeList,
+							Type:             schema.TypeSet,
 							Optional:         true,
 							Computed:         true,
 							DiffSuppressFunc: tfresource.DefinedTagsDiffSuppressFunction,
+							Set:              definedTagsHashCodeForSets,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									// Required
@@ -571,9 +574,10 @@ func IdentityDomainsUserResource() *schema.Resource {
 							},
 						},
 						"freeform_tags": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Optional: true,
 							Computed: true,
+							Set:      freeformTagsHashCodeForSets,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									// Required
@@ -3678,7 +3682,7 @@ func (s *IdentityDomainsUserResourceCrud) SetData() error {
 	}
 
 	if s.Res.UrnIetfParamsScimSchemasOracleIdcsExtensionOciTags != nil {
-		s.D.Set("urnietfparamsscimschemasoracleidcsextension_oci_tags", []interface{}{ExtensionOCITagsToMap(s.Res.UrnIetfParamsScimSchemasOracleIdcsExtensionOciTags)})
+		s.D.Set("urnietfparamsscimschemasoracleidcsextension_oci_tags", []interface{}{ExtensionOCITagsToMap(s.Res.UrnIetfParamsScimSchemasOracleIdcsExtensionOciTags, false)})
 	} else {
 		s.D.Set("urnietfparamsscimschemasoracleidcsextension_oci_tags", nil)
 	}
@@ -4279,10 +4283,11 @@ func (s *IdentityDomainsUserResourceCrud) mapToExtensionOCITags(fieldKeyFormat s
 	result := oci_identity_domains.ExtensionOciTags{}
 
 	if definedTags, ok := s.D.GetOkExists(fmt.Sprintf(fieldKeyFormat, "defined_tags")); ok {
-		interfaces := definedTags.([]interface{})
+		set := definedTags.(*schema.Set)
+		interfaces := set.List()
 		tmp := make([]oci_identity_domains.DefinedTags, len(interfaces))
 		for i := range interfaces {
-			stateDataIndex := i
+			stateDataIndex := definedTagsHashCodeForSets(interfaces[i])
 			fieldKeyFormatNextLevel := fmt.Sprintf("%s.%d.%%s", fmt.Sprintf(fieldKeyFormat, "defined_tags"), stateDataIndex)
 			converted, err := s.mapTodefinedTags(fieldKeyFormatNextLevel)
 			if err != nil {
@@ -4296,10 +4301,11 @@ func (s *IdentityDomainsUserResourceCrud) mapToExtensionOCITags(fieldKeyFormat s
 	}
 
 	if freeformTags, ok := s.D.GetOkExists(fmt.Sprintf(fieldKeyFormat, "freeform_tags")); ok {
-		interfaces := freeformTags.([]interface{})
+		set := freeformTags.(*schema.Set)
+		interfaces := set.List()
 		tmp := make([]oci_identity_domains.FreeformTags, len(interfaces))
 		for i := range interfaces {
-			stateDataIndex := i
+			stateDataIndex := freeformTagsHashCodeForSets(interfaces[i])
 			fieldKeyFormatNextLevel := fmt.Sprintf("%s.%d.%%s", fmt.Sprintf(fieldKeyFormat, "freeform_tags"), stateDataIndex)
 			converted, err := s.mapTofreeformTags(fieldKeyFormatNextLevel)
 			if err != nil {
@@ -4319,7 +4325,7 @@ func (s *IdentityDomainsUserResourceCrud) mapToExtensionOCITags(fieldKeyFormat s
 	return result, nil
 }
 
-func ExtensionOCITagsToMap(obj *oci_identity_domains.ExtensionOciTags) map[string]interface{} {
+func ExtensionOCITagsToMap(obj *oci_identity_domains.ExtensionOciTags, datasource bool) map[string]interface{} {
 	result := map[string]interface{}{}
 
 	definedTags := []interface{}{}
@@ -4332,7 +4338,11 @@ func ExtensionOCITagsToMap(obj *oci_identity_domains.ExtensionOciTags) map[strin
 	for _, item := range obj.FreeformTags {
 		freeformTags = append(freeformTags, freeformTagsToMap(item))
 	}
-	result["freeform_tags"] = freeformTags
+	if datasource {
+		result["freeform_tags"] = freeformTags
+	} else {
+		result["freeform_tags"] = schema.NewSet(freeformTagsHashCodeForSets, freeformTags)
+	}
 
 	if obj.TagSlug != nil {
 		result["tag_slug"] = fmt.Sprintf("%v", *obj.TagSlug)
@@ -5229,7 +5239,7 @@ func UserToMap(obj oci_identity_domains.User, datasource bool) map[string]interf
 	}
 
 	if obj.UrnIetfParamsScimSchemasOracleIdcsExtensionOciTags != nil {
-		result["urnietfparamsscimschemasoracleidcsextension_oci_tags"] = []interface{}{ExtensionOCITagsToMap(obj.UrnIetfParamsScimSchemasOracleIdcsExtensionOciTags)}
+		result["urnietfparamsscimschemasoracleidcsextension_oci_tags"] = []interface{}{ExtensionOCITagsToMap(obj.UrnIetfParamsScimSchemasOracleIdcsExtensionOciTags, datasource)}
 	}
 
 	if obj.UrnIetfParamsScimSchemasOracleIdcsExtensionAdaptiveUser != nil {
@@ -7267,6 +7277,34 @@ func emailsHashCodeForSets(v interface{}) int {
 	}
 	if verified, ok := m["verified"]; ok {
 		buf.WriteString(fmt.Sprintf("%v-", verified))
+	}
+	return utils.GetStringHashcode(buf.String())
+}
+
+func freeformTagsHashCodeForSets(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	if key, ok := m["key"]; ok && key != "" {
+		buf.WriteString(fmt.Sprintf("%v-", key))
+	}
+	if value, ok := m["value"]; ok && value != "" {
+		buf.WriteString(fmt.Sprintf("%v-", value))
+	}
+	return utils.GetStringHashcode(buf.String())
+}
+
+func definedTagsHashCodeForSets(v interface{}) int {
+	m := v.(map[string]interface{})
+	var buf bytes.Buffer
+
+	if ns, ok := m["namespace"]; ok && ns != "" {
+		buf.WriteString(fmt.Sprintf("%v-", ns))
+	}
+	if key, ok := m["key"]; ok && key != "" {
+		buf.WriteString(fmt.Sprintf("%v-", key))
+	}
+	if val, ok := m["value"]; ok && val != "" {
+		buf.WriteString(fmt.Sprintf("%v-", val))
 	}
 	return utils.GetStringHashcode(buf.String())
 }


### PR DESCRIPTION
Identity Domain applications cannot be deleted when they are active. This code will ensure the app is first deactivated before deletion. 