### PR TITLE
Document that compartment_id is not required in oci_identity_compartment

### DIFF
--- a/website/docs/r/identity_compartment.html.markdown
+++ b/website/docs/r/identity_compartment.html.markdown
@@ -38,11 +38,11 @@ not have to be unique, and you can change it anytime with
 ```hcl
 resource "oci_identity_compartment" "test_compartment" {
 	#Required
-	compartment_id = var.compartment_id
 	description = var.compartment_description
 	name = var.compartment_name
 
 	#Optional
+	compartment_id = var.compartment_id
 	defined_tags = {"Operations.CostCenter"= "42"}
 	freeform_tags = {"Department"= "Finance"}
 }
@@ -52,11 +52,12 @@ resource "oci_identity_compartment" "test_compartment" {
 
 The following arguments are supported:
 
-* `compartment_id` - (Required) (Updatable) The OCID of the parent compartment containing the compartment.
-* `defined_tags` - (Optional) (Updatable) Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm). Example: `{"Operations.CostCenter": "42"}` 
-* `description` - (Required) (Updatable) The description you assign to the compartment during creation. Does not have to be unique, and it's changeable. 
-* `freeform_tags` - (Optional) (Updatable) Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm). Example: `{"Department": "Finance"}` 
+* `description` - (Required) (Updatable) The description you assign to the compartment during creation. Does not have to be unique, and it's changeable.
 * `name` - (Required) (Updatable) The name you assign to the compartment during creation. The name must be unique across all compartments in the parent compartment. Avoid entering confidential information. 
+
+* `compartment_id` - (Optional) (Updatable) The OCID of the parent compartment containing the compartment, default: current tenancy's root compartment.
+* `defined_tags` - (Optional) (Updatable) Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm). Example: `{"Operations.CostCenter": "42"}` 
+* `freeform_tags` - (Optional) (Updatable) Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm). Example: `{"Department": "Finance"}` 
 * `enable_delete` - (Optional) Defaults to false. If omitted or set to false the provider will implicitly import the compartment if there is a name collision, and will not actually delete the compartment on destroy or removal of the resource declaration. If set to true, the provider will throw an error on a name collision with another compartment, and will attempt to delete the compartment on destroy or removal of the resource declaration.
 
 ** IMPORTANT **


### PR DESCRIPTION
Updated the compartment resource documentation to clarify the compartment_id as optional. Reorganized arguments to have required on top, optional below.