### PR TITLE
core: allow setting default_drg_route_tables on oci_core_drg

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -181,6 +181,8 @@ github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YF
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/oracle/oci-go-sdk/v65 v65.123.1 h1:UE8xEOuF++LnrnvQDcn4gbviD9N4ZFGOFrV8tW2bHbU=
+github.com/oracle/oci-go-sdk/v65 v65.123.1/go.mod h1:Pzy+BpgkDesvGZXEHgslwhIYobHCPHg6wRta1mWnlqQ=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=
 github.com/pjbgf/sha1cd v0.3.2/go.mod h1:zQWigSxVmsHEZow5qaLtPYxpcKMMQpa09ixqBxuCS6A=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/internal/service/core/core_drg_default_route_table_management_resource.go
+++ b/internal/service/core/core_drg_default_route_table_management_resource.go
@@ -1,0 +1,203 @@
+// Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package core
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/oracle/terraform-provider-oci/internal/client"
+	"github.com/oracle/terraform-provider-oci/internal/tfresource"
+
+	oci_core "github.com/oracle/oci-go-sdk/v65/core"
+)
+
+// CoreDrgDefaultRouteTableManagementResource manages a DRG's per-attachment-type default DRG
+// route table assignment (UpdateDrgDetails.DefaultDrgRouteTables) as its own resource, distinct
+// from oci_core_drg itself. This lets a config point one of these four fields at a DRG route
+// table created in the same apply without oci_core_drg and oci_core_drg_route_table forming a
+// module/resource reference cycle -- same shape of problem oci_core_drg_attachment_management
+// solves for drg_route_table_id/export_drg_route_distribution_id on attachments OCI auto-creates.
+func CoreDrgDefaultRouteTableManagementResource() *schema.Resource {
+	return &schema.Resource{
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: tfresource.DefaultTimeout,
+		Create:   createCoreDrgDefaultRouteTableManagement,
+		Read:     readCoreDrgDefaultRouteTableManagement,
+		Update:   updateCoreDrgDefaultRouteTableManagement,
+		Delete:   deleteCoreDrgDefaultRouteTableManagement,
+		Schema: map[string]*schema.Schema{
+			// Required
+			"drg_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			// Optional
+			"ipsec_tunnel": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"remote_peering_connection": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"vcn": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"virtual_circuit": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func createCoreDrgDefaultRouteTableManagement(d *schema.ResourceData, m interface{}) error {
+	sync := &CoreDrgDefaultRouteTableManagementResourceCrud{}
+	sync.D = d
+	sync.Client = m.(*client.OracleClients).VirtualNetworkClient()
+
+	return tfresource.CreateResource(d, sync)
+}
+
+func readCoreDrgDefaultRouteTableManagement(d *schema.ResourceData, m interface{}) error {
+	sync := &CoreDrgDefaultRouteTableManagementResourceCrud{}
+	sync.D = d
+	sync.Client = m.(*client.OracleClients).VirtualNetworkClient()
+
+	return tfresource.ReadResource(sync)
+}
+
+func updateCoreDrgDefaultRouteTableManagement(d *schema.ResourceData, m interface{}) error {
+	sync := &CoreDrgDefaultRouteTableManagementResourceCrud{}
+	sync.D = d
+	sync.Client = m.(*client.OracleClients).VirtualNetworkClient()
+
+	return tfresource.UpdateResource(d, sync)
+}
+
+func deleteCoreDrgDefaultRouteTableManagement(d *schema.ResourceData, m interface{}) error {
+	sync := &CoreDrgDefaultRouteTableManagementResourceCrud{}
+	sync.D = d
+	sync.Client = m.(*client.OracleClients).VirtualNetworkClient()
+	sync.DisableNotFoundRetries = true
+
+	return tfresource.DeleteResource(d, sync)
+}
+
+type CoreDrgDefaultRouteTableManagementResourceCrud struct {
+	tfresource.BaseCrud
+	Client                 *oci_core.VirtualNetworkClient
+	Res                    *oci_core.Drg
+	DisableNotFoundRetries bool
+}
+
+func (s *CoreDrgDefaultRouteTableManagementResourceCrud) ID() string {
+	return *s.Res.Id
+}
+
+func (s *CoreDrgDefaultRouteTableManagementResourceCrud) Get() error {
+	request := oci_core.GetDrgRequest{}
+
+	tmp := s.D.Id()
+	request.DrgId = &tmp
+
+	request.RequestMetadata.RetryPolicy = tfresource.GetRetryPolicy(s.DisableNotFoundRetries, "core")
+
+	response, err := s.Client.GetDrg(context.Background(), request)
+	if err != nil {
+		return err
+	}
+
+	s.Res = &response.Drg
+	return nil
+}
+
+func (s *CoreDrgDefaultRouteTableManagementResourceCrud) Create() error {
+	return s.Update()
+}
+
+// A DRG's default route table assignment can't actually be deleted -- every attachment type
+// always has SOME default route table (see oci_core_default_drg_route_table's LIFECYCLE.md).
+// Same "management, not ownership" posture as oci_core_drg_attachment_management's Delete:
+// Terraform just stops tracking the assignment, OCI keeps whatever it was last set to.
+func (s *CoreDrgDefaultRouteTableManagementResourceCrud) Delete() error {
+	return nil
+}
+
+func (s *CoreDrgDefaultRouteTableManagementResourceCrud) Update() error {
+	request := oci_core.UpdateDrgRequest{}
+
+	drgId := s.D.Get("drg_id").(string)
+	request.DrgId = &drgId
+
+	defaultDrgRouteTables := oci_core.DefaultDrgRouteTables{}
+
+	if ipsecTunnel, ok := s.D.GetOkExists("ipsec_tunnel"); ok {
+		tmp := ipsecTunnel.(string)
+		defaultDrgRouteTables.IpsecTunnel = &tmp
+	}
+
+	if remotePeeringConnection, ok := s.D.GetOkExists("remote_peering_connection"); ok {
+		tmp := remotePeeringConnection.(string)
+		defaultDrgRouteTables.RemotePeeringConnection = &tmp
+	}
+
+	if vcn, ok := s.D.GetOkExists("vcn"); ok {
+		tmp := vcn.(string)
+		defaultDrgRouteTables.Vcn = &tmp
+	}
+
+	if virtualCircuit, ok := s.D.GetOkExists("virtual_circuit"); ok {
+		tmp := virtualCircuit.(string)
+		defaultDrgRouteTables.VirtualCircuit = &tmp
+	}
+
+	request.DefaultDrgRouteTables = &defaultDrgRouteTables
+
+	request.RequestMetadata.RetryPolicy = tfresource.GetRetryPolicy(s.DisableNotFoundRetries, "core")
+
+	response, err := s.Client.UpdateDrg(context.Background(), request)
+	if err != nil {
+		return err
+	}
+
+	s.Res = &response.Drg
+	return nil
+}
+
+func (s *CoreDrgDefaultRouteTableManagementResourceCrud) SetData() error {
+	if s.Res == nil {
+		return nil
+	}
+
+	s.D.Set("drg_id", *s.Res.Id)
+
+	if s.Res.DefaultDrgRouteTables != nil {
+		if s.Res.DefaultDrgRouteTables.IpsecTunnel != nil {
+			s.D.Set("ipsec_tunnel", *s.Res.DefaultDrgRouteTables.IpsecTunnel)
+		}
+		if s.Res.DefaultDrgRouteTables.RemotePeeringConnection != nil {
+			s.D.Set("remote_peering_connection", *s.Res.DefaultDrgRouteTables.RemotePeeringConnection)
+		}
+		if s.Res.DefaultDrgRouteTables.Vcn != nil {
+			s.D.Set("vcn", *s.Res.DefaultDrgRouteTables.Vcn)
+		}
+		if s.Res.DefaultDrgRouteTables.VirtualCircuit != nil {
+			s.D.Set("virtual_circuit", *s.Res.DefaultDrgRouteTables.VirtualCircuit)
+		}
+	}
+
+	return nil
+}

--- a/internal/service/core/core_drg_resource.go
+++ b/internal/service/core/core_drg_resource.go
@@ -54,36 +54,45 @@ func CoreDrgResource() *schema.Resource {
 				Elem:     schema.TypeString,
 			},
 
-			// Computed
+			// Optional
 			"default_drg_route_tables": {
 				Type:     schema.TypeList,
+				Optional: true,
 				Computed: true,
+				MaxItems: 1,
+				MinItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						// Required
 
 						// Optional
-
-						// Computed
 						"ipsec_tunnel": {
 							Type:     schema.TypeString,
+							Optional: true,
 							Computed: true,
 						},
 						"remote_peering_connection": {
 							Type:     schema.TypeString,
+							Optional: true,
 							Computed: true,
 						},
 						"vcn": {
 							Type:     schema.TypeString,
+							Optional: true,
 							Computed: true,
 						},
 						"virtual_circuit": {
 							Type:     schema.TypeString,
+							Optional: true,
 							Computed: true,
 						},
+
+						// Computed
 					},
 				},
 			},
+
+			// Computed
 			"default_export_drg_route_distribution_id": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/internal/service/core/register_resource.go
+++ b/internal/service/core/register_resource.go
@@ -36,6 +36,7 @@ func RegisterResource() {
 	tfresource.RegisterResource("oci_core_drg_attachment", CoreDrgAttachmentResource())
 	tfresource.RegisterResource("oci_core_drg_attachments_list", CoreDrgAttachmentsListResource())
 	tfresource.RegisterResource("oci_core_drg_attachment_management", CoreDrgAttachmentManagementResource())
+	tfresource.RegisterResource("oci_core_drg_default_route_table_management", CoreDrgDefaultRouteTableManagementResource())
 	tfresource.RegisterResource("oci_core_drg_route_distribution", CoreDrgRouteDistributionResource())
 	tfresource.RegisterResource("oci_core_drg_route_distribution_statement", CoreDrgRouteDistributionStatementResource())
 	tfresource.RegisterResource("oci_core_drg_route_table", CoreDrgRouteTableResource())

--- a/website/docs/r/core_drg.html.markdown
+++ b/website/docs/r/core_drg.html.markdown
@@ -35,6 +35,13 @@ resource "oci_core_drg" "test_drg" {
 	compartment_id = var.compartment_id
 
 	#Optional
+	default_drg_route_tables {
+		#Optional
+		ipsec_tunnel               = oci_core_drg_route_table.test_drg_route_table.id
+		remote_peering_connection  = oci_core_drg_route_table.test_drg_route_table.id
+		vcn                        = oci_core_drg_route_table.test_drg_route_table.id
+		virtual_circuit            = oci_core_drg_route_table.test_drg_route_table.id
+	}
 	defined_tags = {"Operations.CostCenter"= "42"}
 	display_name = var.drg_display_name
 	freeform_tags = {"Department"= "Finance"}
@@ -46,7 +53,16 @@ resource "oci_core_drg" "test_drg" {
 The following arguments are supported:
 
 * `compartment_id` - (Required) (Updatable) The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to contain the DRG.
-* `defined_tags` - (Optional) (Updatable) Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).  Example: `{"Operations.CostCenter": "42"}` 
+* `default_drg_route_tables` - (Optional) (Updatable) The default DRG route table for this DRG. Each network type has a default DRG route table.
+
+	You can update a network type to use a different DRG route table, but each network type must have a default DRG route table. You cannot delete a default DRG route table.
+
+	Reassigning a network type's default route table only affects attachments of that type created *after* the change; it does not retroactively move existing attachments off whatever route table they already resolved to (their own `drg_route_table` field, if set, still wins). Any field left unset here keeps its current default assignment unchanged.
+	* `ipsec_tunnel` - (Optional) (Updatable) The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the default DRG route table assigned to DRG attachments of type IPSEC_TUNNEL on creation.
+	* `remote_peering_connection` - (Optional) (Updatable) The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the default DRG route table to be assigned to DRG attachments of type REMOTE_PEERING_CONNECTION on creation.
+	* `vcn` - (Optional) (Updatable) The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the default DRG route table to be assigned to DRG attachments of type VCN on creation.
+	* `virtual_circuit` - (Optional) (Updatable) The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the default DRG route table to be assigned to DRG attachments of type VIRTUAL_CIRCUIT on creation.
+* `defined_tags` - (Optional) (Updatable) Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).  Example: `{"Operations.CostCenter": "42"}`
 * `display_name` - (Optional) (Updatable) A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information. 
 * `freeform_tags` - (Optional) (Updatable) Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).  Example: `{"Department": "Finance"}` 
 

--- a/website/docs/r/core_drg_default_route_table_management.html.markdown
+++ b/website/docs/r/core_drg_default_route_table_management.html.markdown
@@ -1,0 +1,94 @@
+---
+subcategory: "Core"
+layout: "oci"
+page_title: "Oracle Cloud Infrastructure: oci_core_drg_default_route_table_management"
+sidebar_current: "docs-oci-resource-core-drg-default-route-table-management"
+description: |-
+  Provides details about managing a Drg's default DRG route table assignments in Oracle Cloud Infrastructure Core service
+---
+
+# oci_core_drg_default_route_table_management
+This resource manages a DRG's per-attachment-type default DRG route table assignments — the same
+operation exposed by the OCI console's DRG "Edit default assignments" screen, or
+`oci network drg update --default-drg-route-tables`.
+
+Each DRG auto-generates one default DRG route table per attachment type at DRG-creation time (VCN
+gets its own; IPSEC_TUNNEL/VIRTUAL_CIRCUIT/REMOTE_PEERING_CONNECTION share one). This resource
+reassigns which route table is used as an attachment type's default going forward — it does not
+create a route table, and does not retroactively move any attachment already resolved to a
+different route table.
+
+This is intentionally a separate resource from `oci_core_drg` (which also exposes
+`default_drg_route_tables` directly, for the case where the target route table's OCID is already
+known and not created in the same configuration). Setting a network type's default to a DRG route
+table created in the same `terraform apply` requires referencing that route table's resource
+address; doing so via `oci_core_drg` itself would create a resource cycle, since
+`oci_core_drg_route_table` must reference the DRG's `id` to be created in the first place. This
+resource is addressed by `drg_id` instead, so the graph resolves as: create DRG -> create route
+tables -> assign them as defaults, with no address referencing back to one that isn't finished
+yet — same shape of problem `oci_core_drg_attachment_management` solves for
+`drg_route_table_id`/`export_drg_route_distribution_id` on auto-created attachments.
+
+Only one `oci_core_drg_default_route_table_management` resource should be declared per DRG — like
+`oci_core_drg`'s own `default_drg_route_tables` argument, it manages all four attachment types'
+assignments as a single `UpdateDrg` call.
+
+
+## Example Usage
+
+```hcl
+resource "oci_core_drg_default_route_table_management" "test_drg_default_route_tables" {
+  #Required
+  drg_id = oci_core_drg.test_drg.id
+
+  #Optional
+  ipsec_tunnel              = oci_core_drg_route_table.test_drg_route_table.id
+  remote_peering_connection = oci_core_drg_route_table.test_drg_route_table.id
+  vcn                       = oci_core_drg_route_table.test_drg_route_table.id
+  virtual_circuit           = oci_core_drg_route_table.test_drg_route_table.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `drg_id` - (Required) The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the DRG whose default route table assignments this resource manages. Changing this creates a new resource.
+* `ipsec_tunnel` - (Optional) (Updatable) The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the DRG route table to assign as the default for DRG attachments of type IPSEC_TUNNEL. Left unset, the current default for this type is unchanged.
+* `remote_peering_connection` - (Optional) (Updatable) The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the DRG route table to assign as the default for DRG attachments of type REMOTE_PEERING_CONNECTION. Left unset, the current default for this type is unchanged.
+* `vcn` - (Optional) (Updatable) The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the DRG route table to assign as the default for DRG attachments of type VCN. Left unset, the current default for this type is unchanged.
+* `virtual_circuit` - (Optional) (Updatable) The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the DRG route table to assign as the default for DRG attachments of type VIRTUAL_CIRCUIT. Left unset, the current default for this type is unchanged.
+
+** IMPORTANT **
+Any change to a property that does not support update will force the destruction and recreation of the resource with the new property values
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `drg_id` - The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the DRG.
+* `ipsec_tunnel` - The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the DRG route table currently assigned as the default for DRG attachments of type IPSEC_TUNNEL.
+* `remote_peering_connection` - The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the DRG route table currently assigned as the default for DRG attachments of type REMOTE_PEERING_CONNECTION.
+* `vcn` - The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the DRG route table currently assigned as the default for DRG attachments of type VCN.
+* `virtual_circuit` - The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the DRG route table currently assigned as the default for DRG attachments of type VIRTUAL_CIRCUIT.
+* `id` - Same value as `drg_id` — this resource has no identity of its own distinct from the DRG it manages.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://registry.terraform.io/providers/oracle/oci/latest/docs/guides/changing_timeouts) for certain operations:
+	* `create` - (Defaults to 20 minutes), when creating the resource
+	* `update` - (Defaults to 20 minutes), when updating the resource
+	* `delete` - (Defaults to 20 minutes), when destroying the resource
+
+Deleting this resource does not revert the DRG's default route table assignments — OCI has no
+"unset" operation for a default, and this resource does not attempt to guess or restore whatever
+the auto-generated default was before this resource started managing it. Terraform simply stops
+tracking the assignment.
+
+## Import
+
+DrgDefaultRouteTableManagements can be imported using the `drg_id`, e.g.
+
+```
+$ terraform import oci_core_drg_default_route_table_management.test_drg_default_route_tables "drg_id"
+```

--- a/website/oci.erb
+++ b/website/oci.erb
@@ -2455,6 +2455,9 @@
                             <a href="/docs/providers/oci/r/core_drg_attachments_list.html">oci_core_drg_attachments_list</a>
                         </li>
                         <li>
+                            <a href="/docs/providers/oci/r/core_drg_default_route_table_management.html">oci_core_drg_default_route_table_management</a>
+                        </li>
+                        <li>
                             <a href="/docs/providers/oci/r/core_drg_route_distribution.html">oci_core_drg_route_distribution</a>
                         </li>
                         <li>


### PR DESCRIPTION
Fixes #2600

## Summary

`oci_core_drg`'s `default_drg_route_tables` (and its four sub-fields
`ipsec_tunnel`/`remote_peering_connection`/`vcn`/`virtual_circuit`) are
Computed-only in the current schema, even though the Go SDK and this
provider's own `CoreDrgResourceCrud.Update()` / `mapToDefaultDrgRouteTables()`
already fully implement sending `DefaultDrgRouteTables` on update. Only the
schema declaration blocked using it. This PR:

1. Flips `default_drg_route_tables` and its four sub-fields to
   Optional+Computed on `oci_core_drg`, so a config can reassign a network
   type's default DRG route table directly (same operation as the console's
   DRG "Edit default assignment" screen / `oci network drg update
   --default-drg-route-tables`). No CRUD code changes needed — it already
   worked once reachable.
2. Adds a new resource, `oci_core_drg_default_route_table_management`,
   addressed by `drg_id` rather than owning the `oci_core_drg` resource
   itself. This exists for the case where the target route table is created
   in the *same* apply as the DRG: a config can't set
   `default_drg_route_tables` directly on `oci_core_drg` while also having
   an `oci_core_drg_route_table` whose `drg_id` points back at that same DRG
   — that's a genuine resource reference cycle, not a diamond dependency.
   The new resource is the same "management, not ownership" shape as the
   existing `oci_core_drg_attachment_management` (`Create` just calls
   `Update`; `Delete` is a no-op since OCI has no "unset a DRG's default"
   operation — Terraform just stops tracking the assignment).
3. Documents both — updates `core_drg.html.markdown`'s argument reference
   and example, adds `core_drg_default_route_table_management.html.markdown`,
   and registers the new resource + nav entry.

## Validation

- `go build ./internal/service/...` and `go vet` pass.
- Full binary builds (`GOFLAGS=-mod=vendor go build`) and exercised locally
  against a real tenancy via `dev_overrides`, reassigning a live DRG's VCN/
  IPSec-tunnel/virtual-circuit/remote-peering-connection defaults to a
  caller-managed route table and confirming via `oci network drg get` that
  the change took effect and persisted.
- Pre-existing `go build ./internal/...` failure in
  `internal/integrationtest/database_tools_runtime_test_helpers.go` reproduces
  on `master` at the same base commit (unrelated to this change, not part of
  the resource/service code this PR touches).

## Acceptance checklist
- [x] Signed the [OCA](https://oca.opensource.oracle.com) and commits carry `Signed-off-by`
- [x] Issue filed and referenced (#2600)
- [x] Documentation updated