### PR TITLE
Fix compartment name uniqueness documentation

### DIFF
--- a/website/docs/r/identity_compartment.html.markdown
+++ b/website/docs/r/identity_compartment.html.markdown
@@ -24,7 +24,7 @@ is simply the root compartment. For information about OCIDs, see
 [Resource Identifiers](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
 
 You must also specify a *name* for the compartment, which must be unique across all compartments in
-your tenancy. You can use this name or the OCID when writing policies that apply
+the parent compartment. You can use this name or the OCID when writing policies that apply
 to the compartment. For more information about policies, see
 [How Policies Work](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/policies.htm).
 


### PR DESCRIPTION
## Summary
- Correct the `oci_identity_compartment` introduction: a compartment name is unique within its parent compartment, not across the tenancy.
- Keep the introduction consistent with the existing argument reference.

Fixes #2261.

## Validation
- `make test-docscheck`