### PR TITLE
Add capabilities support to Queue resource

### DIFF
--- a/examples/queue/main.tf
+++ b/examples/queue/main.tf
@@ -32,6 +32,10 @@ resource "oci_queue_queue" "test_queue1" {
   timeout_in_seconds               = var.queue_timeout_in_seconds
   visibility_in_seconds            = var.queue_visibility_in_seconds
   channel_consumption_limit        = var.queue_channel_consumption_limit
+  capabilities {
+    type                              = var.queue_capabilities_type
+    is_primary_consumer_group_enabled = var.queue_capabilities_is_primary_consumer_group_enabled
+  }
 }
 
 # Purging the queue immediately after create if required. Queue is purged if purge trigger is set to any integer value. We are using the purge trigger and purge type optional parameter.

--- a/examples/queue/variables.tf
+++ b/examples/queue/variables.tf
@@ -57,3 +57,11 @@ variable "purge_type" {
 variable "purge_trigger" {
   default = 1
 }
+
+variable "queue_capabilities_type" {
+  default = "CONSUMER_GROUPS"
+}
+
+variable "queue_capabilities_is_primary_consumer_group_enabled" {
+  default = false
+}

--- a/internal/integrationtest/queue_queue_test.go
+++ b/internal/integrationtest/queue_queue_test.go
@@ -50,6 +50,11 @@ var (
 		"values": acctest.Representation{RepType: acctest.Required, Create: []string{`${oci_queue_queue.test_queue.id}`}},
 	}
 
+	QueueQueueCapabilitiesRepresentation = map[string]interface{}{
+		"type":                              acctest.Representation{RepType: acctest.Required, Create: `CONSUMER_GROUPS`, Update: `CONSUMER_GROUPS`},
+		"is_primary_consumer_group_enabled": acctest.Representation{RepType: acctest.Optional, Create: `false`, Update: `true`},
+	}
+
 	QueueQueueRepresentation = map[string]interface{}{
 		"compartment_id":                   acctest.Representation{RepType: acctest.Required, Create: `${var.compartment_id}`},
 		"display_name":                     acctest.Representation{RepType: acctest.Required, Create: `displayName`, Update: `displayName2`},
@@ -61,6 +66,7 @@ var (
 		"retention_in_seconds":             acctest.Representation{RepType: acctest.Optional, Create: `10`},
 		"timeout_in_seconds":               acctest.Representation{RepType: acctest.Optional, Create: `10`, Update: `11`},
 		"visibility_in_seconds":            acctest.Representation{RepType: acctest.Optional, Create: `10`, Update: `11`},
+		"capabilities":                     acctest.RepresentationGroup{RepType: acctest.Optional, Group: QueueQueueCapabilitiesRepresentation},
 		"lifecycle":                        acctest.RepresentationGroup{RepType: acctest.Optional, Group: ignoreDefinedTagsRepresentation},
 	}
 
@@ -131,6 +137,9 @@ func TestQueueQueueResource_basic(t *testing.T) {
 				resource.TestCheckResourceAttrSet(resourceName, "time_updated"),
 				resource.TestCheckResourceAttr(resourceName, "timeout_in_seconds", "10"),
 				resource.TestCheckResourceAttr(resourceName, "visibility_in_seconds", "10"),
+				resource.TestCheckResourceAttr(resourceName, "capabilities.#", "1"),
+				resource.TestCheckResourceAttr(resourceName, "capabilities.0.type", "CONSUMER_GROUPS"),
+				resource.TestCheckResourceAttr(resourceName, "capabilities.0.is_primary_consumer_group_enabled", "false"),
 
 				func(s *terraform.State) (err error) {
 					resId, err = acctest.FromInstanceState(s, resourceName, "id")
@@ -233,6 +242,9 @@ func TestQueueQueueResource_basic(t *testing.T) {
 				resource.TestCheckResourceAttrSet(resourceName, "time_updated"),
 				resource.TestCheckResourceAttr(resourceName, "timeout_in_seconds", "11"),
 				resource.TestCheckResourceAttr(resourceName, "visibility_in_seconds", "11"),
+				resource.TestCheckResourceAttr(resourceName, "capabilities.#", "1"),
+				resource.TestCheckResourceAttr(resourceName, "capabilities.0.type", "CONSUMER_GROUPS"),
+				resource.TestCheckResourceAttr(resourceName, "capabilities.0.is_primary_consumer_group_enabled", "true"),
 
 				func(s *terraform.State) (err error) {
 					resId2, err = acctest.FromInstanceState(s, resourceName, "id")
@@ -281,6 +293,9 @@ func TestQueueQueueResource_basic(t *testing.T) {
 				resource.TestCheckResourceAttrSet(singularDatasourceName, "time_updated"),
 				resource.TestCheckResourceAttr(singularDatasourceName, "timeout_in_seconds", "11"),
 				resource.TestCheckResourceAttr(singularDatasourceName, "visibility_in_seconds", "11"),
+				resource.TestCheckResourceAttr(singularDatasourceName, "capabilities.#", "1"),
+				resource.TestCheckResourceAttr(singularDatasourceName, "capabilities.0.type", "CONSUMER_GROUPS"),
+				resource.TestCheckResourceAttr(singularDatasourceName, "capabilities.0.is_primary_consumer_group_enabled", "true"),
 			),
 		},
 		// verify resource import

--- a/internal/service/queue/queue_queue_data_source.go
+++ b/internal/service/queue/queue_queue_data_source.go
@@ -126,5 +126,13 @@ func (s *QueueQueueDataSourceCrud) SetData() error {
 		s.D.Set("visibility_in_seconds", *s.Res.VisibilityInSeconds)
 	}
 
+	if s.Res.Capabilities != nil {
+		capabilities := []interface{}{}
+		for _, item := range s.Res.Capabilities {
+			capabilities = append(capabilities, QueueCapabilityToMap(item))
+		}
+		s.D.Set("capabilities", capabilities)
+	}
+
 	return nil
 }

--- a/website/docs/d/queue_queue.html.markdown
+++ b/website/docs/d/queue_queue.html.markdown
@@ -49,4 +49,7 @@ The following attributes are exported:
 * `time_updated` - The time that the queue was updated, expressed in [RFC 3339](https://tools.ietf.org/rfc/rfc3339) timestamp format.  Example: `2018-04-20T00:00:07.405Z` 
 * `timeout_in_seconds` - The default polling timeout of the messages in the queue, in seconds.
 * `visibility_in_seconds` - The default visibility timeout of the messages consumed from the queue, in seconds.
+* `capabilities` - The capabilities configuration for the queue.
+	* `type` - The type of capability. Example: `CONSUMER_GROUPS`
+	* `is_primary_consumer_group_enabled` - Whether the primary consumer group is enabled for this capability.
 

--- a/website/docs/r/queue_queue.html.markdown
+++ b/website/docs/r/queue_queue.html.markdown
@@ -35,6 +35,10 @@ resource "oci_queue_queue" "test_queue" {
 	retention_in_seconds = var.queue_retention_in_seconds
 	timeout_in_seconds = var.queue_timeout_in_seconds
 	visibility_in_seconds = var.queue_visibility_in_seconds
+	capabilities {
+		type = "CONSUMER_GROUPS"
+		is_primary_consumer_group_enabled = false
+	}
 }
 ```
 
@@ -54,6 +58,9 @@ The following arguments are supported:
 * `visibility_in_seconds` - (Optional) (Updatable) The default visibility timeout of the messages consumed from the queue, in seconds.
 * `purge_trigger` - (Optional) (Updatable) An optional property when incremented triggers Purge. Could be set to any integer value.
 * `purge_type` - (Optional) (Updatable) An optional value that specifies the purge behavior for the Queue. Could be set to NORMAL, DLQ or BOTH. If unset, the default value is NORMAL
+* `capabilities` - (Optional) (Updatable) The capabilities configuration for the queue.
+	* `type` - (Required) The type of capability. Example: `CONSUMER_GROUPS`
+	* `is_primary_consumer_group_enabled` - (Optional) Whether the primary consumer group is enabled for this capability.
 
 ** IMPORTANT **
 Any change to a property that does not support update will force the destruction and recreation of the resource with the new property values
@@ -79,6 +86,9 @@ The following attributes are exported:
 * `time_updated` - The time that the queue was updated, expressed in [RFC 3339](https://tools.ietf.org/rfc/rfc3339) timestamp format.  Example: `2018-04-20T00:00:07.405Z` 
 * `timeout_in_seconds` - The default polling timeout of the messages in the queue, in seconds.
 * `visibility_in_seconds` - The default visibility timeout of the messages consumed from the queue, in seconds.
+* `capabilities` - The capabilities configuration for the queue.
+	* `type` - The type of capability. Example: `CONSUMER_GROUPS`
+	* `is_primary_consumer_group_enabled` - Whether the primary consumer group is enabled for this capability.
 
 ## Timeouts
 


### PR DESCRIPTION
## Description

This PR adds support for configuring `capabilities` in the `oci_queue_queue` resource. The capabilities configuration allows users to enable consumer groups functionality with the option to enable primary consumer groups.

**Depends on:** [oci-go-sdk PR #612](https://github.com/oracle/oci-go-sdk/pull/612)

## Changes

- Added `capabilities` field to `oci_queue_queue` resource schema
- Implemented create, update, and read operations for capabilities
- Added integration tests for capabilities configuration
- Updated documentation for queue resource and data source
- Updated example configuration

## Capabilities Schema

```hcl
resource "oci_queue_queue" "test_queue" {
  compartment_id      = var.compartment_id
  display_name        = var.queue_display_name
  retention_in_seconds = var.retention_in_seconds
  timeout_in_seconds   = var.timeout_in_seconds
  visibility_in_seconds = var.visibility_in_seconds

  capabilities {
    type = "CONSUMER_GROUPS"
    is_primary_consumer_group_enabled = false
  }
}
```

## Testing

- Integration tests verify capabilities can be set during create and update operations
- Tests validate capabilities are correctly read back from the API
- Example configuration demonstrates usage

## Screenshots

<img width="1030" height="680" alt="Screenshot 2025-11-12 at 11 47 51" src="https://github.com/user-attachments/assets/25c773b9-d2e6-46ed-abb0-3a7218a91019" />

<img width="1675" height="889" alt="Screenshot 2025-11-12 at 11 24 33" src="https://github.com/user-attachments/assets/f66e7338-9431-461e-8e0a-3e01471fa686" />




