### PR TITLE
FIX OCVP: adding ESXi node with commitment field

### DIFF
--- a/internal/service/ocvp/ocvp_esxi_host_resource.go
+++ b/internal/service/ocvp/ocvp_esxi_host_resource.go
@@ -83,8 +83,22 @@ func OcvpEsxiHostResource() *schema.Resource {
 					}
 					return true
 				},
-				ConflictsWith: []string{"cluster_id", "esxi_software_version"},
+				ConflictsWith: []string{"cluster_id", "esxi_software_version", "current_commitment"},
 				Deprecated:    tfresource.FieldDeprecated("current_sku"),
+			},
+			"current_commitment": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				// API may update current_commitment after creation; ignore post-create drift (same behavior as current_sku).
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if old == "" && new != "" {
+						return false
+					}
+					return true
+				},
+				ConflictsWith: []string{"current_sku"},
 			},
 			"defined_tags": {
 				Type:             schema.TypeMap,
@@ -145,8 +159,14 @@ func OcvpEsxiHostResource() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Computed:      true,
-				ConflictsWith: []string{"cluster_id", "esxi_software_version"},
+				ConflictsWith: []string{"cluster_id", "esxi_software_version", "next_commitment"},
 				Deprecated:    tfresource.FieldDeprecated("next_sku"),
+			},
+			"next_commitment": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"next_sku"},
 			},
 			"non_upgraded_esxi_host_id": {
 				Type:          schema.TypeString,
@@ -231,10 +251,6 @@ func OcvpEsxiHostResource() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-			"current_commitment": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"grace_period_end_date": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -245,10 +261,6 @@ func OcvpEsxiHostResource() *schema.Resource {
 			},
 			"is_billing_swapping_in_progress": {
 				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			"next_commitment": {
-				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"primary_vnic_mac_address": {


### PR DESCRIPTION
### Fix for OCVP Service - ESXi Host creation not allowing to specify current and next commitments

See issue: terraform EXSI Host OCVS OCI : current_commitment and next_commitment variables do not not apply **#2498**

### Summary

Fixes the Terraform provider schema for oci_ocvp_esxi_host so current_commitment and next_commitment can be set in configuration. They were incorrectly declared as read-only (Computed only), which caused Terraform to fail with “Value for unconfigurable attribute” even though the create/update logic already passed these fields to the OCVP API (matching CLI behavior and the resource documentation).

### Problem

Users configuring current_commitment (e.g. HOUR) hit: 
`Can’t configure a value for "current_commitment": its value will be decided automatically…`

The underlying Create/Update paths already read current_commitment and next_commitment from ResourceData and map them to the SDK request, so the failure was a schema vs. implementation mismatch, not an API limitation.

### Solution

current_commitment: Mark as Optional and Computed, ForceNew (create-time input, value then comes from the API), with diff suppression aligned with current_sku so post-create API normalization does not force unnecessary churn. ConflictsWith current_sku so the deprecated and new arguments are not used together.

next_commitment: Mark as Optional and Computed (updatable input, also reflected from read), and ConflictsWith next_sku for the same reason.
current_sku / next_sku: Extend ConflictsWith to include current_commitment / next_commitment respectively.

### Notes for reviewers

current_commitment intentionally does not mirror current_sku’s conflict with cluster_id, so the documented pattern cluster_id + current_commitment remains valid.

No change to API call shape—only schema alignment with existing CRUD code.

Tested successfully on internal OCVS environment