### PR TITLE
Add Resource Manager stack resource support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Support for OSMH v3.2 Updates to ALX, Ubuntu Support and Dynamic Groupings
 - Support for VMware to OLVM Virtual Machine Migrations
 - Support for Management Agent: Support for IPv6 dual-stack
+- Support for Resource Manager stack resource
 
 ### Bug Fix
 - Preserve configured IPv6 pair details and derive missing pair details from API during refresh

--- a/examples/resourcemanager/stack_resource/README.md
+++ b/examples/resourcemanager/stack_resource/README.md
@@ -8,3 +8,4 @@ This example shows how to create and read back an OCI Resource Manager stack wit
 - The current resource implementation supports `ZIP_UPLOAD` config sources only.
 - `stack_zip_path` must point to a ZIP archive that already exists on disk.
 - The stack and singular data source both persist the downloaded ZIP content in Terraform state so refresh and import can preserve stack configuration. For large archives, that can noticeably increase state size.
+- For acceptance testing, the authenticated OCI profile and the target `compartment_ocid` must belong to the same tenancy and have Resource Manager permissions. With session-token auth, set `TF_VAR_auth=SecurityToken` and `TF_VAR_config_file_profile=<profile>`.

--- a/examples/resourcemanager/stack_resource/README.md
+++ b/examples/resourcemanager/stack_resource/README.md
@@ -1,0 +1,10 @@
+# Resource Manager Stack Resource Example
+
+This example shows how to create and read back an OCI Resource Manager stack with
+`oci_resourcemanager_stack`.
+
+## Notes
+
+- The current resource implementation supports `ZIP_UPLOAD` config sources only.
+- `stack_zip_path` must point to a ZIP archive that already exists on disk.
+- The stack and singular data source both persist the downloaded ZIP content in Terraform state so refresh and import can preserve stack configuration. For large archives, that can noticeably increase state size.

--- a/examples/resourcemanager/stack_resource/main.tf
+++ b/examples/resourcemanager/stack_resource/main.tf
@@ -1,0 +1,35 @@
+resource "oci_resourcemanager_stack" "example" {
+  compartment_id = var.compartment_ocid
+  display_name   = var.stack_display_name
+  description    = var.stack_description
+
+  config_source {
+    config_source_type     = "ZIP_UPLOAD"
+    zip_file_base64encoded = filebase64(var.stack_zip_path)
+    working_directory      = var.stack_working_directory
+  }
+
+  freeform_tags = {
+    Example = "terraform-provider-oci"
+  }
+
+  variables = {
+    compartment_ocid = var.compartment_ocid
+  }
+}
+
+data "oci_resourcemanager_stack" "example" {
+  stack_id = oci_resourcemanager_stack.example.id
+}
+
+output "stack_id" {
+  value = oci_resourcemanager_stack.example.id
+}
+
+output "downloaded_config_source_type" {
+  value = data.oci_resourcemanager_stack.example.config_source[0].config_source_type
+}
+
+output "downloaded_working_directory" {
+  value = data.oci_resourcemanager_stack.example.config_source[0].working_directory
+}

--- a/examples/resourcemanager/stack_resource/providers.tf
+++ b/examples/resourcemanager/stack_resource/providers.tf
@@ -1,0 +1,7 @@
+provider "oci" {
+  tenancy_ocid     = var.tenancy_ocid
+  user_ocid        = var.user_ocid
+  fingerprint      = var.fingerprint
+  private_key_path = var.private_key_path
+  region           = var.region
+}

--- a/examples/resourcemanager/stack_resource/vars.tf
+++ b/examples/resourcemanager/stack_resource/vars.tf
@@ -1,0 +1,23 @@
+variable "compartment_ocid" {}
+variable "tenancy_ocid" {}
+variable "user_ocid" {}
+variable "fingerprint" {}
+variable "private_key_path" {}
+variable "region" {}
+
+variable "stack_display_name" {
+  default = "example-rm-stack"
+}
+
+variable "stack_description" {
+  default = "Example Resource Manager stack managed by Terraform"
+}
+
+variable "stack_zip_path" {
+  description = "Absolute or module-relative path to the ZIP archive containing the Terraform configuration for the stack."
+}
+
+variable "stack_working_directory" {
+  description = "Optional directory inside the ZIP archive from which Terraform runs."
+  default     = "env/dev"
+}

--- a/internal/integrationtest/database_db_system_os_patch_history_entry_test.go
+++ b/internal/integrationtest/database_db_system_os_patch_history_entry_test.go
@@ -159,12 +159,5 @@ func TestDatabaseDbSystemOsPatchHistoryEntryResource_basic(t *testing.T) {
 }
 
 func init() {
-	if acctest.DependencyGraph == nil {
-		acctest.InitDependencyGraph()
-	}
-	resource.AddTestSweepers("DatabaseDbSystem", &resource.Sweeper{
-		Name:         "DatabaseDbSystem",
-		Dependencies: acctest.DependencyGraph["dbSystem"],
-		F:            sweepDatabaseDbSystemResource,
-	})
+	registerDatabaseDbSystemSweeper()
 }

--- a/internal/integrationtest/database_db_system_resource_basic_test.go
+++ b/internal/integrationtest/database_db_system_resource_basic_test.go
@@ -420,12 +420,5 @@ func TestResourceDatabaseDBSystemBasic(t *testing.T) {
 }
 
 func init() {
-	if acctest.DependencyGraph == nil {
-		acctest.InitDependencyGraph()
-	}
-	resource.AddTestSweepers("DatabaseDbSystem", &resource.Sweeper{
-		Name:         "DatabaseDbSystem",
-		Dependencies: acctest.DependencyGraph["dbSystem"],
-		F:            sweepDatabaseDbSystemResource,
-	})
+	registerDatabaseDbSystemSweeper()
 }

--- a/internal/integrationtest/database_db_system_sweeper_registration_test.go
+++ b/internal/integrationtest/database_db_system_sweeper_registration_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package integrationtest
+
+import (
+	"sync"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/oracle/terraform-provider-oci/internal/acctest"
+)
+
+var databaseDbSystemSweeperRegisterOnce sync.Once
+
+func registerDatabaseDbSystemSweeper() {
+	databaseDbSystemSweeperRegisterOnce.Do(func() {
+		if acctest.DependencyGraph == nil {
+			acctest.InitDependencyGraph()
+		}
+		resource.AddTestSweepers("DatabaseDbSystem", &resource.Sweeper{
+			Name:         "DatabaseDbSystem",
+			Dependencies: acctest.DependencyGraph["dbSystem"],
+			F:            sweepDatabaseDbSystemResource,
+		})
+	})
+}

--- a/internal/integrationtest/resourcemanager_stack_test.go
+++ b/internal/integrationtest/resourcemanager_stack_test.go
@@ -4,8 +4,12 @@
 package integrationtest
 
 import (
+	"archive/zip"
+	"bytes"
 	"context"
+	"encoding/base64"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -26,8 +30,35 @@ import (
 )
 
 var (
+	ResourcemanagerStackCreateZipFiles = map[string]string{
+		"env/dev/main.tf":      "provider oci {}\n",
+		"env/dev/variables.tf": "variable \"stack_name\" { default = \"create\" }\n",
+	}
+	ResourcemanagerStackUpdateZipFiles = map[string]string{
+		"env/dev/main.tf":      "provider oci {}\n# updated config\n",
+		"env/dev/variables.tf": "variable \"stack_name\" { default = \"update\" }\n",
+	}
+	ResourcemanagerStackCreateZipFileBase64Encoded = mustBuildResourcemanagerStackZipBase64(ResourcemanagerStackCreateZipFiles)
+	ResourcemanagerStackUpdateZipFileBase64Encoded = mustBuildResourcemanagerStackZipBase64(ResourcemanagerStackUpdateZipFiles)
+
+	ResourcemanagerStackResourceRepresentation = map[string]interface{}{
+		"compartment_id": acctest.Representation{RepType: acctest.Required, Create: `${var.compartment_id}`},
+		"config_source": acctest.RepresentationGroup{RepType: acctest.Required, Group: map[string]interface{}{
+			"config_source_type":     acctest.Representation{RepType: acctest.Required, Create: `ZIP_UPLOAD`, Update: `ZIP_UPLOAD`},
+			"zip_file_base64encoded": acctest.Representation{RepType: acctest.Required, Create: ResourcemanagerStackCreateZipFileBase64Encoded, Update: ResourcemanagerStackUpdateZipFileBase64Encoded},
+			"working_directory":      acctest.Representation{RepType: acctest.Optional, Create: `env/dev`, Update: `env/dev`},
+		}},
+		"description":   acctest.Representation{RepType: acctest.Optional, Create: `Test Resource Manager stack description`, Update: `Test Resource Manager stack description updated`},
+		"display_name":  acctest.Representation{RepType: acctest.Required, Create: `TestResourcemanagerStackResource_crud`, Update: `TestResourcemanagerStackResource_crud_updated`},
+		"freeform_tags": acctest.Representation{RepType: acctest.Optional, Create: map[string]string{"Department": "Finance"}, Update: map[string]string{"Department": "Accounting"}},
+		"variables":     acctest.Representation{RepType: acctest.Optional, Create: map[string]string{"var1": "value1"}, Update: map[string]string{"var1": "updatedValue", "var2": "value2"}},
+	}
+
 	ResourcemanagerResourcemanagerStackSingularDataSourceRepresentation = map[string]interface{}{
 		"stack_id": acctest.Representation{RepType: acctest.Required, Create: `${var.resource_manager_stack_id}`},
+	}
+	ResourcemanagerResourcemanagerStackResourceSingularDataSourceRepresentation = map[string]interface{}{
+		"stack_id": acctest.Representation{RepType: acctest.Required, Create: `${oci_resourcemanager_stack.test_stack.id}`},
 	}
 
 	ResourcemanagerResourcemanagerStackDataSourceRepresentation = map[string]interface{}{
@@ -37,8 +68,109 @@ var (
 		"state":          acctest.Representation{RepType: acctest.Required, Create: `ACTIVE`}, // make `required` here so it can be asserted against in step 0
 	}
 
-	ResourcemanagerStackResourceConfig = DefinedTagsDependencies
+	ResourcemanagerStackResourceConfig = ""
 )
+
+// issue-routing-tag: resourcemanager/default
+func TestResourcemanagerStackResource_crud(t *testing.T) {
+	if strings.Contains(utils.GetEnvSettingWithBlankDefault("suppressed_tests"), "TestResourcemanagerStackResource_crud") {
+		t.Skip("Skipping suppressed TestResourcemanagerStackResource_crud")
+	}
+
+	httpreplay.SetScenario("TestResourcemanagerStackResource_crud")
+	defer httpreplay.SaveScenario()
+
+	config := acctest.ProviderTestConfig()
+
+	compartmentId := utils.GetEnvSettingWithBlankDefault("compartment_ocid")
+	compartmentIdVariableStr := fmt.Sprintf("variable \"compartment_id\" { default = \"%s\" }\n", compartmentId)
+
+	resourceName := "oci_resourcemanager_stack.test_stack"
+	singularDatasourceName := "data.oci_resourcemanager_stack.test_stack"
+
+	var resId, resId2 string
+
+	acctest.ResourceTest(t, testAccCheckResourcemanagerStackDestroy, []resource.TestStep{
+		{
+			Config: config + compartmentIdVariableStr +
+				acctest.GenerateResourceFromRepresentationMap("oci_resourcemanager_stack", "test_stack", acctest.Optional, acctest.Create, ResourcemanagerStackResourceRepresentation),
+			Check: acctest.ComposeAggregateTestCheckFuncWrapper(
+				resource.TestCheckResourceAttr(resourceName, "compartment_id", compartmentId),
+				resource.TestCheckResourceAttr(resourceName, "config_source.#", "1"),
+				resource.TestCheckResourceAttr(resourceName, "config_source.0.config_source_type", "ZIP_UPLOAD"),
+				resource.TestCheckResourceAttr(resourceName, "config_source.0.working_directory", "env/dev"),
+				resource.TestCheckResourceAttr(resourceName, "description", "Test Resource Manager stack description"),
+				resource.TestCheckResourceAttr(resourceName, "display_name", "TestResourcemanagerStackResource_crud"),
+				resource.TestCheckResourceAttr(resourceName, "freeform_tags.%", "1"),
+				resource.TestCheckResourceAttrSet(resourceName, "id"),
+				resource.TestCheckResourceAttr(resourceName, "state", "ACTIVE"),
+				testCheckResourcemanagerStackZipContents(resourceName, ResourcemanagerStackCreateZipFiles),
+				resource.TestCheckResourceAttrSet(resourceName, "time_created"),
+				resource.TestCheckResourceAttr(resourceName, "variables.%", "1"),
+				func(s *terraform.State) (err error) {
+					resId, err = acctest.FromInstanceState(s, resourceName, "id")
+					return err
+				},
+			),
+		},
+		{
+			Config: config + compartmentIdVariableStr +
+				acctest.GenerateResourceFromRepresentationMap("oci_resourcemanager_stack", "test_stack", acctest.Optional, acctest.Update, ResourcemanagerStackResourceRepresentation),
+			Check: acctest.ComposeAggregateTestCheckFuncWrapper(
+				resource.TestCheckResourceAttr(resourceName, "compartment_id", compartmentId),
+				resource.TestCheckResourceAttr(resourceName, "config_source.#", "1"),
+				resource.TestCheckResourceAttr(resourceName, "config_source.0.config_source_type", "ZIP_UPLOAD"),
+				resource.TestCheckResourceAttr(resourceName, "config_source.0.working_directory", "env/dev"),
+				resource.TestCheckResourceAttr(resourceName, "description", "Test Resource Manager stack description updated"),
+				resource.TestCheckResourceAttr(resourceName, "display_name", "TestResourcemanagerStackResource_crud_updated"),
+				resource.TestCheckResourceAttr(resourceName, "freeform_tags.%", "1"),
+				resource.TestCheckResourceAttrSet(resourceName, "id"),
+				resource.TestCheckResourceAttr(resourceName, "state", "ACTIVE"),
+				testCheckResourcemanagerStackZipContents(resourceName, ResourcemanagerStackUpdateZipFiles),
+				resource.TestCheckResourceAttrSet(resourceName, "time_created"),
+				resource.TestCheckResourceAttr(resourceName, "variables.%", "2"),
+				func(s *terraform.State) (err error) {
+					resId2, err = acctest.FromInstanceState(s, resourceName, "id")
+					if err != nil {
+						return err
+					}
+					if resId != resId2 {
+						return fmt.Errorf("resource recreated when it was supposed to be updated")
+					}
+					return nil
+				},
+			),
+		},
+		{
+			Config: config + compartmentIdVariableStr +
+				acctest.GenerateResourceFromRepresentationMap("oci_resourcemanager_stack", "test_stack", acctest.Optional, acctest.Update, ResourcemanagerStackResourceRepresentation) +
+				acctest.GenerateDataSourceFromRepresentationMap("oci_resourcemanager_stack", "test_stack", acctest.Required, acctest.Create, ResourcemanagerResourcemanagerStackResourceSingularDataSourceRepresentation),
+			Check: acctest.ComposeAggregateTestCheckFuncWrapper(
+				resource.TestCheckResourceAttrSet(singularDatasourceName, "stack_id"),
+				resource.TestCheckResourceAttr(singularDatasourceName, "compartment_id", compartmentId),
+				resource.TestCheckResourceAttr(singularDatasourceName, "config_source.#", "1"),
+				resource.TestCheckResourceAttr(singularDatasourceName, "config_source.0.config_source_type", "ZIP_UPLOAD"),
+				resource.TestCheckResourceAttr(singularDatasourceName, "config_source.0.working_directory", "env/dev"),
+				resource.TestCheckResourceAttr(singularDatasourceName, "description", "Test Resource Manager stack description updated"),
+				resource.TestCheckResourceAttr(singularDatasourceName, "display_name", "TestResourcemanagerStackResource_crud_updated"),
+				resource.TestCheckResourceAttr(singularDatasourceName, "freeform_tags.%", "1"),
+				resource.TestCheckResourceAttrSet(singularDatasourceName, "id"),
+				resource.TestCheckResourceAttr(singularDatasourceName, "state", "ACTIVE"),
+				testCheckResourcemanagerStackZipContents(singularDatasourceName, ResourcemanagerStackUpdateZipFiles),
+				resource.TestCheckResourceAttrSet(singularDatasourceName, "time_created"),
+				resource.TestCheckResourceAttr(singularDatasourceName, "variables.%", "2"),
+			),
+		},
+		{
+			Config: config + compartmentIdVariableStr +
+				acctest.GenerateResourceFromRepresentationMap("oci_resourcemanager_stack", "test_stack", acctest.Optional, acctest.Update, ResourcemanagerStackResourceRepresentation),
+			ImportState:             true,
+			ImportStateVerify:       true,
+			ImportStateVerifyIgnore: []string{},
+			ResourceName:            resourceName,
+		},
+	})
+}
 
 // issue-routing-tag: resourcemanager/default
 func TestResourcemanagerStackResource_basic(t *testing.T) {
@@ -125,6 +257,118 @@ func TestResourcemanagerStackResource_basic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccCheckResourcemanagerStackDestroy(s *terraform.State) error {
+	noResourceFound := true
+	client := acctest.TestAccProvider.Meta().(*tf_client.OracleClients).ResourceManagerClient()
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "oci_resourcemanager_stack" {
+			noResourceFound = false
+			request := oci_resourcemanager.GetStackRequest{}
+
+			tmp := rs.Primary.ID
+			request.StackId = &tmp
+			request.RequestMetadata.RetryPolicy = tfresource.GetRetryPolicy(true, "resourcemanager")
+
+			response, err := client.GetStack(context.Background(), request)
+			if err == nil {
+				deletedLifecycleStates := map[string]bool{
+					string(oci_resourcemanager.StackLifecycleStateDeleted): true,
+				}
+				if _, ok := deletedLifecycleStates[string(response.LifecycleState)]; !ok {
+					return fmt.Errorf("resource lifecycle state: %s is not in expected deleted lifecycle states", response.LifecycleState)
+				}
+				continue
+			}
+
+			if failure, isServiceError := common.IsServiceError(err); !isServiceError || failure.GetHTTPStatusCode() != 404 {
+				return err
+			}
+		}
+	}
+	if noResourceFound {
+		return fmt.Errorf("at least one resource was expected from the state file, but could not be found")
+	}
+
+	return nil
+}
+
+func mustBuildResourcemanagerStackZipBase64(files map[string]string) string {
+	buf := new(bytes.Buffer)
+	zipWriter := zip.NewWriter(buf)
+
+	for name, content := range files {
+		f, err := zipWriter.Create(name)
+		if err != nil {
+			panic(fmt.Sprintf("cannot create zip file %s for stack test: %v", name, err))
+		}
+		if _, err := f.Write([]byte(content)); err != nil {
+			panic(fmt.Sprintf("cannot write zip file %s for stack test: %v", name, err))
+		}
+	}
+
+	if err := zipWriter.Close(); err != nil {
+		panic(fmt.Sprintf("cannot close stack test zip writer: %v", err))
+	}
+
+	return base64.StdEncoding.EncodeToString(buf.Bytes())
+}
+
+func testCheckResourcemanagerStackZipContents(resourceName string, expectedFiles map[string]string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found in state: %s", resourceName)
+		}
+
+		zipFileBase64Encoded, ok := rs.Primary.Attributes["config_source.0.zip_file_base64encoded"]
+		if !ok {
+			return fmt.Errorf("config_source.0.zip_file_base64encoded not found in state for %s", resourceName)
+		}
+
+		archiveBytes, err := base64.StdEncoding.DecodeString(zipFileBase64Encoded)
+		if err != nil {
+			return fmt.Errorf("cannot decode zip_file_base64encoded for %s: %v", resourceName, err)
+		}
+
+		zipReader, err := zip.NewReader(bytes.NewReader(archiveBytes), int64(len(archiveBytes)))
+		if err != nil {
+			return fmt.Errorf("cannot read downloaded stack archive for %s: %v", resourceName, err)
+		}
+
+		actualFiles := make(map[string]string, len(zipReader.File))
+		for _, file := range zipReader.File {
+			rc, err := file.Open()
+			if err != nil {
+				return fmt.Errorf("cannot open file %s in archive for %s: %v", file.Name, resourceName, err)
+			}
+
+			content, err := io.ReadAll(rc)
+			rc.Close()
+			if err != nil {
+				return fmt.Errorf("cannot read file %s in archive for %s: %v", file.Name, resourceName, err)
+			}
+
+			actualFiles[file.Name] = string(content)
+		}
+
+		if len(actualFiles) != len(expectedFiles) {
+			return fmt.Errorf("unexpected archive file count for %s: got %d, want %d", resourceName, len(actualFiles), len(expectedFiles))
+		}
+
+		for fileName, expectedContent := range expectedFiles {
+			actualContent, ok := actualFiles[fileName]
+			if !ok {
+				return fmt.Errorf("expected archive file %s missing for %s", fileName, resourceName)
+			}
+			if actualContent != expectedContent {
+				return fmt.Errorf("unexpected archive content for %s in %s", fileName, resourceName)
+			}
+		}
+
+		return nil
+	}
 }
 
 func init() {

--- a/internal/integrationtest/resourcemanager_stack_test.go
+++ b/internal/integrationtest/resourcemanager_stack_test.go
@@ -34,11 +34,16 @@ var (
 		"env/dev/main.tf":      "provider oci {}\n",
 		"env/dev/variables.tf": "variable \"stack_name\" { default = \"create\" }\n",
 	}
+	ResourcemanagerStackConfigOnlyUpdateZipFiles = map[string]string{
+		"env/dev/main.tf":      "provider oci {}\n# config only update\n",
+		"env/dev/variables.tf": "variable \"stack_name\" { default = \"config-only-update\" }\n",
+	}
 	ResourcemanagerStackUpdateZipFiles = map[string]string{
 		"env/dev/main.tf":      "provider oci {}\n# updated config\n",
 		"env/dev/variables.tf": "variable \"stack_name\" { default = \"update\" }\n",
 	}
 	ResourcemanagerStackCreateZipFileBase64Encoded = mustBuildResourcemanagerStackZipBase64(ResourcemanagerStackCreateZipFiles)
+	ResourcemanagerStackConfigOnlyUpdateZipFileBase64Encoded = mustBuildResourcemanagerStackZipBase64(ResourcemanagerStackConfigOnlyUpdateZipFiles)
 	ResourcemanagerStackUpdateZipFileBase64Encoded = mustBuildResourcemanagerStackZipBase64(ResourcemanagerStackUpdateZipFiles)
 
 	ResourcemanagerStackResourceRepresentation = map[string]interface{}{
@@ -52,6 +57,50 @@ var (
 		"display_name":  acctest.Representation{RepType: acctest.Required, Create: `TestResourcemanagerStackResource_crud`, Update: `TestResourcemanagerStackResource_crud_updated`},
 		"freeform_tags": acctest.Representation{RepType: acctest.Optional, Create: map[string]string{"Department": "Finance"}, Update: map[string]string{"Department": "Accounting"}},
 		"variables":     acctest.Representation{RepType: acctest.Optional, Create: map[string]string{"var1": "value1"}, Update: map[string]string{"var1": "updatedValue", "var2": "value2"}},
+	}
+	ResourcemanagerStackIncrementalCreateRepresentation = map[string]interface{}{
+		"compartment_id": acctest.Representation{RepType: acctest.Required, Create: `${var.compartment_id}`},
+		"config_source": acctest.RepresentationGroup{RepType: acctest.Required, Group: map[string]interface{}{
+			"config_source_type":     acctest.Representation{RepType: acctest.Required, Create: `ZIP_UPLOAD`},
+			"zip_file_base64encoded": acctest.Representation{RepType: acctest.Required, Create: ResourcemanagerStackCreateZipFileBase64Encoded},
+			"working_directory":      acctest.Representation{RepType: acctest.Optional, Create: `env/dev`},
+		}},
+		"display_name":  acctest.Representation{RepType: acctest.Required, Create: `TestResourcemanagerStackResource_incrementalUpdates`},
+		"freeform_tags": acctest.Representation{RepType: acctest.Optional, Create: map[string]string{"Department": "Finance"}},
+		"variables":     acctest.Representation{RepType: acctest.Optional, Create: map[string]string{"var1": "value1"}},
+	}
+	ResourcemanagerStackIncrementalTagUpdateRepresentation = map[string]interface{}{
+		"compartment_id": acctest.Representation{RepType: acctest.Required, Create: `${var.compartment_id}`},
+		"config_source": acctest.RepresentationGroup{RepType: acctest.Required, Group: map[string]interface{}{
+			"config_source_type":     acctest.Representation{RepType: acctest.Required, Create: `ZIP_UPLOAD`},
+			"zip_file_base64encoded": acctest.Representation{RepType: acctest.Required, Create: ResourcemanagerStackCreateZipFileBase64Encoded},
+			"working_directory":      acctest.Representation{RepType: acctest.Optional, Create: `env/dev`},
+		}},
+		"display_name":  acctest.Representation{RepType: acctest.Required, Create: `TestResourcemanagerStackResource_incrementalUpdates`},
+		"freeform_tags": acctest.Representation{RepType: acctest.Optional, Create: map[string]string{"Department": "Accounting"}},
+		"variables":     acctest.Representation{RepType: acctest.Optional, Create: map[string]string{"var1": "value1"}},
+	}
+	ResourcemanagerStackIncrementalVariableUpdateRepresentation = map[string]interface{}{
+		"compartment_id": acctest.Representation{RepType: acctest.Required, Create: `${var.compartment_id}`},
+		"config_source": acctest.RepresentationGroup{RepType: acctest.Required, Group: map[string]interface{}{
+			"config_source_type":     acctest.Representation{RepType: acctest.Required, Create: `ZIP_UPLOAD`},
+			"zip_file_base64encoded": acctest.Representation{RepType: acctest.Required, Create: ResourcemanagerStackCreateZipFileBase64Encoded},
+			"working_directory":      acctest.Representation{RepType: acctest.Optional, Create: `env/dev`},
+		}},
+		"display_name":  acctest.Representation{RepType: acctest.Required, Create: `TestResourcemanagerStackResource_incrementalUpdates`},
+		"freeform_tags": acctest.Representation{RepType: acctest.Optional, Create: map[string]string{"Department": "Accounting"}},
+		"variables":     acctest.Representation{RepType: acctest.Optional, Create: map[string]string{"var1": "updatedValue", "var2": "value2"}},
+	}
+	ResourcemanagerStackIncrementalConfigUpdateRepresentation = map[string]interface{}{
+		"compartment_id": acctest.Representation{RepType: acctest.Required, Create: `${var.compartment_id}`},
+		"config_source": acctest.RepresentationGroup{RepType: acctest.Required, Group: map[string]interface{}{
+			"config_source_type":     acctest.Representation{RepType: acctest.Required, Create: `ZIP_UPLOAD`},
+			"zip_file_base64encoded": acctest.Representation{RepType: acctest.Required, Create: ResourcemanagerStackConfigOnlyUpdateZipFileBase64Encoded},
+			"working_directory":      acctest.Representation{RepType: acctest.Optional, Create: `env/dev`},
+		}},
+		"display_name":  acctest.Representation{RepType: acctest.Required, Create: `TestResourcemanagerStackResource_incrementalUpdates`},
+		"freeform_tags": acctest.Representation{RepType: acctest.Optional, Create: map[string]string{"Department": "Accounting"}},
+		"variables":     acctest.Representation{RepType: acctest.Optional, Create: map[string]string{"var1": "updatedValue", "var2": "value2"}},
 	}
 
 	ResourcemanagerResourcemanagerStackSingularDataSourceRepresentation = map[string]interface{}{
@@ -168,6 +217,70 @@ func TestResourcemanagerStackResource_crud(t *testing.T) {
 			ImportStateVerify:       true,
 			ImportStateVerifyIgnore: []string{},
 			ResourceName:            resourceName,
+		},
+	})
+}
+
+// issue-routing-tag: resourcemanager/default
+func TestResourcemanagerStackResource_incrementalUpdates(t *testing.T) {
+	if strings.Contains(utils.GetEnvSettingWithBlankDefault("suppressed_tests"), "TestResourcemanagerStackResource_incrementalUpdates") {
+		t.Skip("Skipping suppressed TestResourcemanagerStackResource_incrementalUpdates")
+	}
+
+	httpreplay.SetScenario("TestResourcemanagerStackResource_incrementalUpdates")
+	defer httpreplay.SaveScenario()
+
+	config := acctest.ProviderTestConfig()
+	compartmentId := utils.GetEnvSettingWithBlankDefault("compartment_ocid")
+	compartmentIdVariableStr := fmt.Sprintf("variable \"compartment_id\" { default = \"%s\" }\n", compartmentId)
+	resourceName := "oci_resourcemanager_stack.test_stack"
+
+	var resId string
+
+	acctest.ResourceTest(t, testAccCheckResourcemanagerStackDestroy, []resource.TestStep{
+		{
+			Config: config + compartmentIdVariableStr +
+				acctest.GenerateResourceFromRepresentationMap("oci_resourcemanager_stack", "test_stack", acctest.Optional, acctest.Create, ResourcemanagerStackIncrementalCreateRepresentation),
+			Check: acctest.ComposeAggregateTestCheckFuncWrapper(
+				resource.TestCheckResourceAttr(resourceName, "freeform_tags.Department", "Finance"),
+				resource.TestCheckResourceAttr(resourceName, "variables.%", "1"),
+				testCheckResourcemanagerStackZipContents(resourceName, ResourcemanagerStackCreateZipFiles),
+				func(s *terraform.State) (err error) {
+					resId, err = acctest.FromInstanceState(s, resourceName, "id")
+					return err
+				},
+			),
+		},
+		{
+			Config: config + compartmentIdVariableStr +
+				acctest.GenerateResourceFromRepresentationMap("oci_resourcemanager_stack", "test_stack", acctest.Optional, acctest.Create, ResourcemanagerStackIncrementalTagUpdateRepresentation),
+			Check: acctest.ComposeAggregateTestCheckFuncWrapper(
+				resource.TestCheckResourceAttr(resourceName, "freeform_tags.Department", "Accounting"),
+				resource.TestCheckResourceAttr(resourceName, "variables.%", "1"),
+				testCheckResourcemanagerStackZipContents(resourceName, ResourcemanagerStackCreateZipFiles),
+				testCheckResourcemanagerStackResourceIdUnchanged(resourceName, &resId),
+			),
+		},
+		{
+			Config: config + compartmentIdVariableStr +
+				acctest.GenerateResourceFromRepresentationMap("oci_resourcemanager_stack", "test_stack", acctest.Optional, acctest.Create, ResourcemanagerStackIncrementalVariableUpdateRepresentation),
+			Check: acctest.ComposeAggregateTestCheckFuncWrapper(
+				resource.TestCheckResourceAttr(resourceName, "freeform_tags.Department", "Accounting"),
+				resource.TestCheckResourceAttr(resourceName, "variables.%", "2"),
+				resource.TestCheckResourceAttr(resourceName, "variables.var1", "updatedValue"),
+				testCheckResourcemanagerStackZipContents(resourceName, ResourcemanagerStackCreateZipFiles),
+				testCheckResourcemanagerStackResourceIdUnchanged(resourceName, &resId),
+			),
+		},
+		{
+			Config: config + compartmentIdVariableStr +
+				acctest.GenerateResourceFromRepresentationMap("oci_resourcemanager_stack", "test_stack", acctest.Optional, acctest.Create, ResourcemanagerStackIncrementalConfigUpdateRepresentation),
+			Check: acctest.ComposeAggregateTestCheckFuncWrapper(
+				resource.TestCheckResourceAttr(resourceName, "freeform_tags.Department", "Accounting"),
+				resource.TestCheckResourceAttr(resourceName, "variables.%", "2"),
+				testCheckResourcemanagerStackZipContents(resourceName, ResourcemanagerStackConfigOnlyUpdateZipFiles),
+				testCheckResourcemanagerStackResourceIdUnchanged(resourceName, &resId),
+			),
 		},
 	})
 }
@@ -313,6 +426,19 @@ func mustBuildResourcemanagerStackZipBase64(files map[string]string) string {
 	}
 
 	return base64.StdEncoding.EncodeToString(buf.Bytes())
+}
+
+func testCheckResourcemanagerStackResourceIdUnchanged(resourceName string, expectedId *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		currentId, err := acctest.FromInstanceState(s, resourceName, "id")
+		if err != nil {
+			return err
+		}
+		if *expectedId != currentId {
+			return fmt.Errorf("resource recreated when it was supposed to be updated: previous id %s current id %s", *expectedId, currentId)
+		}
+		return nil
+	}
 }
 
 func testCheckResourcemanagerStackZipContents(resourceName string, expectedFiles map[string]string) resource.TestCheckFunc {

--- a/internal/service/resourcemanager/register_resource.go
+++ b/internal/service/resourcemanager/register_resource.go
@@ -7,4 +7,5 @@ import "github.com/oracle/terraform-provider-oci/internal/tfresource"
 
 func RegisterResource() {
 	tfresource.RegisterResource("oci_resourcemanager_private_endpoint", ResourcemanagerPrivateEndpointResource())
+	tfresource.RegisterResource("oci_resourcemanager_stack", ResourcemanagerStackResource())
 }

--- a/internal/service/resourcemanager/resourcemanager_stack_data_source.go
+++ b/internal/service/resourcemanager/resourcemanager_stack_data_source.go
@@ -5,7 +5,6 @@ package resourcemanager
 
 import (
 	"context"
-	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -76,6 +75,10 @@ func ResourcemanagerStackDataSource() *schema.Resource {
 				Computed: true,
 				Elem:     schema.TypeString,
 			},
+			"stack_drift_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"state": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -90,6 +93,10 @@ func ResourcemanagerStackDataSource() *schema.Resource {
 				Computed: true,
 			},
 			"time_created": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"time_drift_last_checked": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -152,7 +159,11 @@ func (s *ResourcemanagerStackDataSourceCrud) SetData() error {
 
 	if s.Res.ConfigSource != nil {
 		configSourceArray := []interface{}{}
-		if configSourceMap := ConfigSourceToMap(&s.Res.ConfigSource); configSourceMap != nil {
+		downloadedConfigSource, err := getDownloadedStackConfigSource(s.Client, &s.Res.Stack, tfresource.GetRetryPolicy(false, "resourcemanager"), nil)
+		if err != nil {
+			return err
+		}
+		if configSourceMap := StackConfigSourceToMap(&s.Res.ConfigSource, downloadedConfigSource); configSourceMap != nil {
 			configSourceArray = append(configSourceArray, configSourceMap)
 		}
 		s.D.Set("config_source", configSourceArray)
@@ -174,6 +185,7 @@ func (s *ResourcemanagerStackDataSourceCrud) SetData() error {
 
 	s.D.Set("freeform_tags", s.Res.FreeformTags)
 
+	s.D.Set("stack_drift_status", s.Res.StackDriftStatus)
 	s.D.Set("state", s.Res.LifecycleState)
 
 	if s.Res.SystemTags != nil {
@@ -188,20 +200,11 @@ func (s *ResourcemanagerStackDataSourceCrud) SetData() error {
 		s.D.Set("time_created", s.Res.TimeCreated.String())
 	}
 
+	if s.Res.TimeDriftLastChecked != nil {
+		s.D.Set("time_drift_last_checked", s.Res.TimeDriftLastChecked.String())
+	}
+
 	s.D.Set("variables", s.Res.Variables)
 
 	return nil
-}
-
-func ConfigSourceToMap(obj *oci_resourcemanager.ConfigSource) map[string]interface{} {
-	result := map[string]interface{}{}
-	switch (*obj).(type) {
-	case oci_resourcemanager.ZipUploadConfigSource:
-		result["config_source_type"] = "ZIP_UPLOAD"
-	default:
-		log.Printf("[WARN] Received 'config_source_type' of unknown type %v", *obj)
-		return nil
-	}
-
-	return result
 }

--- a/internal/service/resourcemanager/resourcemanager_stack_resource.go
+++ b/internal/service/resourcemanager/resourcemanager_stack_resource.go
@@ -1,0 +1,555 @@
+// Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package resourcemanager
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	oci_common "github.com/oracle/oci-go-sdk/v65/common"
+	oci_resourcemanager "github.com/oracle/oci-go-sdk/v65/resourcemanager"
+
+	"github.com/oracle/terraform-provider-oci/internal/client"
+	"github.com/oracle/terraform-provider-oci/internal/tfresource"
+)
+
+func ResourcemanagerStackResource() *schema.Resource {
+	return &schema.Resource{
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: tfresource.DefaultTimeout,
+		Create:   createResourcemanagerStack,
+		Read:     readResourcemanagerStack,
+		Update:   updateResourcemanagerStack,
+		Delete:   deleteResourcemanagerStack,
+		Schema: map[string]*schema.Schema{
+			// Required
+			"compartment_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The OCID of the compartment containing the stack.",
+			},
+			"config_source": {
+				Type:        schema.TypeList,
+				Required:    true,
+				MaxItems:    1,
+				MinItems:    1,
+				Description: "The Terraform configuration source for the stack. Only ZIP_UPLOAD is currently supported.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"config_source_type": {
+							Type:             schema.TypeString,
+							Required:         true,
+							Description:      "Configuration source type. Only ZIP_UPLOAD is currently supported.",
+							DiffSuppressFunc: tfresource.EqualIgnoreCaseSuppressDiff,
+							ValidateFunc: validation.StringInSlice([]string{
+								"ZIP_UPLOAD",
+							}, true),
+						},
+						"zip_file_base64encoded": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Sensitive:   true,
+							Description: "Base64-encoded ZIP archive containing the Terraform configuration for the stack.",
+						},
+						"working_directory": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "File path to the directory inside the ZIP archive from which Terraform runs.",
+						},
+					},
+				},
+			},
+
+			// Optional
+			"defined_tags": {
+				Type:             schema.TypeMap,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: tfresource.DefinedTagsDiffSuppressFunction,
+				Elem:             schema.TypeString,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"display_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"freeform_tags": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem:     schema.TypeString,
+			},
+			"terraform_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"variables": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem:     schema.TypeString,
+			},
+
+			// Computed
+			"stack_drift_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"system_tags": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     schema.TypeString,
+			},
+			"time_created": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"time_drift_last_checked": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func createResourcemanagerStack(d *schema.ResourceData, m interface{}) error {
+	sync := &ResourcemanagerStackResourceCrud{}
+	sync.D = d
+	sync.Client = m.(*client.OracleClients).ResourceManagerClient()
+
+	return tfresource.CreateResource(d, sync)
+}
+
+func readResourcemanagerStack(d *schema.ResourceData, m interface{}) error {
+	sync := &ResourcemanagerStackResourceCrud{}
+	sync.D = d
+	sync.Client = m.(*client.OracleClients).ResourceManagerClient()
+
+	return tfresource.ReadResource(sync)
+}
+
+func updateResourcemanagerStack(d *schema.ResourceData, m interface{}) error {
+	sync := &ResourcemanagerStackResourceCrud{}
+	sync.D = d
+	sync.Client = m.(*client.OracleClients).ResourceManagerClient()
+
+	return tfresource.UpdateResource(d, sync)
+}
+
+func deleteResourcemanagerStack(d *schema.ResourceData, m interface{}) error {
+	sync := &ResourcemanagerStackResourceCrud{}
+	sync.D = d
+	sync.Client = m.(*client.OracleClients).ResourceManagerClient()
+	sync.DisableNotFoundRetries = true
+
+	return tfresource.DeleteResource(d, sync)
+}
+
+type ResourcemanagerStackResourceCrud struct {
+	tfresource.BaseCrud
+	Client                 *oci_resourcemanager.ResourceManagerClient
+	Res                    *oci_resourcemanager.Stack
+	DisableNotFoundRetries bool
+}
+
+func (s *ResourcemanagerStackResourceCrud) ID() string {
+	return *s.Res.Id
+}
+
+func (s *ResourcemanagerStackResourceCrud) CreatedPending() []string {
+	return []string{
+		string(oci_resourcemanager.StackLifecycleStateCreating),
+	}
+}
+
+func (s *ResourcemanagerStackResourceCrud) CreatedTarget() []string {
+	return []string{
+		string(oci_resourcemanager.StackLifecycleStateActive),
+	}
+}
+
+func (s *ResourcemanagerStackResourceCrud) DeletedPending() []string {
+	return []string{
+		string(oci_resourcemanager.StackLifecycleStateDeleting),
+	}
+}
+
+func (s *ResourcemanagerStackResourceCrud) DeletedTarget() []string {
+	return []string{
+		string(oci_resourcemanager.StackLifecycleStateDeleted),
+	}
+}
+
+func (s *ResourcemanagerStackResourceCrud) Create() error {
+	request := oci_resourcemanager.CreateStackRequest{}
+
+	if compartmentId, ok := s.D.GetOkExists("compartment_id"); ok {
+		tmp := compartmentId.(string)
+		request.CompartmentId = &tmp
+	}
+
+	configSource, err := s.mapToCreateConfigSourceDetails("config_source.0.%s")
+	if err != nil {
+		return err
+	}
+	request.ConfigSource = configSource
+
+	if definedTags, ok := s.D.GetOkExists("defined_tags"); ok {
+		convertedDefinedTags, err := tfresource.MapToDefinedTags(definedTags.(map[string]interface{}))
+		if err != nil {
+			return err
+		}
+		request.DefinedTags = convertedDefinedTags
+	}
+
+	if description, ok := s.D.GetOkExists("description"); ok {
+		tmp := description.(string)
+		request.Description = &tmp
+	}
+
+	if displayName, ok := s.D.GetOkExists("display_name"); ok {
+		tmp := displayName.(string)
+		request.DisplayName = &tmp
+	}
+
+	if freeformTags, ok := s.D.GetOkExists("freeform_tags"); ok {
+		request.FreeformTags = tfresource.ObjectMapToStringMap(freeformTags.(map[string]interface{}))
+	}
+
+	if terraformVersion, ok := s.D.GetOkExists("terraform_version"); ok {
+		tmp := terraformVersion.(string)
+		request.TerraformVersion = &tmp
+	}
+
+	if variables, ok := s.D.GetOkExists("variables"); ok {
+		request.Variables = tfresource.ObjectMapToStringMap(variables.(map[string]interface{}))
+	}
+
+	request.RequestMetadata.RetryPolicy = tfresource.GetRetryPolicy(false, "resourcemanager")
+
+	response, err := s.Client.CreateStack(context.Background(), request)
+	if err != nil {
+		return err
+	}
+
+	s.Res = &response.Stack
+	return nil
+}
+
+func (s *ResourcemanagerStackResourceCrud) Get() error {
+	request := oci_resourcemanager.GetStackRequest{}
+
+	tmp := s.D.Id()
+	request.StackId = &tmp
+
+	request.RequestMetadata.RetryPolicy = tfresource.GetRetryPolicy(s.DisableNotFoundRetries, "resourcemanager")
+
+	response, err := s.Client.GetStack(context.Background(), request)
+	if err != nil {
+		return err
+	}
+
+	s.Res = &response.Stack
+	return nil
+}
+
+func (s *ResourcemanagerStackResourceCrud) Update() error {
+	request := oci_resourcemanager.UpdateStackRequest{}
+
+	tmp := s.D.Id()
+	request.StackId = &tmp
+
+	if s.D.HasChange("config_source") {
+		configSource, err := s.mapToUpdateConfigSourceDetails("config_source.0.%s")
+		if err != nil {
+			return err
+		}
+		request.ConfigSource = configSource
+	}
+
+	if s.D.HasChange("defined_tags") {
+		if definedTags, ok := s.D.GetOkExists("defined_tags"); ok {
+			convertedDefinedTags, err := tfresource.MapToDefinedTags(definedTags.(map[string]interface{}))
+			if err != nil {
+				return err
+			}
+			request.DefinedTags = convertedDefinedTags
+		} else {
+			request.DefinedTags = map[string]map[string]interface{}{}
+		}
+	}
+
+	if s.D.HasChange("description") {
+		if description, ok := s.D.GetOkExists("description"); ok {
+			tmp := description.(string)
+			request.Description = &tmp
+		} else {
+			request.Description = nil
+		}
+	}
+
+	if s.D.HasChange("display_name") {
+		if displayName, ok := s.D.GetOkExists("display_name"); ok {
+			tmp := displayName.(string)
+			request.DisplayName = &tmp
+		} else {
+			request.DisplayName = nil
+		}
+	}
+
+	if s.D.HasChange("freeform_tags") {
+		if freeformTags, ok := s.D.GetOkExists("freeform_tags"); ok {
+			request.FreeformTags = tfresource.ObjectMapToStringMap(freeformTags.(map[string]interface{}))
+		} else {
+			request.FreeformTags = map[string]string{}
+		}
+	}
+
+	if s.D.HasChange("terraform_version") {
+		if terraformVersion, ok := s.D.GetOkExists("terraform_version"); ok {
+			tmp := terraformVersion.(string)
+			request.TerraformVersion = &tmp
+		} else {
+			request.TerraformVersion = nil
+		}
+	}
+
+	if s.D.HasChange("variables") {
+		if variables, ok := s.D.GetOkExists("variables"); ok {
+			request.Variables = tfresource.ObjectMapToStringMap(variables.(map[string]interface{}))
+		} else {
+			request.Variables = map[string]string{}
+		}
+	}
+
+	request.RequestMetadata.RetryPolicy = tfresource.GetRetryPolicy(s.DisableNotFoundRetries, "resourcemanager")
+
+	response, err := s.Client.UpdateStack(context.Background(), request)
+	if err != nil {
+		return err
+	}
+
+	s.Res = &response.Stack
+	return nil
+}
+
+func (s *ResourcemanagerStackResourceCrud) Delete() error {
+	request := oci_resourcemanager.DeleteStackRequest{}
+
+	tmp := s.D.Id()
+	request.StackId = &tmp
+	request.RequestMetadata.RetryPolicy = tfresource.GetRetryPolicy(s.DisableNotFoundRetries, "resourcemanager")
+
+	_, err := s.Client.DeleteStack(context.Background(), request)
+	return err
+}
+
+func (s *ResourcemanagerStackResourceCrud) SetData() error {
+	if s.Res == nil {
+		return nil
+	}
+
+	s.D.SetId(*s.Res.Id)
+
+	if s.Res.CompartmentId != nil {
+		s.D.Set("compartment_id", *s.Res.CompartmentId)
+	}
+
+	if s.Res.ConfigSource != nil {
+		configSourceArray := []interface{}{}
+		downloadedConfigSource, err := s.getDownloadedStackConfigSource()
+		if err != nil {
+			return err
+		}
+		if configSourceMap := StackConfigSourceToMap(&s.Res.ConfigSource, downloadedConfigSource); configSourceMap != nil {
+			configSourceArray = append(configSourceArray, configSourceMap)
+		}
+		s.D.Set("config_source", configSourceArray)
+	} else {
+		s.D.Set("config_source", nil)
+	}
+
+	if s.Res.DefinedTags != nil {
+		s.D.Set("defined_tags", tfresource.DefinedTagsToMap(s.Res.DefinedTags))
+	}
+
+	if s.Res.Description != nil {
+		s.D.Set("description", *s.Res.Description)
+	}
+
+	if s.Res.DisplayName != nil {
+		s.D.Set("display_name", *s.Res.DisplayName)
+	}
+
+	s.D.Set("freeform_tags", s.Res.FreeformTags)
+	s.D.Set("stack_drift_status", s.Res.StackDriftStatus)
+	s.D.Set("state", s.Res.LifecycleState)
+
+	if s.Res.SystemTags != nil {
+		s.D.Set("system_tags", tfresource.SystemTagsToMap(s.Res.SystemTags))
+	}
+
+	if s.Res.TerraformVersion != nil {
+		s.D.Set("terraform_version", *s.Res.TerraformVersion)
+	}
+
+	if s.Res.TimeCreated != nil {
+		s.D.Set("time_created", s.Res.TimeCreated.String())
+	}
+
+	if s.Res.TimeDriftLastChecked != nil {
+		s.D.Set("time_drift_last_checked", s.Res.TimeDriftLastChecked.String())
+	}
+
+	s.D.Set("variables", s.Res.Variables)
+
+	return nil
+}
+
+func (s *ResourcemanagerStackResourceCrud) getDownloadedStackConfigSource() ([]interface{}, error) {
+	return getDownloadedStackConfigSource(s.Client, s.Res, tfresource.GetRetryPolicy(s.DisableNotFoundRetries, "resourcemanager"), getExistingStackConfigSource(s.D))
+}
+
+func getDownloadedStackConfigSource(client *oci_resourcemanager.ResourceManagerClient, stack *oci_resourcemanager.Stack, retryPolicy *oci_common.RetryPolicy, existingConfigSource []interface{}) ([]interface{}, error) {
+	if stack == nil || stack.ConfigSource == nil {
+		return nil, nil
+	}
+
+	switch v := stack.ConfigSource.(type) {
+	case oci_resourcemanager.ZipUploadConfigSource:
+		request := oci_resourcemanager.GetStackTfConfigRequest{
+			StackId: stack.Id,
+			RequestMetadata: oci_common.RequestMetadata{
+				RetryPolicy: retryPolicy,
+			},
+		}
+
+		response, err := client.GetStackTfConfig(context.Background(), request)
+		if err != nil {
+			return nil, err
+		}
+		defer response.Content.Close()
+
+		content, err := io.ReadAll(response.Content)
+		if err != nil {
+			return nil, err
+		}
+
+		result := map[string]interface{}{
+			"config_source_type":     "ZIP_UPLOAD",
+			"zip_file_base64encoded": base64.StdEncoding.EncodeToString(content),
+		}
+		if v.WorkingDirectory != nil {
+			result["working_directory"] = *v.WorkingDirectory
+		}
+
+		return []interface{}{result}, nil
+	default:
+		return existingConfigSource, nil
+	}
+}
+
+func (s *ResourcemanagerStackResourceCrud) mapToCreateConfigSourceDetails(fieldKeyFormat string) (oci_resourcemanager.CreateConfigSourceDetails, error) {
+	configSourceTypeRaw, ok := s.D.GetOkExists(fmt.Sprintf(fieldKeyFormat, "config_source_type"))
+	configSourceType := ""
+	if ok {
+		configSourceType = configSourceTypeRaw.(string)
+	}
+
+	switch strings.ToLower(configSourceType) {
+	case strings.ToLower("ZIP_UPLOAD"):
+		details := oci_resourcemanager.CreateZipUploadConfigSourceDetails{}
+		if workingDirectory, ok := s.D.GetOkExists(fmt.Sprintf(fieldKeyFormat, "working_directory")); ok {
+			tmp := workingDirectory.(string)
+			details.WorkingDirectory = &tmp
+		}
+		if zipFileBase64Encoded, ok := s.D.GetOkExists(fmt.Sprintf(fieldKeyFormat, "zip_file_base64encoded")); ok {
+			tmp := zipFileBase64Encoded.(string)
+			details.ZipFileBase64Encoded = &tmp
+		}
+		return details, nil
+	default:
+		return nil, fmt.Errorf("unknown config_source_type '%v' was specified", configSourceType)
+	}
+}
+
+func (s *ResourcemanagerStackResourceCrud) mapToUpdateConfigSourceDetails(fieldKeyFormat string) (oci_resourcemanager.UpdateConfigSourceDetails, error) {
+	configSourceTypeRaw, ok := s.D.GetOkExists(fmt.Sprintf(fieldKeyFormat, "config_source_type"))
+	configSourceType := ""
+	if ok {
+		configSourceType = configSourceTypeRaw.(string)
+	}
+
+	switch strings.ToLower(configSourceType) {
+	case strings.ToLower("ZIP_UPLOAD"):
+		details := oci_resourcemanager.UpdateZipUploadConfigSourceDetails{}
+		if workingDirectory, ok := s.D.GetOkExists(fmt.Sprintf(fieldKeyFormat, "working_directory")); ok {
+			tmp := workingDirectory.(string)
+			details.WorkingDirectory = &tmp
+		}
+		if zipFileBase64Encoded, ok := s.D.GetOkExists(fmt.Sprintf(fieldKeyFormat, "zip_file_base64encoded")); ok {
+			tmp := zipFileBase64Encoded.(string)
+			details.ZipFileBase64Encoded = &tmp
+		}
+		return details, nil
+	default:
+		return nil, fmt.Errorf("unknown config_source_type '%v' was specified", configSourceType)
+	}
+}
+
+func getExistingStackConfigSource(d *schema.ResourceData) []interface{} {
+	if existingConfigSource, ok := d.GetOkExists("config_source"); ok {
+		if interfaces, ok := existingConfigSource.([]interface{}); ok {
+			return interfaces
+		}
+	}
+
+	return nil
+}
+
+func StackConfigSourceToMap(obj *oci_resourcemanager.ConfigSource, existingConfigSource []interface{}) map[string]interface{} {
+	result := map[string]interface{}{}
+
+	switch v := (*obj).(type) {
+	case oci_resourcemanager.ZipUploadConfigSource:
+		result["config_source_type"] = "ZIP_UPLOAD"
+
+		if v.WorkingDirectory != nil {
+			result["working_directory"] = *v.WorkingDirectory
+		}
+
+		if len(existingConfigSource) > 0 {
+			if existingConfigSourceMap, ok := existingConfigSource[0].(map[string]interface{}); ok {
+				if zipFileBase64Encoded, ok := existingConfigSourceMap["zip_file_base64encoded"]; ok && zipFileBase64Encoded != nil {
+					result["zip_file_base64encoded"] = zipFileBase64Encoded.(string)
+				}
+			}
+		}
+	default:
+		log.Printf("[WARN] Received 'config_source_type' of unknown type %v", *obj)
+		return nil
+	}
+
+	return result
+}

--- a/website/docs/d/resourcemanager_stack.html.markdown
+++ b/website/docs/d/resourcemanager_stack.html.markdown
@@ -14,6 +14,8 @@ Gets the specified stack.
 For more information, see
 [Getting a Stack's Details](https://docs.cloud.oracle.com/iaas/Content/ResourceManager/Tasks/get-stack.htm).
 
+For ZIP-upload stacks, this data source downloads the stack configuration archive and stores it in Terraform state as base64 so refreshes preserve the config source. Large archives can noticeably increase state size.
+
 
 ## Example Usage
 
@@ -39,6 +41,7 @@ The following attributes are exported:
 * `config_source` - Location of the Terraform configuration.
     * `config_source_type` - Specifies the `configSourceType` for uploading the Terraform configuration. Presently, the .zip file type (`ZIP_UPLOAD`) is the only supported `configSourceType`.
     * `working_directory` - File path to the directory from which Terraform runs. If not specified, we use the root directory.
+    * `zip_file_base64encoded` - For ZIP-upload stacks, the downloaded ZIP archive content stored in Terraform state as base64.
 * `defined_tags` - Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm). Example: `{"Operations.CostCenter": "42"}`
 * `description` - General description of the stack.
 * `display_name` - A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information. 

--- a/website/docs/r/resourcemanager_stack.html.markdown
+++ b/website/docs/r/resourcemanager_stack.html.markdown
@@ -1,0 +1,100 @@
+---
+subcategory: "Resource Manager"
+layout: "oci"
+page_title: "Oracle Cloud Infrastructure: oci_resourcemanager_stack"
+sidebar_current: "docs-oci-resource-resourcemanager-stack"
+description: |-
+  Provides the Stack resource in Oracle Cloud Infrastructure Resource Manager service
+---
+
+# oci_resourcemanager_stack
+
+This resource provides the Stack resource in Oracle Cloud Infrastructure Resource Manager service.
+
+Creates, updates, and deletes a stack.
+For more information, see
+[Managing Stacks](https://docs.cloud.oracle.com/iaas/Content/ResourceManager/Tasks/stacks.htm).
+
+The current implementation supports ZIP-upload configuration sources only.
+
+Because Resource Manager does not return ZIP-upload contents from the standard `GetStack` API, this resource downloads the stack configuration archive during refresh and import and stores it in Terraform state. That preserves config fidelity, but large stack archives can noticeably increase state size.
+
+## Example Usage
+
+```hcl
+resource "oci_resourcemanager_stack" "test_stack" {
+  compartment_id = var.compartment_id
+  display_name   = "example-stack"
+  description    = "Stack managed by Terraform"
+
+  config_source {
+    config_source_type     = "ZIP_UPLOAD"
+    zip_file_base64encoded = filebase64("${path.module}/stack.zip")
+    working_directory      = "env/dev"
+  }
+
+  terraform_version = "1.5.x"
+  variables = {
+    compartment_ocid = var.compartment_id
+  }
+
+  freeform_tags = {
+    Department = "Finance"
+  }
+}
+```
+
+For a runnable example layout, see `examples/resourcemanager/stack_resource`.
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `compartment_id` - (Required) The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment containing this stack.
+* `config_source` - (Required) The Terraform configuration source for the stack. Only ZIP-upload stacks are currently supported by this resource.
+  * `config_source_type` - (Required) Configuration source type. `ZIP_UPLOAD` is currently supported.
+  * `zip_file_base64encoded` - (Required) Base64-encoded ZIP archive containing the Terraform configuration.
+  * `working_directory` - (Optional) File path to the directory from which Terraform runs. If not specified, the root directory is used.
+* `defined_tags` - (Optional) (Updatable) Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm). Example: `{"Operations.CostCenter": "42"}`
+* `description` - (Optional) (Updatable) General description of the stack.
+* `display_name` - (Optional) (Updatable) A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
+* `freeform_tags` - (Optional) (Updatable) Free-form tags associated with the resource. Each tag is a key-value pair with no predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm). Example: `{"Department": "Finance"}`
+* `terraform_version` - (Optional) (Updatable) The version of Terraform to use with the stack. Example: `1.5.x`
+* `variables` - (Optional) (Updatable) Terraform variables associated with this resource. Maximum number of variables supported is 250. The maximum size of each variable, including both name and value, is 8192 bytes. Example: `{"CompartmentId": "compartment-id-value"}`
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `compartment_id` - Unique identifier ([OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm)) for the compartment where the stack is located.
+* `config_source` - Location of the Terraform configuration.
+  * `config_source_type` - Configuration source type.
+  * `working_directory` - File path to the directory from which Terraform runs. If not specified, the root directory is used.
+  * `zip_file_base64encoded` - For ZIP-upload stacks, the ZIP archive content fetched from the stack configuration download API and stored in Terraform state as base64. This is what allows refresh and import to preserve the stack configuration in state.
+* `defined_tags` - Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm). Example: `{"Operations.CostCenter": "42"}`
+* `description` - General description of the stack.
+* `display_name` - A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
+* `freeform_tags` - Free-form tags associated with the resource. Each tag is a key-value pair with no predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm). Example: `{"Department": "Finance"}`
+* `id` - Unique identifier ([OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm)) for the stack.
+* `stack_drift_status` - Drift status of the stack. Drift refers to differences between the actual (current) state of the stack and the expected (defined) state of the stack.
+* `state` - The current lifecycle state of the stack.
+* `system_tags` - The system tags associated with this resource, if any. The system tags are set by Oracle cloud infrastructure services. Each key is predefined and scoped to namespaces. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm). Example: `{orcl-cloud: {free-tier-retain: true}}`
+* `terraform_version` - The version of Terraform specified for the stack. Example: `1.5.x`
+* `time_created` - The date and time at which the stack was created. Format is defined by RFC3339. Example: `2020-01-25T21:10:29.600Z`
+* `time_drift_last_checked` - The date and time when the drift detection was last executed. Format is defined by RFC3339. Example: `2020-01-25T21:10:29.600Z`
+* `variables` - Terraform variables associated with this resource.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://registry.terraform.io/providers/oracle/oci/latest/docs/guides/changing_timeouts) for certain operations:
+  * `create` - (Defaults to 20 minutes), when creating the Stack
+  * `update` - (Defaults to 20 minutes), when updating the Stack
+  * `delete` - (Defaults to 20 minutes), when destroying the Stack
+
+## Import
+
+Stacks can be imported using the `id`, e.g.
+
+```bash
+$ terraform import oci_resourcemanager_stack.test_stack "ocid1.ormstack.oc1..exampleuniqueID"
+```


### PR DESCRIPTION
## Summary

This PR adds support for managing OCI Resource Manager stacks as a Terraform resource.

Included in this change:
- adds `oci_resourcemanager_stack` resource support
- preserves ZIP-uploaded Terraform config during read/refresh by calling `GetStackTfConfig`
- aligns the singular stack data source so ZIP-backed config remains usable there as well
- adds docs and an example for the new resource
- adds acceptance coverage for CRUD and incremental updates
- fixes duplicate database DB system sweeper registration that was blocking the integration test package

Current scope is intentionally limited to ZIP-uploaded stack config.

## Validation

Executed successfully:
- `go test ./internal/service/resourcemanager/...`
- `TF_ACC=1 go test ./internal/integrationtest -run TestResourcemanagerStackResource_crud -count=1 -v`
- `TF_ACC=1 go test ./internal/integrationtest -run TestResourcemanagerStackResource_basic -count=1 -v`
- `TF_ACC=1 go test ./internal/integrationtest -run TestResourcemanagerStackResource_incrementalUpdates -count=1 -v`

Acceptance tests were run with Phoenix profile / security token auth.

## Notes

- resource refresh/import reconstructs ZIP config using `GetStackTfConfig`
- incremental update coverage verifies tag-only, variable-only, and config ZIP-only updates without recreation
- docs and example were added for the new resource workflow
