### PR TITLE
fix(file_storage): tolerate released private IP during mount target read (GetPrivateIp 404 wedges refresh)

### DIFF
--- a/internal/service/file_storage/file_storage_mount_target_resource.go
+++ b/internal/service/file_storage/file_storage_mount_target_resource.go
@@ -737,8 +737,14 @@ func (s *FileStorageMountTargetResourceCrud) SetData() error {
 		s.D.Set("reserved_storage_capacity", strconv.FormatInt(*s.Res.ReservedStorageCapacity, 10))
 	}
 
-	// Service returns only 1 item in this field
-	if len(s.Res.PrivateIpIds) > 0 {
+	// Service returns only 1 item in this field.
+	// Skip hydration while the mount target is DELETING/DELETED: the service
+	// releases the private IP early in the deletion flow but keeps returning
+	// the mount target record (with the now-stale privateIpIds reference)
+	// until the deletion completes, so GetPrivateIp is guaranteed to 404.
+	if len(s.Res.PrivateIpIds) > 0 &&
+		s.Res.LifecycleState != oci_file_storage.MountTargetLifecycleStateDeleting &&
+		s.Res.LifecycleState != oci_file_storage.MountTargetLifecycleStateDeleted {
 		err := s.setPrivateIpDetails(s.Res.PrivateIpIds[0])
 		if err != nil {
 			return err
@@ -1147,6 +1153,15 @@ func (s *FileStorageMountTargetResourceCrud) setPrivateIpDetails(privateIpOcid s
 
 	response, err := s.VirtualNetworkClient.GetPrivateIp(context.Background(), request)
 	if err != nil {
+		// The mount target releases its private IP early in the deletion
+		// flow, before the mount target record itself stops being returned.
+		// A refresh racing that window must not fail the whole read - treat
+		// the vanished private IP as absent details, not as an error, so the
+		// resource can converge (e.g. a destroy retry can proceed) instead
+		// of wedging every subsequent plan/apply/destroy on a 404.
+		if serviceErr, ok := oci_common.IsServiceError(err); ok && serviceErr.GetHTTPStatusCode() == 404 {
+			return nil
+		}
 		return err
 	}
 	if response.HostnameLabel != nil {


### PR DESCRIPTION
## Problem

The File Storage service releases a mount target's private IP **early** in the deletion flow, while `GetMountTarget` keeps returning the record — in `DELETING` and then `DELETED` state — **still carrying the stale `privateIpIds` reference**. The mount target resource read hydrates `ip_address`/`hostname_label` from that reference unconditionally (`setPrivateIpDetails`), so `GetPrivateIp` returns 404 and the **entire refresh fails**:

```
Error: Error returned by VirtualNetwork Service. Http Status Code: 404. Error Code: NotAuthorizedOrNotFound.
Operation Name: GetPrivateIp
  with oci_file_storage_mount_target.fss["this"]
```

### Impact

Any `plan`/`apply`/`destroy` that refreshes state while a mount target deletion is in flight hits this. The most damaging shape: a multi-resource `destroy` issues the mount target deletion, fails on an unrelated transient elsewhere in the graph, and then **every retry fails at refresh** on the 404 — permanently, until the deleted record ages out server-side (observed 40+ minutes). The only recovery is a manual `terraform state rm`. We reproduced this in CI on two independent clusters the same day (each froze at the identical refresh point), and then minimally on a scratch configuration.

## Reproduction (provider 8.25.0)

1. Create a mount target with a minimal config, `terraform apply`.
2. Delete it out of band: `oci fs mount-target delete --mount-target-id ...`.
3. Observe the service behavior (the root of the issue):
```
MT=DELETING private-ip-ids=["ocid1.privateip.oc1.iad.aaaa..."]
MT=DELETED  private-ip-ids=["ocid1.privateip.oc1.iad.aaaa..."]   # stale reference retained
```
4. `terraform plan -refresh-only` → fails with the `GetPrivateIp` 404 above.

## Fix

Two guards in `file_storage_mount_target_resource.go`:

1. **Skip private IP hydration when the mount target is `DELETING`/`DELETED`** — the `privateIpIds` reference is stale by definition in those states.
2. **Treat `GetPrivateIp` 404 as absent details rather than a read error** — covering the race where the IP is already released but the lifecycle state has not flipped yet.

No schema changes; behavior for live mount targets is unchanged.

## Verification

Same reproduction with the patched provider (`dev_overrides`):

```
# oci_file_storage_mount_target.repro has been deleted
```

Refresh converges cleanly (resource reported deleted and removed), and a subsequent `destroy` completes. Package builds and vets clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)